### PR TITLE
[Feat/#87] 약관동의 API 연동

### DIFF
--- a/app/src/main/java/com/example/teumteum/data/remote/agreement/AgreementRetrofitInterface.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/agreement/AgreementRetrofitInterface.kt
@@ -1,0 +1,13 @@
+package com.example.teumteum.data.remote.agreement
+
+import com.example.teumteum.data.remote.agreement.dto.AgreementRequest
+import com.example.teumteum.data.remote.agreement.dto.AgreementResponse
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface AgreementRetrofitInterface {
+    @POST("/api/users/onboarding/agreement")
+    fun postAgreements(@Body request: AgreementRequest): Call<AgreementResponse>
+
+}

--- a/app/src/main/java/com/example/teumteum/data/remote/agreement/AgreementRetrofitInterface.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/agreement/AgreementRetrofitInterface.kt
@@ -7,7 +7,7 @@ import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface AgreementRetrofitInterface {
-    @POST("/api/users/onboarding/agreement")
+    @POST("/api/users/onboarding/agreements")
     fun postAgreements(@Body request: AgreementRequest): Call<AgreementResponse>
 
 }

--- a/app/src/main/java/com/example/teumteum/data/remote/agreement/AgreementService.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/agreement/AgreementService.kt
@@ -1,0 +1,46 @@
+package com.example.teumteum.data.remote.agreement
+
+import android.util.Log
+import com.example.teumteum.data.remote.agreement.dto.AgreementRequest
+import com.example.teumteum.data.remote.agreement.dto.AgreementResponse
+import com.example.teumteum.ui.signup.view.AgreementView
+import com.example.teumteum.utils.getRetrofitWithToken
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+class AgreementService {
+
+    private lateinit var agreementView: AgreementView
+
+    fun setAgreementView(agreementView: AgreementView) {
+        this.agreementView = agreementView
+    }
+
+    fun postAgreements(request: AgreementRequest) {
+        val agreementApi = getRetrofitWithToken().create(AgreementRetrofitInterface::class.java)
+        val call = agreementApi.postAgreements(request)
+
+        call.enqueue(object : Callback<AgreementResponse> {
+            override fun onResponse(
+                call: Call<AgreementResponse>,
+                response: Response<AgreementResponse>
+            ) {
+                if (response.isSuccessful) {
+                    val body = response.body()
+                    if (body != null && body.code == "ONBOARDING2001") {
+                        agreementView.onAgreementSuccess(body.code)
+                    } else {
+                        agreementView.onAgreementFailure(body?.code ?: "UNKNOWN", body?.message)
+                    }
+                } else {
+                    agreementView.onAgreementFailure("HTTP_${response.code()}", response.errorBody()?.string())
+                }
+            }
+
+            override fun onFailure(call: Call<AgreementResponse>, t: Throwable) {
+                agreementView.onAgreementFailure("NETWORK_ERROR", t.localizedMessage)
+            }
+        })
+    }
+}

--- a/app/src/main/java/com/example/teumteum/data/remote/agreement/dto/AgreementRequest.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/agreement/dto/AgreementRequest.kt
@@ -1,0 +1,10 @@
+package com.example.teumteum.data.remote.agreement.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class AgreementRequest(
+    @SerializedName("tosConsent") val tosConsent: Boolean,
+    @SerializedName("privacyConsent") val privacyConsent: Boolean,
+    @SerializedName("thirdPartyConsent") val thirdPartyConsent: Boolean,
+    @SerializedName("marketingConsent") val marketingConsent: Boolean
+)

--- a/app/src/main/java/com/example/teumteum/data/remote/agreement/dto/AgreementResponse.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/agreement/dto/AgreementResponse.kt
@@ -1,0 +1,9 @@
+package com.example.teumteum.data.remote.agreement.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class AgreementResponse(
+    @SerializedName("isSuccess") val isSuccess: Boolean,
+    @SerializedName("code") val code: String,
+    @SerializedName("message") val message: String
+)

--- a/app/src/main/java/com/example/teumteum/ui/signup/AgreementFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/AgreementFragment.kt
@@ -38,10 +38,12 @@ class AgreementFragment : Fragment(), AgreementView {
         Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
         Log.e("AGREEMENT_FRAGMENT", msg)
 
-        parentFragmentManager.beginTransaction()
-            .replace(R.id.fragment_container, CompleteFragment())
-            .addToBackStack(null)
-            .commit()
+        if(code.equals("ONBOARDING4001")) {
+            parentFragmentManager.beginTransaction()
+                .replace(R.id.fragment_container, CompleteFragment())
+                .addToBackStack(null)
+                .commit()
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/example/teumteum/ui/signup/AgreementFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/AgreementFragment.kt
@@ -38,7 +38,8 @@ class AgreementFragment : Fragment(), AgreementView {
         Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
         Log.e("AGREEMENT_FRAGMENT", msg)
 
-        if(code.equals("ONBOARDING4001")) {
+        //서버 로직 예외
+        if (message?.contains("ONBOARDING4001") == true) {
             parentFragmentManager.beginTransaction()
                 .replace(R.id.fragment_container, CompleteFragment())
                 .addToBackStack(null)

--- a/app/src/main/java/com/example/teumteum/ui/signup/AgreementFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/AgreementFragment.kt
@@ -3,18 +3,46 @@ package com.example.teumteum.ui.signup
 import android.content.res.ColorStateList
 import android.graphics.Color
 import android.os.Bundle
+import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.CompoundButton
+import android.widget.Toast
 import androidx.core.content.ContextCompat
 import com.example.teumteum.R
+import com.example.teumteum.data.remote.agreement.AgreementService
+import com.example.teumteum.data.remote.agreement.dto.AgreementRequest
+import com.example.teumteum.data.remote.todo.TodoService
 import com.example.teumteum.databinding.FragmentAgreementBinding
+import com.example.teumteum.ui.signup.view.AgreementView
 
-class AgreementFragment : Fragment() {
+class AgreementFragment : Fragment(), AgreementView {
 
     private lateinit var binding: FragmentAgreementBinding
+
+    override fun onAgreementSuccess(code: String) {
+        val msg = "약관 동의 성공 (code: $code)"
+        Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
+        Log.d("AGREEMENT_FRAGMENT", msg)
+
+        parentFragmentManager.beginTransaction()
+            .replace(R.id.fragment_container, CompleteFragment())
+            .addToBackStack(null)
+            .commit()
+    }
+
+    override fun onAgreementFailure(code: String, message: String?) {
+        val msg = "약관 동의 실패 (code: $code, message: ${message ?: "없음"})"
+        Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
+        Log.e("AGREEMENT_FRAGMENT", msg)
+
+        parentFragmentManager.beginTransaction()
+            .replace(R.id.fragment_container, CompleteFragment())
+            .addToBackStack(null)
+            .commit()
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -39,10 +67,10 @@ class AgreementFragment : Fragment() {
         setupSelectAllCheckbox()
 
         binding.nextBtn.setOnClickListener {
-            parentFragmentManager.beginTransaction()
-                .replace(R.id.fragment_container, CompleteFragment())
-                .addToBackStack(null)
-                .commit()
+            val request = getAgreementRequest()
+            val agreementService = AgreementService()
+            agreementService.setAgreementView(this)
+            agreementService.postAgreements(request)
         }
 
         //체크박스 초기 색상
@@ -151,5 +179,14 @@ class AgreementFragment : Fragment() {
             .replace(R.id.fragment_container, fragment)
             .addToBackStack(null)
             .commit()
+    }
+
+    private fun getAgreementRequest(): AgreementRequest{
+        return AgreementRequest(
+            tosConsent = binding.term1Checkbox.isChecked,
+            privacyConsent = binding.term2Checkbox.isChecked,
+            thirdPartyConsent = binding.term3Checkbox.isChecked,
+            marketingConsent = binding.term4Checkbox.isChecked
+        )
     }
 }

--- a/app/src/main/java/com/example/teumteum/ui/signup/view/AgreementView.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/view/AgreementView.kt
@@ -1,0 +1,6 @@
+package com.example.teumteum.ui.signup.view
+
+interface AgreementView {
+    fun onAgreementSuccess(code: String)
+    fun onAgreementFailure(code: String, message: String?)
+}

--- a/app/src/main/java/com/example/teumteum/utils/NetworkModule.kt
+++ b/app/src/main/java/com/example/teumteum/utils/NetworkModule.kt
@@ -1,6 +1,6 @@
 package com.example.teumteum.utils
 
-import com.example.teumteum.utils.TEMP_ACCESS_TOKEN
+import com.example.teumteum.TEMP_ACCESS_TOKEN
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #87

## ✨ 작업 내용
> 약관동의 API연결
> 현재 서버로직이 한 계정당 약관동의가 1번밖에 안됩니다.(한 번 성공하면 유저의 단계가 ONBOARDING으로 변경되고 ONBOARDING 상태의 유저가 약관동의 API를 호출하면 실패가 됨.)
> 그래서 실패해도 서버의 메세지가 ONBOARDING4001이면 다음 화면으로 넘어가도록 구현하였습니다.

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 약관동의화면에서 다음으로 버튼 클릭 시 API호출이 잘 되는지(성공하면 로그 캡처해주시면 감사하겠습니다.)

## 📸 스크린샷 (선택)
> 약관동의 후 다음으로 버튼 클릭 시 로그
> - 저는 스웨거에서 테스트했을 때 제 계정이 이미 약관동의가 완료되어서 실패뜨는게 맞습니다.
> - 다른 분들도 첫번째 테스트에서만 성공하고 두번째부터는 실패로 처리될겁니다.
<img width="791" height="21" alt="image" src="https://github.com/user-attachments/assets/d8118259-c73d-4065-abdf-548a2273a2e0" />


## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항
