### PR TITLE
[FEAT/#82] 5.5.4 틈메이트 매칭_세부 조절 + 완료 화면 구현

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendMatchingPreviewDialog.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendMatchingPreviewDialog.kt
@@ -56,7 +56,7 @@ class FriendMatchingPreviewDialog : DialogFragment() {
             updateSuggestion()
         }
 
-        // 이전 버튼 (선택)
+        // 이전 버튼
         binding.btnPrev.setOnClickListener {
             currentIndex = if (currentIndex == 0) suggestions.size - 1 else currentIndex - 1
             updateSuggestion()

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendRoommateMatchingDetailFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendRoommateMatchingDetailFragment.kt
@@ -69,7 +69,7 @@ class FriendRoommateMatchingDetailFragment : Fragment() {
             updateNextButtonState()
         }
 
-        // 전송할게요 버튼 클릭 시 dialogFragment 띄우기
+        // 전송할게요 버튼 클릭 시 dialogFragment 화면 띄우기
         binding.sendBtn.setOnClickListener {
             val dialog = FriendMatchingPreviewDialog()
             dialog.show(parentFragmentManager, "PreviewDialog")
@@ -82,7 +82,6 @@ class FriendRoommateMatchingDetailFragment : Fragment() {
                 .addToBackStack(null)
                 .commit()
         }
-
         setupTimePickers()
 
         // 초기 버튼 상태 설정

--- a/app/src/main/res/drawable/nextbtn.xml
+++ b/app/src/main/res/drawable/nextbtn.xml
@@ -3,6 +3,7 @@
     android:height="15dp"
     android:viewportWidth="9"
     android:viewportHeight="15">
+
   <path
       android:pathData="M1,1L7.211,6.767C7.637,7.163 7.637,7.837 7.211,8.233L1,14"
       android:strokeWidth="1.5"

--- a/app/src/main/res/drawable/previousbtn.xml
+++ b/app/src/main/res/drawable/previousbtn.xml
@@ -3,6 +3,7 @@
     android:height="15dp"
     android:viewportWidth="9"
     android:viewportHeight="15">
+
   <path
       android:pathData="M8,1L1.789,6.767C1.363,7.163 1.363,7.837 1.789,8.233L8,14"
       android:strokeWidth="1.5"

--- a/app/src/main/res/layout/dialog_friend_matching_preview.xml
+++ b/app/src/main/res/layout/dialog_friend_matching_preview.xml
@@ -6,7 +6,7 @@
     android:layout_height="wrap_content"
     android:background="@android:color/transparent">
 
-    <!-- 상단 카드 -->
+    <!-- 상단 카드 부분ㅊ -->
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/teum_time_card"
         android:layout_width="350dp"


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #82

## ✨ 작업 내용
> 
<img width="485" height="519" alt="image" src="https://github.com/user-attachments/assets/5c3e323b-2124-4768-b77b-7dc7b50e8f11" />


## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 활성화된 전송할게요 버튼을 누르면 전송하기 화면이 뜨는지 확인해주세요
- [x] 전송하기 버튼을 누르면 친구 화면으로 돌아가기 화면이 뜨는지 확인해주세요
- [x] 친구 화면으로 돌아가기 버튼을 누르면 친구 화면이 뜨는지 확인해주세요 

## 📸 스크린샷 (선택)
> 
<img width="428" height="854" alt="image" src="https://github.com/user-attachments/assets/88947eea-339b-46e3-a51c-e752d0715a92" />

<img width="409" height="839" alt="image" src="https://github.com/user-attachments/assets/daa0dcd9-1199-47e8-a292-53ed39b3a529" />


## 💬 기타 참고 사항
> x
