### PR TITLE
[FEAT/#78] 5.5.4 화면 구현

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendRoommateDateFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendRoommateDateFragment.kt
@@ -66,8 +66,12 @@ class FriendRoommateDateFragment : Fragment() {
         binding.nextBtn.setBackgroundColor(Color.parseColor("#F6F6F6"))
         binding.nextBtn.setTextColor(Color.parseColor("#0F0F0F"))
 
+        // 뒤로가기 버튼ㅇ
         binding.btnBack.setOnClickListener {
-            requireActivity().onBackPressedDispatcher.onBackPressed()
+            parentFragmentManager.beginTransaction()
+                .replace(R.id.main_frm, FriendFragment())
+                .addToBackStack(null)
+                .commit()
         }
 
         binding.nextBtn.setOnClickListener {

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendRoommateFriendFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendRoommateFriendFragment.kt
@@ -40,9 +40,21 @@ class FriendRoommateFriendFragment : Fragment() {
                 .commit()
         }
 
+        //나중에 수정 필요
+        binding.matchBtn.setOnClickListener {
+            parentFragmentManager.beginTransaction()
+                .replace(R.id.main_frm, FriendRoommateMatchingDetailFragment())
+                .addToBackStack(null)  // 뒤로가기 버튼으로 돌아올 수 있게
+                .commit()
+        }
+
+
         // 뒤로가기 버튼 처리
         binding.btnBack.setOnClickListener {
-            requireActivity().onBackPressedDispatcher.onBackPressed()
+            parentFragmentManager.beginTransaction()
+                .replace(R.id.main_frm, FriendRoommateDateFragment())
+                .addToBackStack(null)
+                .commit()
         }
 
         // TODO: 이곳에 추가 로직 구현

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendRoommateMatchingDetailFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendRoommateMatchingDetailFragment.kt
@@ -1,0 +1,247 @@
+package com.example.teumteum.ui.friend
+
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.NumberPicker
+import android.widget.TextView
+import androidx.core.widget.addTextChangedListener
+import androidx.fragment.app.Fragment
+import com.example.teumteum.R
+import com.example.teumteum.databinding.FragmentFriendRoommateMatchingDetailBinding
+import com.example.teumteum.ui.main.MainActivity
+import com.example.teumteum.ui.signup.SignUpActivity
+import com.google.android.material.bottomsheet.BottomSheetDialog
+
+class FriendRoommateMatchingDetailFragment : Fragment() {
+
+    private lateinit var binding: FragmentFriendRoommateMatchingDetailBinding
+
+    private var selectedStartTime: String? = null
+    private var selectedEndTime: String? = null
+    private var lastSelectedCardView: View? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = FragmentFriendRoommateMatchingDetailBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        (activity as? SignUpActivity)?.setProgressBar(75)
+        (activity as? MainActivity)?.hideBottomBar()
+
+        val fullText = "틈 요청 제목을 작성해주세요*"
+        val spannable = android.text.SpannableString(fullText)
+        val starIndex = fullText.indexOf("*")
+
+        if (starIndex != -1) {
+            spannable.setSpan(
+                android.text.style.ForegroundColorSpan(android.graphics.Color.parseColor("#7770FE")),
+                starIndex,
+                starIndex + 1,
+                android.text.Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+            binding.teumRequestTitle.text = spannable
+        }
+
+
+        binding.clearTitleBtn.setOnClickListener {
+            binding.editTextTitle.text.clear()
+        }
+
+        binding.clearDetailBtn.setOnClickListener {
+            binding.editTextDetail.text.clear()
+        }
+
+        binding.editTextTitle.addTextChangedListener {
+            updateNextButtonState()
+        }
+
+        binding.editTextDetail.addTextChangedListener {
+            updateNextButtonState()
+        }
+
+        binding.btnBack.setOnClickListener {
+            parentFragmentManager.beginTransaction()
+                .replace(R.id.main_frm, FriendRoommateFriendFragment())
+                .addToBackStack(null)
+                .commit()
+        }
+
+        setupTimePickers()
+
+        // 초기 버튼 상태 설정
+        binding.sendBtn.isEnabled = false
+        binding.sendBtn.setBackgroundColor(android.graphics.Color.parseColor("#F6F6F6"))
+
+    }
+
+    private fun setupTimePickers() {
+        val startTextViews = listOf(binding.startChoiceTv1, binding.startChoiceTv2, binding.startChoiceTv3)
+        val endTextViews = listOf(binding.endChoiceTv1, binding.endChoiceTv2, binding.endChoiceTv3)
+
+        val startContainers = listOf(binding.sleepStartContainer1, binding.sleepStartContainer2, binding.sleepStartContainer3)
+        val endContainers = listOf(binding.sleepEndContainer1, binding.sleepEndContainer2, binding.sleepEndContainer3)
+
+        val upArrows = listOf(binding.startUpArrow1, binding.startUpArrow2, binding.startUpArrow3, binding.endUpArrow1, binding.endUpArrow2, binding.endUpArrow3)
+        val downArrows = listOf(binding.startDownArrow1, binding.startDownArrow2, binding.startDownArrow3, binding.endDownArrow1, binding.endDownArrow2, binding.endDownArrow3)
+
+        startContainers.zip(startTextViews).forEach { (container, tv) ->
+            container.setOnClickListener { showCustomTimePicker(tv) }
+        }
+        endContainers.zip(endTextViews).forEach { (container, tv) ->
+            container.setOnClickListener { showCustomTimePicker(tv) }
+        }
+
+        upArrows.forEach { arrow ->
+            arrow.setOnClickListener {
+                val target = arrow.tag as? TextView
+                target?.let { increaseHour(it) }
+            }
+        }
+        downArrows.forEach { arrow ->
+            arrow.setOnClickListener {
+                val target = arrow.tag as? TextView
+                target?.let { decreaseHour(it) }
+            }
+        }
+
+        // 직접 연결 (tag 미사용 방식)
+        binding.startUpArrow1.setOnClickListener { increaseHour(binding.startChoiceTv1) }
+        binding.startDownArrow1.setOnClickListener { decreaseHour(binding.startChoiceTv1) }
+        binding.endUpArrow1.setOnClickListener { increaseHour(binding.endChoiceTv1) }
+        binding.endDownArrow1.setOnClickListener { decreaseHour(binding.endChoiceTv1) }
+
+        binding.startUpArrow2.setOnClickListener { increaseHour(binding.startChoiceTv2) }
+        binding.startDownArrow2.setOnClickListener { decreaseHour(binding.startChoiceTv2) }
+        binding.endUpArrow2.setOnClickListener { increaseHour(binding.endChoiceTv2) }
+        binding.endDownArrow2.setOnClickListener { decreaseHour(binding.endChoiceTv2) }
+
+        binding.startUpArrow3.setOnClickListener { increaseHour(binding.startChoiceTv3) }
+        binding.startDownArrow3.setOnClickListener { decreaseHour(binding.startChoiceTv3) }
+        binding.endUpArrow3.setOnClickListener { increaseHour(binding.endChoiceTv3) }
+        binding.endDownArrow3.setOnClickListener { decreaseHour(binding.endChoiceTv3) }
+    }
+
+    private fun showCustomTimePicker(targetTextView: TextView) {
+        val dialogView = layoutInflater.inflate(R.layout.dialog_time_picker, null, false)
+
+        val ampmPicker = dialogView.findViewById<NumberPicker>(R.id.ampmPicker01Np)
+        val hourPicker = dialogView.findViewById<NumberPicker>(R.id.hourPicker01Np)
+        val minutePicker = dialogView.findViewById<NumberPicker>(R.id.minutePicker01Np)
+
+        val minuteValues = arrayOf("00", "10", "20", "30", "40", "50")
+
+        ampmPicker.minValue = 0
+        ampmPicker.maxValue = 1
+        ampmPicker.displayedValues = arrayOf("AM", "PM")
+
+        hourPicker.minValue = 1
+        hourPicker.maxValue = 12
+        hourPicker.wrapSelectorWheel = true
+
+        minutePicker.minValue = 0
+        minutePicker.maxValue = minuteValues.size - 1
+        minutePicker.displayedValues = minuteValues
+        minutePicker.wrapSelectorWheel = true
+
+        val dialog = BottomSheetDialog(requireContext())
+        dialog.setContentView(dialogView)
+
+        dialog.setOnShowListener { dialogInterface ->
+            val bottomSheet = (dialogInterface as BottomSheetDialog)
+                .findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
+            bottomSheet?.setBackgroundResource(R.drawable.calendar_background)
+        }
+
+        dialogView.findViewById<Button>(R.id.btnCancel).setOnClickListener {
+            dialog.dismiss()
+        }
+
+        dialogView.findViewById<Button>(R.id.btnOk).setOnClickListener {
+            val isAm = ampmPicker.value == 0
+            var hour = hourPicker.value % 12
+            if (!isAm) hour += 12
+            if (hour == 0) hour = 0
+
+            val minute = minuteValues[minutePicker.value]
+            val timeText = String.format("%02d:%s", hour, minute)
+
+            targetTextView.text = timeText
+
+            val parentCard = targetTextView.parent?.parent as? ViewGroup
+            if (parentCard != null) {
+                lastSelectedCardView?.background = null
+                parentCard.setBackgroundResource(R.drawable.friend_time_card_bg_selected)
+                lastSelectedCardView = parentCard
+            }
+
+            updateNextButtonState()
+            dialog.dismiss()
+        }
+
+        dialog.show()
+    }
+
+    private fun increaseHour(targetTextView: TextView) {
+        val currentText = targetTextView.text.toString()
+        if (currentText.isNotBlank()) {
+            val parts = currentText.split(":")
+            if (parts.size == 2) {
+                var hour = parts[0].toIntOrNull() ?: return
+                val minute = parts[1]
+
+                hour = (hour + 1) % 24
+                val newTime = String.format("%02d:%s", hour, minute)
+                targetTextView.text = newTime
+                updateNextButtonState()
+            }
+        }
+    }
+
+    private fun decreaseHour(targetTextView: TextView) {
+        val currentText = targetTextView.text.toString()
+        if (currentText.isNotBlank()) {
+            val parts = currentText.split(":")
+            if (parts.size == 2) {
+                var hour = parts[0].toIntOrNull() ?: return
+                val minute = parts[1]
+
+                hour = if (hour == 0) 23 else hour - 1
+                val newTime = String.format("%02d:%s", hour, minute)
+                targetTextView.text = newTime
+                updateNextButtonState()
+            }
+        }
+    }
+
+    private fun updateNextButtonState() {
+        val isTimeSelected = listOf(
+            binding.startChoiceTv1, binding.endChoiceTv1,
+            binding.startChoiceTv2, binding.endChoiceTv2,
+            binding.startChoiceTv3, binding.endChoiceTv3
+        ).any { it.text.toString() != "선택" }
+
+        val isTitleFilled = binding.editTextTitle.text.toString().isNotBlank()
+
+        val isEnabled = isTimeSelected && isTitleFilled  //  상세 멘트 제거
+
+        binding.sendBtn.isEnabled = isEnabled
+        binding.sendBtn.setBackgroundColor(
+            if (isEnabled) android.graphics.Color.parseColor("#0F0F0F")
+            else android.graphics.Color.parseColor("#F6F6F6")
+        )
+        binding.sendBtn.setTextColor(
+            if (isEnabled) android.graphics.Color.parseColor("#FFFFFF")
+            else android.graphics.Color.parseColor("#0F0F0F")
+        )
+    }
+}

--- a/app/src/main/res/drawable/bg_edittext_gray.xml
+++ b/app/src/main/res/drawable/bg_edittext_gray.xml
@@ -1,0 +1,6 @@
+<!-- res/drawable/bg_edittext_gray.xml -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#F6F6F6" />
+    <corners android:radius="10dp" />
+</shape>

--- a/app/src/main/res/drawable/delet_btn.xml
+++ b/app/src/main/res/drawable/delet_btn.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="17dp"
+    android:height="18dp"
+    android:viewportWidth="17"
+    android:viewportHeight="18">
+  <path
+      android:pathData="M8.5,0.5L8.5,0.5A8.5,8.5 0,0 1,17 9L17,9A8.5,8.5 0,0 1,8.5 17.5L8.5,17.5A8.5,8.5 0,0 1,0 9L0,9A8.5,8.5 0,0 1,8.5 0.5z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M9.067,9.021L11.803,11.671L11.123,12.373L8.387,9.723L5.89,12.301L5.188,11.621L7.685,9.043L5.109,6.547L5.789,5.845L8.365,8.341L11.014,5.607L11.716,6.287L9.067,9.021Z"
+      android:fillColor="#B1B2B3"/>
+</vector>

--- a/app/src/main/res/layout/fragment_friend_roommate_matching_detail.xml
+++ b/app/src/main/res/layout/fragment_friend_roommate_matching_detail.xml
@@ -1,0 +1,554 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#FFFFFF"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <!-- 뒤로가기 버튼 -->
+    <ImageButton
+        android:id="@+id/btnBack"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="70dp"
+        android:layout_marginStart="16dp"
+        android:src="@drawable/ic_arrow_back"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="뒤로가기"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <TextView
+        android:id="@+id/textView2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="19.5dp"
+        android:fontFamily="@font/noto_sans_kr_medium"
+        android:includeFontPadding="false"
+        android:text="함께 할 틈을 선택해주세요"
+        android:textColor="#0F0F0F"
+        android:textSize="20dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/btnBack" />
+
+    <TextView
+        android:id="@+id/textView3"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="4dp"
+        android:fontFamily="@font/noto_sans_kr_regular"
+        android:includeFontPadding="false"
+        android:text="하나만 선택 가능해요"
+        android:textColor="#0F0F0F"
+        android:textSize="14dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView2" />
+
+    <LinearLayout
+        android:id="@+id/linearLayout1"
+        android:layout_width="match_parent"
+        android:layout_height="76dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginEnd="16dp"
+        android:background="@drawable/rounded_sleep_pattern"
+        android:orientation="horizontal"
+        android:paddingStart="14dp"
+        android:paddingTop="14dp"
+        android:paddingEnd="16dp"
+        android:paddingBottom="9dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView3">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/sleep_start_container1"
+            android:layout_width="0dp"
+            android:layout_height="53dp"
+            android:layout_marginEnd="31dp"
+            android:layout_weight="1">
+
+            <TextView
+                android:id="@+id/start_tv1"
+                style="@style/Sm12Regular"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:includeFontPadding="false"
+                android:text="시작"
+                android:textColor="@color/text_secondary"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/start_choice_tv1"
+                style="@style/Md15Medium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:includeFontPadding="false"
+                android:text="선택"
+                android:textColor="@color/text_primary"
+                android:textSize="22sp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/start_tv1" />
+
+            <ImageView
+                android:id="@+id/start_up_arrow1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:src="@drawable/ic_arrow_up"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/start_choice_tv1" />
+
+
+            <ImageView
+                android:id="@+id/start_down_arrow1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:src="@drawable/ic_arrow_down"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/start_up_arrow1" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/sleep_end_container1"
+            android:layout_width="0dp"
+            android:layout_height="53dp"
+            android:layout_weight="1">
+
+            <TextView
+                android:id="@+id/end_tv1"
+                style="@style/Sm12Regular"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:includeFontPadding="false"
+                android:text="종료"
+                android:textColor="@color/text_secondary"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/end_choice_tv1"
+                style="@style/Md15Medium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:includeFontPadding="false"
+                android:text="선택"
+                android:textColor="@color/text_primary"
+                android:textSize="22sp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/end_tv1" />
+
+            <ImageView
+                android:id="@+id/end_up_arrow1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:src="@drawable/ic_arrow_up"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/end_choice_tv1" />
+
+            <ImageView
+                android:id="@+id/end_down_arrow1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:src="@drawable/ic_arrow_down"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/end_up_arrow1" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/linearLayout3"
+        android:layout_width="match_parent"
+        android:layout_height="76dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginTop="14dp"
+        android:background="@drawable/rounded_sleep_pattern"
+        android:orientation="horizontal"
+        android:paddingStart="14dp"
+        android:paddingTop="14dp"
+        android:paddingEnd="16dp"
+        android:paddingBottom="9dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/linearLayout2">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/sleep_start_container3"
+            android:layout_width="0dp"
+            android:layout_height="53dp"
+            android:layout_marginEnd="31dp"
+            android:layout_weight="1">
+
+            <TextView
+                android:id="@+id/start_tv3"
+                style="@style/Sm12Regular"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:includeFontPadding="false"
+                android:text="시작"
+                android:textColor="@color/text_secondary"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/start_choice_tv3"
+                style="@style/Md15Medium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:includeFontPadding="false"
+                android:text="선택"
+                android:textColor="@color/text_primary"
+                android:textSize="22sp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/start_tv3" />
+
+            <ImageView
+                android:id="@+id/start_up_arrow3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:src="@drawable/ic_arrow_up"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/start_choice_tv3" />
+
+
+            <ImageView
+                android:id="@+id/start_down_arrow3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:src="@drawable/ic_arrow_down"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/start_up_arrow3" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/sleep_end_container3"
+            android:layout_width="0dp"
+            android:layout_height="53dp"
+            android:layout_weight="1">
+
+            <TextView
+                android:id="@+id/end_tv3"
+                style="@style/Sm12Regular"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:includeFontPadding="false"
+                android:text="종료"
+                android:textColor="@color/text_secondary"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/end_choice_tv3"
+                style="@style/Md15Medium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:includeFontPadding="false"
+                android:text="선택"
+                android:textColor="@color/text_primary"
+                android:textSize="22sp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/end_tv3" />
+
+            <ImageView
+                android:id="@+id/end_up_arrow3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:src="@drawable/ic_arrow_up"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/end_choice_tv3" />
+
+            <ImageView
+                android:id="@+id/end_down_arrow3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:src="@drawable/ic_arrow_down"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/end_up_arrow3" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/linearLayout2"
+        android:layout_width="match_parent"
+        android:layout_height="76dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginTop="14dp"
+        android:background="@drawable/rounded_sleep_pattern"
+        android:orientation="horizontal"
+        android:paddingStart="14dp"
+        android:paddingTop="14dp"
+        android:paddingEnd="16dp"
+        android:paddingBottom="9dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/linearLayout1">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/sleep_start_container2"
+            android:layout_width="0dp"
+            android:layout_height="53dp"
+            android:layout_marginEnd="31dp"
+            android:layout_weight="1">
+
+            <TextView
+                android:id="@+id/start_tv2"
+                style="@style/Sm12Regular"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:includeFontPadding="false"
+                android:text="시작"
+                android:textColor="@color/text_secondary"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/start_choice_tv2"
+                style="@style/Md15Medium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:includeFontPadding="false"
+                android:text="선택"
+                android:textColor="@color/text_primary"
+                android:textSize="22sp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/start_tv2" />
+
+            <ImageView
+                android:id="@+id/start_up_arrow2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:src="@drawable/ic_arrow_up"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/start_choice_tv2" />
+
+
+            <ImageView
+                android:id="@+id/start_down_arrow2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:src="@drawable/ic_arrow_down"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/start_up_arrow2" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/sleep_end_container2"
+            android:layout_width="0dp"
+            android:layout_height="53dp"
+            android:layout_weight="1">
+
+            <TextView
+                android:id="@+id/end_tv2"
+                style="@style/Sm12Regular"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:includeFontPadding="false"
+                android:text="종료"
+                android:textColor="@color/text_secondary"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/end_choice_tv2"
+                style="@style/Md15Medium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:includeFontPadding="false"
+                android:text="선택"
+                android:textColor="@color/text_primary"
+                android:textSize="22sp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/end_tv2" />
+
+            <ImageView
+                android:id="@+id/end_up_arrow2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:src="@drawable/ic_arrow_up"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/end_choice_tv2" />
+
+            <ImageView
+                android:id="@+id/end_down_arrow2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:src="@drawable/ic_arrow_down"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/end_up_arrow2" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/teum_request_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="39dp"
+        android:layout_marginStart="16dp"
+        android:fontFamily="@font/noto_sans_kr_medium"
+        android:includeFontPadding="false"
+        android:text="틈 요청 제목을 작성해주세요*"
+        android:textColor="#0F0F0F"
+        android:textSize="20dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/linearLayout3" />
+
+    <!-- 제목 입력 필드 (EditText + X 버튼 포함) -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/editTitleContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        app:layout_constraintTop_toBottomOf="@id/teum_request_title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <EditText
+            android:id="@+id/editTextTitle"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:hint="친구에게 보낼 요청 제목을 작성해주세요. (최대 10자)"
+            android:maxLength="10"
+            android:background="@drawable/bg_edittext_gray"
+            android:padding="10dp"
+            android:textColor="#0F0F0F"
+            android:textColorHint="#B1B2B3"
+            android:textSize="12sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <ImageButton
+            android:id="@+id/clearTitleBtn"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:background="@android:color/transparent"
+            android:layout_marginEnd="15.5dp"
+            android:src="@drawable/delet_btn"
+            android:contentDescription="입력 삭제"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/editTextTitle"
+            app:layout_constraintBottom_toBottomOf="@id/editTextTitle" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <!-- 상세 멘트 제목 TextView -->
+    <TextView
+        android:id="@+id/textViewDetailMent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="39dp"
+        android:fontFamily="@font/noto_sans_kr_medium"
+        android:includeFontPadding="false"
+        android:text="자세한 멘트를 작성할까요?"
+        android:textColor="#0F0F0F"
+        android:textSize="20sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/editTitleContainer" />
+
+    <!-- 상세 멘트 서브텍스트 -->
+    <TextView
+        android:id="@+id/textViewSubDetail"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:layout_marginStart="16dp"
+        android:text="작성하지 않으면 기본 멘트로 전송돼요"
+        android:textSize="14sp"
+        android:fontFamily="@font/noto_sans_kr_regular"
+        android:includeFontPadding="false"
+        android:textColor="#0F0F0F"
+        app:layout_constraintTop_toBottomOf="@id/textViewDetailMent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <!-- 상세 멘트 입력 필드 (EditText + X 버튼 포함) -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/editDetailContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        app:layout_constraintTop_toBottomOf="@id/textViewSubDetail"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <EditText
+            android:id="@+id/editTextDetail"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:background="@drawable/bg_edittext_gray"
+            android:hint="같이 빈틈을 채워봐요. (최대 40자)"
+            android:maxLength="40"
+            android:padding="10dp"
+            android:textColor="#0F0F0F"
+            android:textColorHint="#B1B2B3"
+            android:textSize="12sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageButton
+            android:id="@+id/clearDetailBtn"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:background="@android:color/transparent"
+            android:layout_marginEnd="15.5dp"
+            android:src="@drawable/delet_btn"
+            android:contentDescription="입력 삭제"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/editTextDetail"
+            app:layout_constraintBottom_toBottomOf="@id/editTextDetail" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/send_btn"
+        style="@style/Md16"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="19dp"
+        android:layout_marginEnd="19dp"
+        android:layout_marginBottom="19dp"
+        android:layout_marginTop="115dp"
+        android:backgroundTint="#F6F6F6"
+        android:enabled="false"
+        android:text="전송할게요"
+        android:textColor="#0F0F0F"
+        app:cornerRadius="12dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/editDetailContainer" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #78

## ✨ 작업 내용
> 
<img width="1128" height="562" alt="image" src="https://github.com/user-attachments/assets/fcd86305-08f5-47aa-890b-fd2a0d79a285" />


## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 빈틈을 매칭해요 버튼을 누르면 함께 할 틈을 선택해주세요 화면으로 넘어가는지 확인해주세요 (원래는 빈틈을 매칭해요 버튼을 누르면 넘어가는게 아닌데 아직 그 전 화면을 만들지 못해서 우선 이렇게 했습니다)
- [x] 타임피커 선택 시 시간이 잘 띄고 테두리가 보라색으로 바뀌는지 확인해주세요 
- [x] 타임피커, 틈 요청 제목 다 입력 시 밑에 버튼이 검정색으로 바뀌는지 확인해주세요
- [x] editText 부분에 삭제 버튼 누르면 글이 삭제되는지 확인해주세요 

## 📸 스크린샷 (선택)
> 
<img width="409" height="859" alt="image" src="https://github.com/user-attachments/assets/18c63981-74dd-4bd5-84fe-480af41c803d" />

<img width="427" height="861" alt="image" src="https://github.com/user-attachments/assets/7f644006-b903-44da-bd84-5ae3fd37e555" />


## 💬 기타 참고 사항
> 빈틈을 매칭해요 버튼을 누르면 원래 이 화면으로 넘어가는게 아니고 아직 그 전 화면을 구현 못해서 임의로 이렇게 했습니다..
