### PR TITLE
[Feat/#20] 온보딩02 화면 제작

### DIFF
--- a/app/src/main/java/com/example/teumteum/data/Schedule.kt
+++ b/app/src/main/java/com/example/teumteum/data/Schedule.kt
@@ -1,0 +1,9 @@
+package com.example.teumteum.data
+
+data class Schedule(
+    val title: String,
+    val day: String,
+    val startTime: String,
+    val endTime: String,
+    val description: String,
+)

--- a/app/src/main/java/com/example/teumteum/ui/singup/BottomSheetScheduleFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/singup/BottomSheetScheduleFragment.kt
@@ -1,0 +1,115 @@
+import android.graphics.Color
+import android.graphics.Typeface
+import android.os.Bundle
+import android.util.TypedValue
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
+import android.widget.NumberPicker
+import androidx.core.view.isVisible
+import com.example.teumteum.data.Schedule
+import com.example.teumteum.databinding.FragmentBottomSheetScheduleBinding
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+
+class BottomSheetScheduleFragment(
+    private val selectedDayIndex: Int,
+    private val onScheduleAdded: (Schedule) -> Unit
+) : BottomSheetDialogFragment() {
+
+    private lateinit var binding: FragmentBottomSheetScheduleBinding
+    private val dayNames = listOf("일", "월", "화", "수", "목", "금", "토")
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = FragmentBottomSheetScheduleBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        val dayText = "매주 ${dayNames[selectedDayIndex]}요일"
+        binding.startDateTv.text = dayText
+        binding.endDateTv.text = dayText
+
+        setupPickers()
+
+        binding.startTimeTv.setOnClickListener {
+            val visible = binding.timePickerStartLl.isShown
+            if (visible) applySelectedTime(isStart = true)
+            binding.timePickerStartLl.isVisible = !visible
+            binding.timePickerEndLl.isVisible = false
+        }
+
+        binding.endTimeTv.setOnClickListener {
+            val visible = binding.timePickerEndLl.isShown
+            if (visible) applySelectedTime(isStart = false)
+            binding.timePickerEndLl.isVisible = !visible
+            binding.timePickerStartLl.isVisible = false
+        }
+
+        binding.registerBtn.setOnClickListener {
+            val title = binding.scheduleTitleEt.text.toString().trim()
+            val description = binding.descriptionTextEt.text.toString().trim()
+
+            //Todo: 일정 등록 시 입력값 부족할 때 처리
+
+            applySelectedTime(isStart = true)
+            applySelectedTime(isStart = false)
+
+            val schedule = Schedule(
+                title = title,
+                day = dayNames[selectedDayIndex],
+                startTime = binding.startTimeTv.text.toString(),
+                endTime = binding.endTimeTv.text.toString(),
+                description = description
+            )
+            onScheduleAdded(schedule)
+            dismiss()
+        }
+    }
+
+    private fun setupPickers() {
+        listOf(binding.ampmPicker01Np, binding.ampmPicker02Np).forEach {
+            it.minValue = 0
+            it.maxValue = 1
+            it.displayedValues = arrayOf("오전", "오후")
+        }
+
+        listOf(binding.hourPicker01Np, binding.hourPicker02Np).forEach {
+            it.minValue = 1
+            it.maxValue = 12
+            it.wrapSelectorWheel = true
+        }
+
+        val minuteValues = arrayOf("00", "10", "20", "30", "40", "50")
+        listOf(binding.minutePicker01Np, binding.minutePicker02Np).forEach {
+            it.minValue = 0
+            it.maxValue = minuteValues.size - 1
+            it.displayedValues = minuteValues
+            it.wrapSelectorWheel = true
+        }
+    }
+
+    private fun applySelectedTime(isStart: Boolean) {
+        val ampmPicker = if (isStart) binding.ampmPicker01Np else binding.ampmPicker02Np
+        val hourPicker = if (isStart) binding.hourPicker01Np else binding.hourPicker02Np
+        val minutePicker = if (isStart) binding.minutePicker01Np else binding.minutePicker02Np
+
+        val ampm = if (ampmPicker.value == 0) "오전" else "오후"
+        val hour = hourPicker.value
+        val minute = arrayOf("00", "10", "20", "30", "40", "50")[minutePicker.value]
+
+        val timeText = "$ampm $hour:$minute"
+
+        if (isStart) {
+            binding.startTimeTv.text = timeText
+            binding.timePickerStartLl.isVisible = false
+        } else {
+            binding.endTimeTv.text = timeText
+            binding.timePickerEndLl.isVisible = false
+        }
+    }
+
+}

--- a/app/src/main/java/com/example/teumteum/ui/singup/OnBoardingProfileFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/singup/OnBoardingProfileFragment.kt
@@ -1,5 +1,6 @@
 package com.example.teumteum.ui.singup
 
+import android.R.attr.fragment
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
@@ -9,6 +10,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
+import com.example.teumteum.R
 import com.example.teumteum.databinding.FragmentOnBoardingProfileBinding
 import com.example.teumteum.ui.main.MainActivity
 
@@ -60,7 +62,11 @@ class OnBoardingProfileFragment : Fragment() {
 
 
         binding.nextBtn.setOnClickListener {
-            startActivity(Intent(requireContext(), MainActivity::class.java))
+//            startActivity(Intent(requireContext(), MainActivity::class.java))
+            parentFragmentManager.beginTransaction()
+                .replace(R.id.fragment_container, OnBoardingScheduleFragment())
+                .addToBackStack(null)
+                .commit()
         }
 
     }

--- a/app/src/main/java/com/example/teumteum/ui/singup/OnBoardingScheduleFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/singup/OnBoardingScheduleFragment.kt
@@ -1,0 +1,80 @@
+package com.example.teumteum.ui.singup
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import androidx.viewpager2.widget.ViewPager2
+import com.example.teumteum.R
+import com.example.teumteum.databinding.FragmentOnBoardingProfileBinding
+import com.example.teumteum.databinding.FragmentOnBoardingScheduleBinding
+import com.example.teumteum.ui.calendar.CalendarMode
+import com.example.teumteum.ui.calendar.IDateClickListener
+import com.example.teumteum.ui.main.CalendarVPAdapter
+import com.example.teumteum.ui.main.MainActivity
+import com.example.teumteum.util.saveSelectedDate
+import org.threeten.bp.LocalDate
+
+class OnBoardingScheduleFragment : Fragment(){
+
+    private lateinit var binding: FragmentOnBoardingScheduleBinding
+    private lateinit var selectedDayTextView: TextView
+    private val dayTextViews by lazy {
+        listOf(binding.sunTv, binding.monTv, binding.tueTv, binding.wedTv, binding.thuTv, binding.friTv, binding.satTv)
+    }
+
+    private var selectedDayIndex = 0
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = FragmentOnBoardingScheduleBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        (activity as? SignUpActivity)?.setProgressBar(25)
+
+        binding.nextBtn.setOnClickListener {
+            startActivity(Intent(requireContext(), MainActivity::class.java))
+
+        }
+
+        setupDaySelection()
+
+    }
+
+    private fun setupDaySelection() {
+        dayTextViews.forEachIndexed { index, textView ->
+            textView.setOnClickListener {
+                updateDayHighlight(index)
+            }
+        }
+    }
+
+    private fun updateDayHighlight(selectedIndex: Int) {
+        // 이전 선택 요일: 배경 제거 + 글자색 검정
+        dayTextViews[selectedDayIndex].background = null
+        dayTextViews[selectedDayIndex].setTextColor(ContextCompat.getColor(requireContext(), R.color.black))
+
+        // 새로 선택한 요일: 배경 보라색 + 글자색 흰색
+        dayTextViews[selectedIndex].background = ContextCompat.getDrawable(requireContext(), R.drawable.bg_day_selected)
+        dayTextViews[selectedIndex].setTextColor(ContextCompat.getColor(requireContext(), R.color.white))
+
+        selectedDayIndex = selectedIndex
+
+        // 해당 요일의 일정 보여주기
+//        scheduleAdapter.submitList(scheduleMap[selectedDayIndex] ?: emptyList())
+    }
+
+}

--- a/app/src/main/java/com/example/teumteum/ui/singup/OnBoardingScheduleFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/singup/OnBoardingScheduleFragment.kt
@@ -1,5 +1,6 @@
 package com.example.teumteum.ui.singup
 
+import BottomSheetScheduleFragment
 import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
@@ -8,26 +9,26 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.core.content.ContextCompat
-import androidx.viewpager2.widget.ViewPager2
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.teumteum.R
-import com.example.teumteum.databinding.FragmentOnBoardingProfileBinding
 import com.example.teumteum.databinding.FragmentOnBoardingScheduleBinding
-import com.example.teumteum.ui.calendar.CalendarMode
-import com.example.teumteum.ui.calendar.IDateClickListener
-import com.example.teumteum.ui.main.CalendarVPAdapter
 import com.example.teumteum.ui.main.MainActivity
-import com.example.teumteum.util.saveSelectedDate
-import org.threeten.bp.LocalDate
+import com.example.teumteum.ui.register.BottomSheetRegisterFragment
+import kotlin.collections.toList
+import com.example.teumteum.data.Schedule
 
 class OnBoardingScheduleFragment : Fragment(){
 
     private lateinit var binding: FragmentOnBoardingScheduleBinding
-    private lateinit var selectedDayTextView: TextView
+    private val scheduleAdapter by lazy { ScheduleAdapter() }
+
     private val dayTextViews by lazy {
         listOf(binding.sunTv, binding.monTv, binding.tueTv, binding.wedTv, binding.thuTv, binding.friTv, binding.satTv)
     }
 
     private var selectedDayIndex = 0
+
+    private val scheduleMap = mutableMapOf<Int, MutableList<Schedule>>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -43,11 +44,23 @@ class OnBoardingScheduleFragment : Fragment(){
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        (activity as? SignUpActivity)?.setProgressBar(25)
+        (activity as? SignUpActivity)?.setProgressBar(50)
 
         binding.nextBtn.setOnClickListener {
             startActivity(Intent(requireContext(), MainActivity::class.java))
+        }
 
+        // RecyclerView 세팅
+        binding.scheduleRv.adapter = scheduleAdapter
+        binding.scheduleRv.layoutManager = LinearLayoutManager(requireContext())
+
+        binding.fabAddIv.setOnClickListener {
+            val bottomSheet = BottomSheetScheduleFragment(selectedDayIndex) { schedule ->
+                val list = scheduleMap.getOrPut(selectedDayIndex) { mutableListOf() }
+                list.add(schedule)
+                scheduleAdapter.submitList(list.toList())
+            }
+            bottomSheet.show(parentFragmentManager, "BottomSheetScheduleFragment")
         }
 
         setupDaySelection()
@@ -62,19 +75,19 @@ class OnBoardingScheduleFragment : Fragment(){
         }
     }
 
+    //요일 선택했을 때 하이라이팅, 해당 요일 일정 보여주기
     private fun updateDayHighlight(selectedIndex: Int) {
-        // 이전 선택 요일: 배경 제거 + 글자색 검정
+
         dayTextViews[selectedDayIndex].background = null
         dayTextViews[selectedDayIndex].setTextColor(ContextCompat.getColor(requireContext(), R.color.black))
 
-        // 새로 선택한 요일: 배경 보라색 + 글자색 흰색
         dayTextViews[selectedIndex].background = ContextCompat.getDrawable(requireContext(), R.drawable.bg_day_selected)
         dayTextViews[selectedIndex].setTextColor(ContextCompat.getColor(requireContext(), R.color.white))
 
         selectedDayIndex = selectedIndex
 
         // 해당 요일의 일정 보여주기
-//        scheduleAdapter.submitList(scheduleMap[selectedDayIndex] ?: emptyList())
+        scheduleAdapter.submitList(scheduleMap[selectedDayIndex] ?: emptyList())
     }
 
 }

--- a/app/src/main/java/com/example/teumteum/ui/singup/ScheduleAdapter.kt
+++ b/app/src/main/java/com/example/teumteum/ui/singup/ScheduleAdapter.kt
@@ -14,8 +14,8 @@ class ScheduleAdapter : ListAdapter<Schedule, ScheduleAdapter.ScheduleViewHolder
         RecyclerView.ViewHolder(binding.root) {
 
         fun bind(item: Schedule) {
-            val startTime = item.startTime.replace("오전 ", "").replace("오후 ", "")
-            val endTime = item.endTime.replace("오전 ", "").replace("오후 ", "")
+            val startTime = formatTime(item.startTime)
+            val endTime = formatTime(item.endTime)
             binding.timeStartTv.text = startTime
             binding.timeEndTv.text = endTime
             binding.titleTv.text = item.title
@@ -29,6 +29,17 @@ class ScheduleAdapter : ListAdapter<Schedule, ScheduleAdapter.ScheduleViewHolder
 
     override fun onBindViewHolder(holder: ScheduleViewHolder, position: Int) {
         holder.bind(getItem(position))
+    }
+
+    private fun formatTime(time: String): String {
+        val cleaned = time.replace("오전 ", "").replace("오후 ", "")
+        val parts = cleaned.split(":")
+        if (parts.size != 2) return cleaned // 예외 처리: 형식이 이상하면 원본 반환
+
+        val hour = parts[0].toIntOrNull() ?: return cleaned
+        val minute = parts[1].toIntOrNull() ?: return cleaned
+
+        return String.format("%02d:%02d", hour, minute)
     }
 
     companion object {

--- a/app/src/main/java/com/example/teumteum/ui/singup/ScheduleAdapter.kt
+++ b/app/src/main/java/com/example/teumteum/ui/singup/ScheduleAdapter.kt
@@ -1,0 +1,38 @@
+package com.example.teumteum.ui.singup
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.example.teumteum.data.Schedule
+import com.example.teumteum.databinding.ItemScheduleBinding
+
+class ScheduleAdapter : ListAdapter<Schedule, ScheduleAdapter.ScheduleViewHolder>(DIFF_CALLBACK) {
+
+    inner class ScheduleViewHolder(private val binding: ItemScheduleBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: Schedule) {
+            binding.timeStartTv.text = item.startTime
+            binding.timeEndTv.text = item.endTime
+            binding.titleTv.text = item.title
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ScheduleViewHolder {
+        val binding = ItemScheduleBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ScheduleViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ScheduleViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    companion object {
+        val DIFF_CALLBACK = object : DiffUtil.ItemCallback<Schedule>() {
+            override fun areItemsTheSame(oldItem: Schedule, newItem: Schedule) = oldItem === newItem
+            override fun areContentsTheSame(oldItem: Schedule, newItem: Schedule) = oldItem == newItem
+        }
+    }
+}

--- a/app/src/main/java/com/example/teumteum/ui/singup/ScheduleAdapter.kt
+++ b/app/src/main/java/com/example/teumteum/ui/singup/ScheduleAdapter.kt
@@ -14,8 +14,10 @@ class ScheduleAdapter : ListAdapter<Schedule, ScheduleAdapter.ScheduleViewHolder
         RecyclerView.ViewHolder(binding.root) {
 
         fun bind(item: Schedule) {
-            binding.timeStartTv.text = item.startTime
-            binding.timeEndTv.text = item.endTime
+            val startTime = item.startTime.replace("오전 ", "").replace("오후 ", "")
+            val endTime = item.endTime.replace("오전 ", "").replace("오후 ", "")
+            binding.timeStartTv.text = startTime
+            binding.timeEndTv.text = endTime
             binding.titleTv.text = item.title
         }
     }

--- a/app/src/main/res/drawable/bg_day_selected.xml
+++ b/app/src/main/res/drawable/bg_day_selected.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/main_1"/>
+</shape>

--- a/app/src/main/res/drawable/ic_arrow_sv.xml
+++ b/app/src/main/res/drawable/ic_arrow_sv.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M9,6L15,12L9,18"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#0F0F0F"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/ic_fab_add_purple_sv.xml
+++ b/app/src/main/res/drawable/ic_fab_add_purple_sv.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="60dp"
+    android:height="60dp"
+    android:viewportWidth="60"
+    android:viewportHeight="60">
+  <path
+      android:pathData="M30,0L30,0A30,30 0,0 1,60 30L60,30A30,30 0,0 1,30 60L30,60A30,30 0,0 1,0 30L0,30A30,30 0,0 1,30 0z"
+      android:fillColor="#7770FE"/>
+  <path
+      android:pathData="M22,30H38M30,22V38"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2.2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/layout/fragment_bottom_sheet_schedule.xml
+++ b/app/src/main/res/layout/fragment_bottom_sheet_schedule.xml
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical" >
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true"
+        android:background="@drawable/calendar_background">
+
+        <LinearLayout
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="20dp">
+
+            <EditText
+                android:id="@+id/schedule_title_et"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                style="@style/Header1"
+                android:hint="일정 이름을 작성해주세요"
+                android:minHeight="28dp"
+                android:textSize="20sp"
+                android:background="@android:color/transparent"
+                android:inputType="textMultiLine"
+                android:maxLines="5"
+                android:gravity="top|start" />
+
+            <ImageView
+                android:id="@+id/title_underline"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="15dp"
+                android:src="@drawable/ic_horizon_sv"
+                android:scaleType="centerCrop" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:background="@android:color/white"
+                android:layout_marginTop="15dp"
+                android:padding="8dp">
+
+                <LinearLayout
+                    android:id="@+id/schedule_start_time"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:layout_marginBottom="4dp" >
+
+                    <ImageView
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        android:src="@drawable/ic_timer_sv"
+                        android:layout_marginEnd="8dp" />
+
+                    <TextView
+                        android:id="@+id/start_date_tv"
+                        android:layout_width="0dp"
+                        android:layout_weight="1"
+                        android:layout_height="wrap_content"
+                        android:text="매주 수요일"
+                        android:textColor="@android:color/black"
+                        android:textSize="15sp" />
+
+                    <TextView
+                        android:id="@+id/start_time_tv"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="오전 9:00"
+                        android:textColor="@android:color/black"
+                        android:textSize="14sp"
+                        android:clickable="true"
+                        android:focusable="true" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/time_picker_start_ll"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center"
+                    android:layout_marginTop="16dp"
+                    android:layout_marginBottom="16dp"
+                    android:visibility="gone"
+                    >
+
+                    <NumberPicker
+                        android:id="@+id/ampm_picker_01_np"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="8dp"/>
+
+                    <NumberPicker
+                        android:id="@+id/hour_picker_01_np"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="8dp"/>
+
+                    <NumberPicker
+                        android:id="@+id/minute_picker_01_np"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="8dp"/>
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/todo_end_time"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
+
+                    <View
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        android:layout_marginEnd="8dp"
+                        android:visibility="invisible" />
+
+                    <TextView
+                        android:id="@+id/end_date_tv"
+                        android:layout_width="0dp"
+                        android:layout_weight="1"
+                        android:layout_height="wrap_content"
+                        android:text="매주 수요일"
+                        android:textColor="@android:color/black"
+                        android:textSize="15sp" />
+
+                    <TextView
+                        android:id="@+id/end_time_tv"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="오후 12:00"
+                        android:textColor="@android:color/black"
+                        android:textSize="14sp" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/time_picker_end_ll"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center"
+                    android:layout_marginTop="16dp"
+                    android:layout_marginBottom="16dp"
+                    android:visibility="gone" >
+
+                    <NumberPicker
+                        android:id="@+id/ampm_picker_02_np"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="8dp"/>
+
+                    <NumberPicker
+                        android:id="@+id/hour_picker_02_np"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="8dp"/>
+
+                    <NumberPicker
+                        android:id="@+id/minute_picker_02_np"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="8dp"/>
+                </LinearLayout>
+            </LinearLayout>
+
+            <ImageView
+                android:id="@+id/horizon_02_iv"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="21dp"
+                android:src="@drawable/ic_horizon_sv"
+                android:scaleType="centerCrop" />
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginTop="23dp"
+                android:layout_marginBottom="80dp" >
+
+                <ImageView
+                    android:id="@+id/detail_text_iv"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:layout_marginEnd="8dp"
+                    android:contentDescription="상세 내용"
+                    android:src="@drawable/ic_detail_text_sv" />
+
+                <EditText
+                    android:id="@+id/description_text_et"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="상세 내용 입력"
+                    android:textColorHint="@color/black"
+                    android:minHeight="28dp"
+                    android:textSize="15sp"
+                    android:background="@android:color/transparent"
+                    android:inputType="textMultiLine"
+                    android:maxLines="5"
+                    android:gravity="top|start" />
+
+            </LinearLayout>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/register_btn"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="등록할게요"
+                style="@style/Md16"
+                android:textColor="@color/white"
+                app:cornerRadius="8dp"
+                android:backgroundTint="@color/black"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                />
+
+        </LinearLayout>
+
+    </ScrollView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_on_boarding_schedule.xml
+++ b/app/src/main/res/layout/fragment_on_boarding_schedule.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white"
+    tools:context=".ui.singup.OnBoardingScheduleFragment">
+
+    <TextView
+        android:id="@+id/title_tv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="요일마다 반복되는\n일정이 있나요?"
+        style="@style/Header1"
+        android:textSize="28sp"
+        android:textColor="@color/black"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="159dp"
+        android:includeFontPadding="false"
+        />
+
+    <TextView
+        android:id="@+id/sub_title_tv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="없으시면 다음으로 넘어가주세요"
+        style="@style/Header2"
+        android:textSize="14sp"
+        android:textColor="@color/black"
+        app:layout_constraintTop_toBottomOf="@+id/title_tv"
+        app:layout_constraintStart_toStartOf="@+id/title_tv"
+        android:layout_marginTop="10dp"
+        android:includeFontPadding="false"
+        />
+
+    <LinearLayout
+        android:id="@+id/calendar_container"
+        android:layout_width="330dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="53dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toTopOf="@+id/calendar_underline"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginStart="35dp"
+        android:layout_marginEnd="35dp"
+        app:layout_constraintTop_toBottomOf="@+id/sub_title_tv">
+
+        <TextView
+            android:id="@+id/sun_tv"
+            style="@style/Sm12Regular"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:gravity="center"
+            android:text="일"
+            android:textColor="@color/black"
+            android:includeFontPadding="false"/>
+
+        <TextView
+            android:id="@+id/mon_tv"
+            style="@style/Sm12Regular"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:gravity="center"
+            android:layout_marginStart="30dp"
+            android:text="월"
+            android:textColor="@color/black"
+            android:includeFontPadding="false"/>
+
+        <TextView
+            android:id="@+id/tue_tv"
+            style="@style/Sm12Regular"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:gravity="center"
+            android:layout_marginStart="30dp"
+            android:text="화"
+            android:textColor="@color/black"
+            android:includeFontPadding="false"/>
+
+        <TextView
+            android:id="@+id/wed_tv"
+            style="@style/Sm12Regular"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:gravity="center"
+            android:layout_marginStart="30dp"
+            android:text="수"
+            android:textColor="@color/black"
+            android:includeFontPadding="false"/>
+
+        <TextView
+            android:id="@+id/thu_tv"
+            style="@style/Sm12Regular"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:gravity="center"
+            android:layout_marginStart="30dp"
+            android:text="목"
+            android:textColor="@color/black"
+            android:includeFontPadding="false"/>
+
+        <TextView
+            android:id="@+id/fri_tv"
+            style="@style/Sm12Regular"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:gravity="center"
+            android:layout_marginStart="30dp"
+            android:text="금"
+            android:textColor="@color/black"
+            android:includeFontPadding="false"/>
+
+        <TextView
+            android:id="@+id/sat_tv"
+            style="@style/Sm12Regular"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:gravity="center"
+            android:layout_marginStart="30dp"
+            android:text="토"
+            android:textColor="@color/black"
+            android:includeFontPadding="false"/>
+    </LinearLayout>
+
+    <View
+        android:id="@+id/calendar_underline"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="#EAEAEA"
+        app:layout_constraintTop_toBottomOf="@+id/calendar_container"
+        android:layout_marginTop="30dp"
+        android:layout_marginStart="20dp"
+        android:layout_marginEnd="20dp"
+        />
+
+    <!-- TODO: 일정 리스트 추가 -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/schedule_rv"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@+id/calendar_underline"
+        app:layout_constraintStart_toStartOf="@+id/calendar_underline"
+        app:layout_constraintEnd_toEndOf="@+id/calendar_underline"
+        app:layout_constraintBottom_toTopOf="@+id/next_btn"
+        android:layout_marginTop="30dp"
+        android:layout_marginBottom="30dp"
+        />
+
+
+    <ImageView
+        android:id="@+id/fab_add_iv"
+        android:layout_width="64dp"
+        android:layout_height="64dp"
+        app:layout_constraintBottom_toTopOf="@+id/next_btn"
+        app:layout_constraintEnd_toEndOf="@+id/next_btn"
+        android:src="@drawable/ic_fab_add_purple_sv"
+        android:elevation="20dp"
+        android:translationZ="20dp"
+        android:backgroundTint="@color/black"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:layout_marginBottom="29dp"
+        />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/next_btn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="다음으로"
+        style="@style/Md16"
+        app:cornerRadius="8dp"
+        android:backgroundTint="@color/black"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginStart="19dp"
+        android:layout_marginEnd="19dp"
+        android:layout_marginBottom="18.5dp"
+        />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_schedule.xml
+++ b/app/src/main/res/layout/item_schedule.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/rounded_border"
+    android:padding="16dp"
+    android:layout_marginBottom="12dp">
+
+    <TextView
+        android:id="@+id/time_start_tv"
+        style="@style/Sm12Regular"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="09:00"
+        android:textColor="#000000"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:includeFontPadding="false"/>
+
+
+    <TextView
+        android:id="@+id/time_end_tv"
+        style="@style/Sm12Regular"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="12:00"
+        android:textColor="#AAAAAA"
+        app:layout_constraintTop_toBottomOf="@id/time_start_tv"
+        app:layout_constraintStart_toStartOf="@id/time_start_tv"
+        android:includeFontPadding="false"/>
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="1dp"
+        android:layout_height="40dp"
+        android:background="#B1B2B3"
+        app:layout_constraintStart_toEndOf="@id/time_start_tv"
+        app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginStart="17dp"
+        android:layout_marginEnd="12dp"
+        />
+
+    <TextView
+        android:id="@+id/title_tv"
+        style="@style/Sm12Regular"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="교내 근로"
+        android:textSize="15sp"
+        android:textColor="@color/black"
+        app:layout_constraintStart_toEndOf="@id/divider"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/arrow"
+        android:layout_marginStart="17dp"/>
+
+    <ImageView
+        android:id="@+id/arrow"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_arrow_sv"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_schedule.xml
+++ b/app/src/main/res/layout/item_schedule.xml
@@ -3,18 +3,21 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="58dp"
     android:background="@drawable/rounded_border"
-    android:padding="16dp"
+    android:paddingTop="11dp"
+    android:paddingStart="19dp"
+    android:paddingBottom="11dp"
     android:layout_marginBottom="12dp">
 
     <TextView
         android:id="@+id/time_start_tv"
         style="@style/Sm12Regular"
+        android:textSize="12sp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="09:00"
-        android:textColor="#000000"
+        android:textColor="#0F0F0F"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         android:includeFontPadding="false"/>
@@ -23,12 +26,16 @@
     <TextView
         android:id="@+id/time_end_tv"
         style="@style/Sm12Regular"
+        android:textSize="12sp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="12:00"
-        android:textColor="#AAAAAA"
+        android:textColor="#B1B2B3"
+        android:layout_marginTop="2dp"
+        android:layout_marginBottom="1dp"
         app:layout_constraintTop_toBottomOf="@id/time_start_tv"
         app:layout_constraintStart_toStartOf="@id/time_start_tv"
+        app:layout_constraintBottom_toBottomOf="parent"
         android:includeFontPadding="false"/>
 
     <View
@@ -54,7 +61,8 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/arrow"
-        android:layout_marginStart="17dp"/>
+        android:layout_marginStart="17dp"
+        android:includeFontPadding="false"/>
 
     <ImageView
         android:id="@+id/arrow"
@@ -63,6 +71,7 @@
         android:src="@drawable/ic_arrow_sv"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginEnd="15dp"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #20

## ✨ 작업 내용
> 온보딩02 화면 제작 - 반복 일정 등록 
> 요일마다 반복되는 일정을 등록하고, 해당 요일을 클릭했을 때 등록한 일정들을 보여주는 화면

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 요일 선택 시 해당 요일에서 등록한 일정만 나오는지
- [x] 시간 선택이 제대로 반영되는지
- [x] 그 외 UI 요소에 이상한 점 없는지

## 📸 스크린샷 (선택)
> 반복 일정 첫 화면
<img width="264" height="563" alt="반복 일정" src="https://github.com/user-attachments/assets/2f50e4c8-4604-44a8-8c87-0a492567fade" />

> 요일 선택 시
<img width="271" height="569" alt="반복 일정 - 요일 선택" src="https://github.com/user-attachments/assets/7d319da8-f489-48b5-9187-0a0b425cf7ad" />

> '+' 버튼 클릭 - 바텀 시트
<img width="268" height="569" alt="반복 일정 - 바텀 시트" src="https://github.com/user-attachments/assets/f97fd442-7763-46ef-bb36-f3666060a511" />

> 바텀 시트 - 타임피커
<img width="266" height="566" alt="반복 일정 - 시간 선택" src="https://github.com/user-attachments/assets/e7f3e04b-a210-4c0c-b116-d1d5786ee8c5" />

> 일정 등록 시
<img width="269" height="566" alt="반복 일정 - 일정 등록" src="https://github.com/user-attachments/assets/ea463005-4254-4812-9834-ab529bea838e" />

> 일정 여러개 등록 시 스크롤
<img width="267" height="563" alt="반복 일정 - 일정 리스트 스크롤" src="https://github.com/user-attachments/assets/f4b83eaf-1746-415c-9bf3-1a1e462feebe" />

> 일정을 등록하지 않은 다른 요일 선택 시
<img width="269" height="560" alt="반복 일정 - 다른 요일" src="https://github.com/user-attachments/assets/715c964b-69f8-4b95-b91c-01ed80e0720d" />


## 💬 기타 참고 사항
> 시간 data 저장할 때 LocalDate를 사용하려고 했는데 저번에 승현님이 말씀하신대로 API레벨이 26이상에서만 사용 가능해서 틈틈 서비스 특성상 시간 데이터를 중요하게 다루기 때문에 API레벨을 올리거나 라이브러리를 찾아보는게 좋을 것 같습니다. 7/15 회의 때 다시 말씀 드리겠습니다.

>타임피커의 경우 여러곳에서 사용되는데 UI가 다른 부분이 있어서 전체회의 때 확실하게 정하는 것이 좋을 것 같습니다. 우선 디자인 페이지에서 수면 패턴 등록 부분을 참고하여 구현했습니다. 
