### PR TITLE
[Refactor/#85] 빈틈채우기 시간표 ui 작업

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/filling/FillingSetting01Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/filling/FillingSetting01Fragment.kt
@@ -7,7 +7,11 @@ import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import com.example.teumteum.R
+import com.example.teumteum.data.TimeBlock
+import com.example.teumteum.data.TimeType
 import com.example.teumteum.databinding.FragmentFillingSetting01Binding
+import com.example.teumteum.ui.clock.ChartUtils
+import com.example.teumteum.ui.clock.IconPieChartRenderer
 import com.google.android.material.bottomnavigation.BottomNavigationView
 
 class FillingSetting01Fragment : Fragment() {
@@ -19,6 +23,19 @@ class FillingSetting01Fragment : Fragment() {
     private var selectedTimeText: String? = null
     private var selectedStartTime: String? = null
     private var selectedEndTime: String? = null
+
+    private val fullDaySchedule = listOf(
+        TimeBlock(0, 360, TimeType.SLEEP),   // 00:00 ~ 06:00
+        TimeBlock(360, 580, TimeType.TODO),  // 06:00 ~ 09:40
+        TimeBlock(720, 860, TimeType.TODO),  // 12:00 ~ 14:20
+        TimeBlock(870, 930, TimeType.EMPTY), // 14:30 ~ 15:30
+        TimeBlock(930, 1050, TimeType.TODO), // 15:30 ~ 17:30
+        TimeBlock(1110, 1200, TimeType.TODO),// 18:30 ~ 20:00
+        TimeBlock(1200, 1320, TimeType.EMPTY),// 20:00 ~ 22:00
+        TimeBlock(1320, 1440, TimeType.SLEEP)// 22:00 ~ 24:00
+    )
+
+    private var isAM: Boolean = true
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -162,6 +179,26 @@ class FillingSetting01Fragment : Fragment() {
         binding.backArrowIv.setOnClickListener {
             parentFragmentManager.popBackStack()
         }
+
+        ChartUtils.setupPieChart(binding.clockChart)
+
+        val sleepBitmap = ChartUtils.getBitmapFromVector(requireContext(), R.drawable.ic_sleep_sv)
+
+        binding.clockChart.renderer = IconPieChartRenderer(
+            binding.clockChart,
+            binding.clockChart.animator,
+            binding.clockChart.viewPortHandler,
+            sleepBitmap
+        )
+
+        updateTimeChart(isAM)
+        updateIndicator(isAM)
+
+        binding.amPmTv.setOnClickListener {
+            isAM = !isAM
+            updateTimeChart(isAM)
+            updateIndicator(isAM)
+        }
     }
 
     private fun enableNextButton() {
@@ -176,5 +213,46 @@ class FillingSetting01Fragment : Fragment() {
 
     private fun setTime(time: String){
         binding.fillingActivityTimeTv.text = time
+    }
+
+    private fun updateTimeChart(isAM: Boolean) {
+        val halfDayBlocks = ChartUtils.splitAndFillTimeBlocks(fullDaySchedule, isAM)
+        ChartUtils.setTimePieChartData(requireContext(), binding.clockChart, halfDayBlocks)
+    }
+
+    private fun updateIndicator(isAM: Boolean) {
+        val leftView = binding.leftView
+        val rightView = binding.rightView
+
+        if (isAM) {
+            //왼쪽이 막대, 오른쪽이 점
+            leftView.layoutParams.width = dpToPx(28)
+            leftView.layoutParams.height = dpToPx(4)
+            leftView.background = ContextCompat.getDrawable(requireContext(), R.drawable.clock_indicator_bar_purple)
+
+            rightView.layoutParams.width = dpToPx(4)
+            rightView.layoutParams.height = dpToPx(4)
+            rightView.background = ContextCompat.getDrawable(requireContext(), R.drawable.clock_indicator_dot)
+
+            binding.amPmTv.text="AM"
+        } else {
+            //왼쪽이 점, 오른쪽이 막대
+            leftView.layoutParams.width = dpToPx(4)
+            leftView.layoutParams.height = dpToPx(4)
+            leftView.background = ContextCompat.getDrawable(requireContext(), R.drawable.clock_indicator_dot)
+
+            rightView.layoutParams.width = dpToPx(28)
+            rightView.layoutParams.height = dpToPx(4)
+            rightView.background = ContextCompat.getDrawable(requireContext(), R.drawable.clock_indicator_bar_purple)
+
+            binding.amPmTv.text="PM"
+        }
+
+        leftView.requestLayout()
+        rightView.requestLayout()
+    }
+
+    private fun dpToPx(dp: Int): Int {
+        return (dp * resources.displayMetrics.density).toInt()
     }
 }

--- a/app/src/main/java/com/example/teumteum/ui/todo/TodoRegisterFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/TodoRegisterFragment.kt
@@ -83,6 +83,12 @@ class TodoRegisterFragment : BottomSheetDialogFragment(), IDateClickListener, Re
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        val today = getTodayFormatted()
+
+        // 시작/종료 날짜를 오늘 날짜로 초기화
+        binding.startDateTv.text = today
+        binding.endDateTv.text = today
+
         selectedItems.forEach { label -> addAlarmItem(label) }
 
         setupPickers()
@@ -467,6 +473,11 @@ class TodoRegisterFragment : BottomSheetDialogFragment(), IDateClickListener, Re
         return alarms
     }
 
+    private fun getTodayFormatted(): String {
+        val today = LocalDate.now()
+        val formatter = DateTimeFormatter.ofPattern("M월 d일 (E)", Locale.KOREAN)
+        return today.format(formatter)
+    }
 
     private fun getTodoRequest(): RegisterTodoRequest {
         val title = binding.todoTitleEt.text.toString()
@@ -491,18 +502,11 @@ class TodoRegisterFragment : BottomSheetDialogFragment(), IDateClickListener, Re
 
     private fun register() {
         val title = binding.todoTitleEt.text.toString()
-        val startDateText = binding.startDateTv.text.toString()
-        val endDateText = binding.endDateTv.text.toString()
         val startTimeText = binding.startTimeTv.text.toString()
         val endTimeText = binding.endTimeTv.text.toString()
 
         if (title.isEmpty()) {
             Toast.makeText(requireContext(), "제목을 입력해주세요.", Toast.LENGTH_SHORT).show()
-            return
-        }
-
-        if (startDateText == "시작 날짜" || endDateText == "종료 날짜") {
-            Toast.makeText(requireContext(), "시작/종료 날짜를 설정해주세요.", Toast.LENGTH_SHORT).show()
             return
         }
 

--- a/app/src/main/java/com/example/teumteum/utils/NetworkModule.kt
+++ b/app/src/main/java/com/example/teumteum/utils/NetworkModule.kt
@@ -1,6 +1,6 @@
 package com.example.teumteum.utils
 
-import com.example.teumteum.utils.TEMP_ACCESS_TOKEN
+import com.example.teumteum.TEMP_ACCESS_TOKEN
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory

--- a/app/src/main/res/layout/dialog_time_picker.xml
+++ b/app/src/main/res/layout/dialog_time_picker.xml
@@ -81,14 +81,14 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <!-- 확인 버튼 -->
+    <!-- 완료 버튼 -->
     <Button
         android:id="@+id/btnOk"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="-30dp"
         android:layout_marginStart="0dp"
-        android:text="확인"
+        android:text="완료"
         android:textSize="16dp"
         android:textColor="#0F0F0F"
         android:fontFamily="@font/noto_sans_kr_medium"

--- a/app/src/main/res/layout/dialog_time_picker.xml
+++ b/app/src/main/res/layout/dialog_time_picker.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="#FFFFFF"
-    android:minHeight="270dp"
-    android:padding="16dp">
+    android:minHeight="270dp">
 
     <!-- 버튼 영역 (위쪽) -->
     <LinearLayout
@@ -30,13 +28,20 @@
         app:layout_constraintTop_toBottomOf="@id/buttonContainer"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginTop="24dp">
+        android:layout_marginTop="50dp">
 
         <!-- AM/PM -->
         <NumberPicker
             android:id="@+id/ampmPicker01Np"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
+            android:layout_width="80dp"
+            android:layout_height="200dp"/>
+
+        <!-- Hour -->
+        <NumberPicker
+            android:id="@+id/hourPicker01Np"
+            android:layout_width="80dp"
+            android:layout_height="200dp"
+            android:layout_marginStart="20dp"/>
 
         <!-- : 기호 -->
         <TextView
@@ -48,20 +53,13 @@
             android:textColor="#0F0F0F"
             android:layout_marginStart="8dp"
             android:layout_marginEnd="8dp"
-            android:gravity="center_vertical" />
-
-        <!-- Hour -->
-        <NumberPicker
-            android:id="@+id/hourPicker01Np"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
+            android:gravity="center_vertical"/>
 
         <!-- Minute -->
         <NumberPicker
             android:id="@+id/minutePicker01Np"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="12dp" />
+            android:layout_width="80dp"
+            android:layout_height="200dp"/>
     </LinearLayout>
 
     <!-- 취소 버튼 -->
@@ -69,15 +67,14 @@
         android:id="@+id/btnCancel"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="-30dp"
-        android:layout_marginStart="0dp"
+        android:layout_marginTop="15dp"
+        android:includeFontPadding="false"
         android:text="취소"
-        android:textSize="16dp"
-        android:textColor="#0F0F0F"
+        android:textSize="16sp"
+        android:textColor="@color/text_primary"
         android:fontFamily="@font/noto_sans_kr_medium"
         android:backgroundTint="@android:color/transparent"
         android:background="@null"
-        app:layout_constraintBottom_toTopOf="@+id/pickerContainer"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -86,15 +83,14 @@
         android:id="@+id/btnOk"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="-30dp"
-        android:layout_marginStart="0dp"
+        android:layout_marginTop="15dp"
+        android:includeFontPadding="false"
         android:text="완료"
-        android:textSize="16dp"
-        android:textColor="#0F0F0F"
+        android:textSize="16sp"
+        android:textColor="@color/text_primary"
         android:fontFamily="@font/noto_sans_kr_medium"
         android:backgroundTint="@android:color/transparent"
         android:background="@null"
-        app:layout_constraintBottom_toTopOf="@+id/pickerContainer"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/layout/fragment_filling_setting_01.xml
+++ b/app/src/main/res/layout/fragment_filling_setting_01.xml
@@ -185,14 +185,14 @@
         android:id="@+id/time_01_cv"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="320dp"
+        android:layout_marginTop="40dp"
         android:layout_marginStart="19dp"
         android:layout_marginEnd="19dp"
         app:cardElevation="0dp"
         app:cardCornerRadius="10dp"
         android:layout_marginHorizontal="10dp"
         android:backgroundTint="@color/teumteum_bg"
-        app:layout_constraintTop_toBottomOf="@id/filling_activity_cv"
+        app:layout_constraintTop_toBottomOf="@id/am_pm_tv"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
 

--- a/app/src/main/res/layout/fragment_filling_setting_01.xml
+++ b/app/src/main/res/layout/fragment_filling_setting_01.xml
@@ -98,6 +98,89 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.cardview.widget.CardView>
 
+    <ImageView
+        android:id="@+id/clock_background_iv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/clock_mini_sv"
+        app:layout_constraintTop_toBottomOf="@id/filling_activity_cv"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="12dp"
+        android:layout_marginStart="55dp"
+        android:layout_marginEnd="55dp"
+        />
+
+    <com.github.mikephil.charting.charts.PieChart
+        android:id="@+id/clock_chart"
+        android:layout_width="179.49dp"
+        android:layout_height="179.49dp"
+        app:layout_constraintTop_toTopOf="@id/clock_background_iv"
+        app:layout_constraintStart_toStartOf="@id/clock_background_iv"
+        app:layout_constraintEnd_toEndOf="@id/clock_background_iv"
+        app:layout_constraintBottom_toBottomOf="@id/clock_background_iv"
+        android:background="@color/transparent"
+        />
+
+    <ImageView
+        android:id="@+id/clock_center_iv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="@id/clock_background_iv"
+        app:layout_constraintStart_toStartOf="@id/clock_background_iv"
+        app:layout_constraintEnd_toEndOf="@id/clock_background_iv"
+        app:layout_constraintBottom_toBottomOf="@id/clock_background_iv"
+        android:src="@drawable/clock_mini_center_sv"
+        android:background="@color/transparent"
+        />
+
+    <LinearLayout
+        android:id="@+id/clock_indicator_ll"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:background="@android:color/transparent"
+        app:layout_constraintTop_toBottomOf="@id/clock_background_iv"
+        app:layout_constraintStart_toStartOf="@id/clock_background_iv"
+        app:layout_constraintEnd_toEndOf="@id/clock_background_iv"
+        android:layout_marginTop="13dp"
+        >
+
+        <!-- 왼쪽 -->
+        <View
+            android:id="@+id/leftView"
+            android:layout_width="28dp"
+            android:layout_height="4dp"
+            android:background="@drawable/clock_indicator_bar"/>
+
+        <Space
+            android:layout_width="4dp"
+            android:layout_height="wrap_content"/>
+
+        <!-- 오른쪽 -->
+        <View
+            android:id="@+id/rightView"
+            android:layout_width="4dp"
+            android:layout_height="4dp"
+            android:background="@drawable/clock_indicator_dot"/>
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/am_pm_tv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="AM"
+        android:fontFamily="@font/noto_sans_kr_medium"
+        android:textSize="15sp"
+        android:textColor="@color/main_2"
+        android:includeFontPadding="false"
+        app:layout_constraintStart_toEndOf="@id/clock_background_iv"
+        app:layout_constraintBottom_toBottomOf="@id/clock_indicator_ll"
+        android:layout_marginStart="16dp"
+        />
+
     <androidx.cardview.widget.CardView
         android:id="@+id/time_01_cv"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_filling_setting_02.xml
+++ b/app/src/main/res/layout/fragment_filling_setting_02.xml
@@ -147,7 +147,7 @@
         android:layout_marginTop="30dp"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
-        android:layout_marginBottom="439dp"
+        android:layout_marginBottom="442dp"
         android:paddingTop="14dp"
         android:paddingStart="14dp"
         android:paddingBottom="9dp"

--- a/app/src/main/res/layout/fragment_filling_setting_03.xml
+++ b/app/src/main/res/layout/fragment_filling_setting_03.xml
@@ -141,7 +141,7 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         app:layout_constraintTop_toBottomOf="@id/filling_activity_cv"
-        app:layout_constraintStart_toStartOf="@id/filling_activity_cv"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBottom_toTopOf="@id/register_btn"
         android:layout_marginTop="30dp"
@@ -276,7 +276,6 @@
         android:layout_marginStart="19dp"
         android:layout_marginEnd="19dp"
         android:layout_marginBottom="19dp"
-        android:enabled="false"
-        app:layout_constraintTop_toBottomOf="@id/filling_activity_time_pick_layout" />
+        android:enabled="false"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_filling_setting_03.xml
+++ b/app/src/main/res/layout/fragment_filling_setting_03.xml
@@ -147,7 +147,7 @@
         android:layout_marginTop="30dp"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
-        android:layout_marginBottom="439dp"
+        android:layout_marginBottom="442dp"
         android:paddingTop="14dp"
         android:paddingStart="14dp"
         android:paddingBottom="9dp"

--- a/app/src/main/res/layout/fragment_wish_setting_01.xml
+++ b/app/src/main/res/layout/fragment_wish_setting_01.xml
@@ -187,7 +187,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="19dp"
         android:layout_marginEnd="19dp"
-        android:layout_marginTop="23dp"
+        android:layout_marginTop="40dp"
         app:cardElevation="0dp"
         app:cardCornerRadius="10dp"
         android:layout_marginHorizontal="10dp"

--- a/app/src/main/res/layout/fragment_wish_setting_02.xml
+++ b/app/src/main/res/layout/fragment_wish_setting_02.xml
@@ -147,7 +147,7 @@
         android:layout_marginTop="30dp"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
-        android:layout_marginBottom="439dp"
+        android:layout_marginBottom="442dp"
         android:paddingTop="14dp"
         android:paddingStart="14dp"
         android:paddingBottom="9dp"

--- a/app/src/main/res/layout/fragment_wish_setting_03.xml
+++ b/app/src/main/res/layout/fragment_wish_setting_03.xml
@@ -146,7 +146,7 @@
         android:layout_marginTop="30dp"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
-        android:layout_marginBottom="439dp"
+        android:layout_marginBottom="442dp"
         android:paddingTop="14dp"
         android:paddingStart="14dp"
         android:paddingBottom="9dp"

--- a/app/src/main/res/layout/fragment_wish_setting_03.xml
+++ b/app/src/main/res/layout/fragment_wish_setting_03.xml
@@ -143,6 +143,7 @@
         app:layout_constraintTop_toBottomOf="@id/wish_cv"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/register_btn"
         android:layout_marginTop="30dp"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
@@ -275,7 +276,6 @@
         android:layout_marginStart="19dp"
         android:layout_marginEnd="19dp"
         android:layout_marginBottom="19dp"
-        android:enabled="false"
-        app:layout_constraintTop_toBottomOf="@id/wish_time_pick_layout" />
+        android:enabled="false"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_wishlist.xml
+++ b/app/src/main/res/layout/fragment_wishlist.xml
@@ -37,7 +37,7 @@
             android:id="@+id/edit_tv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="16dp"
+            android:layout_marginEnd="20dp"
             android:fontFamily="@font/pretendard_medium"
             android:text="편집"
             android:textColor="@color/text_primary"

--- a/app/src/main/res/layout/fragment_wishlist_edit.xml
+++ b/app/src/main/res/layout/fragment_wishlist_edit.xml
@@ -1,124 +1,112 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/white"
     tools:context=".ui.wish.WishlistEditFragment">
 
-    <androidx.core.widget.NestedScrollView
-        android:id="@+id/scroll_container"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:fillViewport="true"
-        android:layout_marginBottom="100dp">
+        android:layout_marginTop="70dp">
 
-        <LinearLayout
+
+        <ImageView
+            android:id="@+id/back_arrow_iv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:src="@drawable/ic_arrow_back"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/edit_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginTop="-18dp"
+            android:fontFamily="@font/noto_sans_kr_medium"
+            android:text="편집"
+            android:textColor="@color/text_primary"
+            android:textSize="20sp"
+            app:layout_constraintStart_toEndOf="@id/back_arrow_iv"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/complete_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="20dp"
+            android:fontFamily="@font/pretendard_medium"
+            android:text="완료"
+            android:textColor="@color/text_primary"
+            android:textSize="16sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/select_wish_to_delete_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="25.5dp"
+            android:fontFamily="@font/pretendard_medium"
+            android:text="삭제할 위시를 선택해주세요"
+            android:textColor="@color/text_primary"
+            android:textSize="18sp"
+            app:layout_constraintBottom_toTopOf="@id/wishlist_rv"
+            app:layout_constraintStart_toStartOf="@id/back_arrow_iv"
+            app:layout_constraintTop_toBottomOf="@id/edit_tv" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/wishlist_rv"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:layout_marginTop="54dp">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:gravity="center_vertical">
-
-                <ImageView
-                    android:id="@+id/back_arrow_iv"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="16dp"
-                    android:src="@drawable/ic_arrow_back" />
-
-                <TextView
-                    android:id="@+id/edit_tv"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="-1dp"
-                    android:layout_marginStart="12dp"
-                    android:text="편집"
-                    android:textSize="20sp"
-                    android:textColor="@color/text_primary"
-                    android:fontFamily="@font/noto_sans_kr_medium" />
-
-                <View
-                    android:layout_width="0dp"
-                    android:layout_weight="1"
-                    android:layout_height="0dp" />
-
-                <TextView
-                    android:id="@+id/complete_tv"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="-1dp"
-                    android:text="완료"
-                    android:textSize="16sp"
-                    android:textColor="@color/text_primary"
-                    android:layout_marginEnd="16dp"
-                    android:fontFamily="@font/pretendard_medium" />
-            </LinearLayout>
-
-            <TextView
-                android:id="@+id/select_wish_to_delete_tv"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="26dp"
-                android:layout_marginStart="16dp"
-                android:text="삭제할 위시를 선택해주세요"
-                android:textSize="18sp"
-                android:textColor="@color/text_primary"
-                android:fontFamily="@font/pretendard_medium" />
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/wishlist_rv"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="23.45dp"
-                android:nestedScrollingEnabled="false"
-                android:overScrollMode="never"
-                android:clipToPadding="false"
-                tools:listitem="@layout/item_wishlist_edit"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
-        </LinearLayout>
-    </androidx.core.widget.NestedScrollView>
+            android:layout_marginTop="24.5dp"
+            android:paddingBottom="120dp"
+            android:clipToPadding="false"
+            android:nestedScrollingEnabled="true"
+            android:overScrollMode="never"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/select_wish_to_delete_tv"
+            tools:listitem="@layout/item_wishlist_edit" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <LinearLayout
         android:id="@+id/wishlist_bottom_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="10dp"
+        android:layout_height="94dp"
         android:layout_alignParentBottom="true"
         android:layout_gravity="bottom"
+        android:background="@color/white"
         android:orientation="horizontal"
         android:padding="10dp"
-        android:background="@color/white"
         android:weightSum="2">
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_wish_cancel"
             android:layout_width="0dp"
             android:layout_height="65dp"
+            android:layout_marginEnd="8dp"
             android:layout_weight="1"
             android:text="선택 취소"
             android:textColor="@color/text_primary"
-            app:cornerRadius="12dp"
             app:backgroundTint="@color/teumteum_bg"
-            android:layout_marginEnd="8dp" />
+            app:cornerRadius="12dp" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_wish_delete"
             android:layout_width="0dp"
             android:layout_height="65dp"
+            android:layout_marginStart="8dp"
             android:layout_weight="1"
             android:text="삭제"
             android:textColor="@color/white"
-            app:cornerRadius="12dp"
             app:backgroundTint="@color/text_primary"
-            android:layout_marginStart="8dp" />
+            app:cornerRadius="12dp" />
     </LinearLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_wishlist_edit.xml
+++ b/app/src/main/res/layout/fragment_wishlist_edit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
+<RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -91,9 +91,10 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="10dp"
+        android:layout_alignParentBottom="true"
         android:layout_gravity="bottom"
         android:orientation="horizontal"
-        android:padding="12dp"
+        android:padding="10dp"
         android:background="@color/white"
         android:weightSum="2">
 
@@ -120,4 +121,4 @@
             android:layout_marginStart="8dp" />
     </LinearLayout>
 
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</RelativeLayout>


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #85 

## ✨ 작업 내용 + 기타 참고 사항
빈틈채우기 화면에 시간표 ui 추가하는 작업 진행하였습니다.
그 외에 수정한 부분들은 다음과 같습니다.


- 채움활동-빈틈채우기 화면 시간표 ui 추가 -> 하단 버튼 위치 조정
- 타임피커 dialog 텍스트 수정 + 크기 등 ui 수정
- 투두 등록 바텀시트에서 시작날짜/종료날짜 텍스트 대신 오늘 날짜 불러오기
- 위시리스트 편집 화면 하단 버튼 고정 + 스크롤뷰 제거 + 상단 고정 + 하단 프레임 추가

+) 안드로이드 자체 타임피커로 개발해달라고 하셔서 폰트, 텍스트크기 적용 안하고 ui 크기와 간격만 수정하였습니다!

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 수정된 ui 확인하기!

## 📸 스크린샷 (선택)
- 채움활동-빈틈채우기 화면 시간표 ui 추가
<img width="375" height="798" alt="image" src="https://github.com/user-attachments/assets/79f809a4-39f6-4142-a30e-f114ca0f5841" />


- 타임피커 dialog 텍스트 수정(확인->완료) + ui 크기와 간격 조정 (오른쪽 사진이 수정된 버전)
<img width="367" height="797" alt="image" src="https://github.com/user-attachments/assets/476ae3b4-8928-4676-ab36-3a576e2e34a2" />
<img width="372" height="802" alt="image" src="https://github.com/user-attachments/assets/42058bfb-5220-42ba-aee8-a62f96a23cb3" />


- 투두 등록 바텀시트의 시작날짜/종료날짜 부분(ui 변경됨에 따라 날짜 유효성 검사는 제거하였으며, 추후에 날짜 또는 시간 관련하여 처리해야 할 로직이 생긴다면 유효성 검사 등 리팩토링 작업할 예정입니다.)
<img width="377" height="797" alt="image" src="https://github.com/user-attachments/assets/6bb53861-2831-42a6-ab90-0d2a8910b42a" />


- 위시리스트 편집 화면 하단에 프레임을 추가하였기 때문에 아래로 스크롤해도 버튼 뒤로 위시리스트가 보이지 않는 것이 정상입니다!
<img width="375" height="802" alt="image" src="https://github.com/user-attachments/assets/60ddd267-0421-4e42-9acd-51f151df467d" />