### PR TITLE
[FEAT/#22] 수면 패턴 등록 화면 구현

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/singup/OnBoardingScheduleFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/singup/OnBoardingScheduleFragment.kt
@@ -1,19 +1,15 @@
 package com.example.teumteum.ui.singup
 
 import BottomSheetScheduleFragment
-import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.teumteum.R
 import com.example.teumteum.databinding.FragmentOnBoardingScheduleBinding
-import com.example.teumteum.ui.main.MainActivity
-import com.example.teumteum.ui.register.BottomSheetRegisterFragment
 import kotlin.collections.toList
 import com.example.teumteum.data.Schedule
 
@@ -47,7 +43,11 @@ class OnBoardingScheduleFragment : Fragment(){
         (activity as? SignUpActivity)?.setProgressBar(50)
 
         binding.nextBtn.setOnClickListener {
-            startActivity(Intent(requireContext(), MainActivity::class.java))
+//            startActivity(Intent(requireContext(), MainActivity::class.java))
+            parentFragmentManager.beginTransaction()
+                .replace(R.id.fragment_container, OnBoardingSleepPatternFragment())
+                .addToBackStack(null)
+                .commit()
         }
 
         // RecyclerView 세팅

--- a/app/src/main/java/com/example/teumteum/ui/singup/OnBoardingSleepPatternFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/singup/OnBoardingSleepPatternFragment.kt
@@ -1,0 +1,184 @@
+package com.example.teumteum.ui.singup
+
+import android.content.Intent
+import android.graphics.Color
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.NumberPicker
+import android.widget.TextView
+import com.example.teumteum.R
+import com.example.teumteum.databinding.FragmentOnBoardingSleepPatternBinding
+import com.example.teumteum.ui.main.MainActivity
+import com.google.android.material.bottomsheet.BottomSheetDialog
+
+class OnBoardingSleepPatternFragment : Fragment() {
+
+    private lateinit var binding: FragmentOnBoardingSleepPatternBinding
+
+    private var selectedStartTime: String? = null
+    private var selectedEndTime: String? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+
+        binding = FragmentOnBoardingSleepPatternBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        (activity as? SignUpActivity)?.setProgressBar(75)
+
+        binding.nextBtn.setOnClickListener {
+            startActivity(Intent(requireContext(), MainActivity::class.java))
+        }
+
+        binding.sleepStartContainer.setOnClickListener {
+            showCustomTimePicker(binding.startChoiceTv)
+        }
+
+        binding.sleepEndContainer.setOnClickListener {
+            showCustomTimePicker(binding.endChoiceTv)
+        }
+
+        binding.startUpArrow.setOnClickListener{
+            increaseHour(binding.startChoiceTv)
+        }
+
+        binding.startDownArrow.setOnClickListener {
+            decreaseHour(binding.startChoiceTv)
+        }
+
+        binding.endUpArrow.setOnClickListener {
+            increaseHour(binding.endChoiceTv)
+        }
+
+        binding.endDownArrow.setOnClickListener {
+            decreaseHour(binding.endChoiceTv)
+        }
+    }
+
+    private fun showCustomTimePicker(targetTextView: TextView) {
+        val dialogView = layoutInflater.inflate(R.layout.dialog_time_picker, null, false)
+
+        val ampmPicker = dialogView.findViewById<NumberPicker>(R.id.ampmPicker01Np)
+        val hourPicker = dialogView.findViewById<NumberPicker>(R.id.hourPicker01Np)
+        val minutePicker = dialogView.findViewById<NumberPicker>(R.id.minutePicker01Np)
+
+        val minuteValues = arrayOf("00", "10", "20", "30", "40", "50")
+
+        // Picker 초기화
+        ampmPicker.minValue = 0
+        ampmPicker.maxValue = 1
+        ampmPicker.displayedValues = arrayOf("AM", "PM")
+
+        hourPicker.minValue = 1
+        hourPicker.maxValue = 12
+        hourPicker.wrapSelectorWheel = true
+
+        minutePicker.minValue = 0
+        minutePicker.maxValue = minuteValues.size - 1
+        minutePicker.displayedValues = minuteValues
+        minutePicker.wrapSelectorWheel = true
+
+        val dialog = BottomSheetDialog(requireContext())
+        dialog.setContentView(dialogView)
+
+        // ✅ 배경 적용
+        dialog.setOnShowListener { dialogInterface ->
+            val bottomSheet = (dialogInterface as BottomSheetDialog)
+                .findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
+            bottomSheet?.setBackgroundResource(R.drawable.calendar_background)
+        }
+
+        // 취소 버튼
+        dialogView.findViewById<Button>(R.id.btnCancel).setOnClickListener {
+            dialog.dismiss()
+        }
+
+        // 확인 버튼
+        dialogView.findViewById<Button>(R.id.btnOk).setOnClickListener {
+            val isAm = ampmPicker.value == 0
+            var hour = hourPicker.value % 12
+            if (!isAm) hour += 12
+            if (hour == 0) hour = 0 // 12AM → 0시로
+
+            val minute = minuteValues[minutePicker.value]
+            val timeText = String.format("%02d:%s", hour, minute)
+
+            targetTextView.text = timeText
+
+            if (targetTextView == binding.startChoiceTv) {
+                selectedStartTime = timeText
+            } else if (targetTextView == binding.endChoiceTv) {
+                selectedEndTime = timeText
+            }
+
+            updateNextButtonState()
+            dialog.dismiss()
+        }
+
+        dialog.show()
+    }
+
+    private fun increaseHour(targetTextView: TextView) {
+        val currentText = targetTextView.text.toString()
+        if (currentText.isNotBlank()) {
+            val parts = currentText.split(":")
+            if (parts.size == 2) {
+                var hour = parts[0].toIntOrNull() ?: return
+                val minute = parts[1]
+
+                hour = (hour + 1) % 24
+                val newTime = String.format("%02d:%s", hour, minute)
+                targetTextView.text = newTime
+            }
+        }
+    }
+
+    private fun decreaseHour(targetTextView: TextView) {
+        val currentText = targetTextView.text.toString()
+        if (currentText.isNotBlank()) {
+            val parts = currentText.split(":")
+            if (parts.size == 2) {
+                var hour = parts[0].toIntOrNull() ?: return
+                val minute = parts[1]
+
+                hour = if (hour == 0) 23 else hour - 1
+                val newTime = String.format("%02d:%s", hour, minute)
+                targetTextView.text = newTime
+            }
+        }
+    }
+
+    //다음으로 버튼 업데이트
+    private fun updateNextButtonState() {
+        val allSet = selectedStartTime != null && selectedEndTime != null
+        binding.nextBtn.isEnabled = allSet
+
+        binding.nextBtn.setBackgroundColor(
+            if (allSet)
+                requireContext().getColor(R.color.black)
+            else
+                Color.parseColor("#F6F6F6")
+        )
+
+        binding.nextBtn.setTextColor(
+            if (allSet)
+                requireContext().getColor(R.color.white)
+            else
+                requireContext().getColor(R.color.black)
+        )
+    }
+
+}

--- a/app/src/main/res/drawable/ic_arrow_down.xml
+++ b/app/src/main/res/drawable/ic_arrow_down.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="7dp"
+    android:viewportWidth="12"
+    android:viewportHeight="7">
+  <path
+      android:pathData="M1,1L6,6L11,1"
+      android:strokeWidth="1.2"
+      android:fillColor="#00000000"
+      android:strokeColor="#0F0F0F"/>
+</vector>

--- a/app/src/main/res/drawable/ic_arrow_up.xml
+++ b/app/src/main/res/drawable/ic_arrow_up.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="7dp"
+    android:viewportWidth="12"
+    android:viewportHeight="7">
+  <path
+      android:pathData="M1,6L6,1L11,6"
+      android:strokeWidth="1.2"
+      android:fillColor="#00000000"
+      android:strokeColor="#0F0F0F"/>
+</vector>

--- a/app/src/main/res/drawable/rounded_sleep_pattern.xml
+++ b/app/src/main/res/drawable/rounded_sleep_pattern.xml
@@ -1,0 +1,5 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#F6F6F6"/>
+    <corners android:radius="10dp"/>
+</shape>

--- a/app/src/main/res/layout/fragment_on_boarding_sleep_pattern.xml
+++ b/app/src/main/res/layout/fragment_on_boarding_sleep_pattern.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white"
+    tools:context=".ui.singup.OnBoardingSleepPatternFragment">
+
+    <TextView
+        android:id="@+id/title_tv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="수면 패턴을 등록해주세요"
+        style="@style/Header1"
+        android:textSize="28sp"
+        android:textColor="@color/black"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="159dp"
+        android:includeFontPadding="false"
+        />
+
+    <TextView
+        android:id="@+id/sub_title_tv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="평균적인 취침 시작 시간과 기상 시간을 알려주세요"
+        style="@style/Header2"
+        android:textSize="14sp"
+        android:textColor="@color/black"
+        app:layout_constraintTop_toBottomOf="@+id/title_tv"
+        app:layout_constraintStart_toStartOf="@+id/title_tv"
+        android:layout_marginTop="10dp"
+        android:includeFontPadding="false"
+        />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="76dp"
+        android:orientation="horizontal"
+        app:layout_constraintTop_toBottomOf="@+id/sub_title_tv"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="84dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:paddingTop="14dp"
+        android:paddingStart="14dp"
+        android:paddingBottom="9dp"
+        android:paddingEnd="16dp"
+        android:background="@drawable/rounded_sleep_pattern">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/sleep_start_container"
+            android:layout_width="0dp"
+            android:layout_height="53dp"
+            android:layout_weight="1"
+            android:layout_marginEnd="31dp">
+
+            <TextView
+                android:id="@+id/start_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="@style/Sm12Regular"
+                android:text="시작"
+                android:textColor="@color/text_secondary"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                android:includeFontPadding="false"/>
+
+            <TextView
+                android:id="@+id/start_choice_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="@style/Md15Medium"
+                android:text="선택"
+                android:textColor="@color/text_primary"
+                android:textSize="22sp"
+                app:layout_constraintTop_toBottomOf="@id/start_tv"
+                app:layout_constraintStart_toStartOf="parent"
+                android:layout_marginTop="4dp"
+                android:includeFontPadding="false"/>
+
+                <ImageView
+                    android:id="@+id/start_up_arrow"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_arrow_up"
+                    app:layout_constraintTop_toTopOf="@+id/start_choice_tv"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    android:layout_marginTop="8dp"
+                    />
+
+
+                <ImageView
+                    android:id="@+id/start_down_arrow"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_arrow_down"
+                    app:layout_constraintTop_toBottomOf="@+id/start_up_arrow"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    android:layout_marginTop="6dp"
+                    />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/sleep_end_container"
+            android:layout_width="0dp"
+            android:layout_height="53dp"
+            android:layout_weight="1">
+
+            <TextView
+                android:id="@+id/end_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="@style/Sm12Regular"
+                android:text="종료"
+                android:textColor="@color/text_secondary"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                android:includeFontPadding="false"/>
+
+            <TextView
+                android:id="@+id/end_choice_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="@style/Md15Medium"
+                android:text="선택"
+                android:textColor="@color/text_primary"
+                android:textSize="22sp"
+                app:layout_constraintTop_toBottomOf="@id/end_tv"
+                app:layout_constraintStart_toStartOf="parent"
+                android:layout_marginTop="4dp"
+                android:includeFontPadding="false"/>
+
+                <ImageView
+                    android:id="@+id/end_up_arrow"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_arrow_up"
+                    app:layout_constraintTop_toTopOf="@+id/end_choice_tv"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    android:layout_marginTop="8dp" />
+
+                <ImageView
+                    android:id="@+id/end_down_arrow"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_arrow_down"
+                    app:layout_constraintTop_toBottomOf="@+id/end_up_arrow"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    android:layout_marginTop="6dp"
+                    />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </LinearLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/next_btn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="다음으로"
+        style="@style/Md16"
+        android:textColor="#0F0F0F"
+        app:cornerRadius="8dp"
+        android:backgroundTint="#F6F6F6"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginStart="19dp"
+        android:layout_marginEnd="19dp"
+        android:layout_marginBottom="19dp"
+        android:enabled="false"
+        />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #22

## ✨ 작업 내용
> 수면 패턴 등록 화면 제작
> - 시간 선택 시 다음으로 버튼 활성화
> - 화살표 버튼 클릭 시 1시간씩 변경

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 시간 선택을 완료해야 다음으로 버튼이 활성화 되는지
- [x] 화살표 버튼을 눌렀을 때 시간이 늘어나고 줄어드는지

## 📸 스크린샷 (선택)
> 첫 화면
<img width="248" height="528" alt="image" src="https://github.com/user-attachments/assets/7312722c-0394-403d-b7e0-069b3033f204" />

> 시간 선택 화면
<img width="248" height="527" alt="image" src="https://github.com/user-attachments/assets/4c193aa8-12c1-421e-8749-74d9708a37bd" />

> 시간 선택 후
<img width="248" height="527" alt="image" src="https://github.com/user-attachments/assets/1522933a-7701-4a39-a233-9f5597cc07e1" />

> 시작 시간 화살표 버튼 클릭(위 화살표)
<img width="250" height="528" alt="image" src="https://github.com/user-attachments/assets/0b85163e-5d08-4a46-9875-69e7ac31b8a6" />

> 종료 시간까지 선택
<img width="251" height="530" alt="image" src="https://github.com/user-attachments/assets/6c2310e4-4f5f-4be9-b13f-69f6557e9dff" />


## 💬 기타 참고 사항
> 희원님이 이미 시간 선택할 때 타임피커(dialog_time_picker.xml) 만들어주셔서 재사용했습니다. 디자이너님 피드백 받은 부분 수정하면 해당 화면도 변경될겁니다!
