### PR TITLE
[FEAT/#91] 5.6 틈 요청 기록 화면 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,6 +56,10 @@ dependencies {
     // 달력
     implementation ("com.jakewharton.threetenabp:threetenabp:1.4.5")
 
+    // 프로필
+    implementation ("com.google.android.flexbox:flexbox:3.0.0")
+
+
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendFragment.kt
@@ -65,6 +65,14 @@ class FriendFragment : Fragment() {
                 .commit()
         }
 
+        // 틈 요청 기록 화면으로 이동
+        binding.btnAlarm.setOnClickListener {
+            parentFragmentManager.beginTransaction()
+                .replace(R.id.main_frm, FriendTeumRequestFragment())
+                .addToBackStack(null)
+                .commit()
+        }
+
         binding.recommendRecyclerView.layoutManager =
             LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
         binding.recommendRecyclerView.adapter = recommendAdapter

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendTeumRequestFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendTeumRequestFragment.kt
@@ -1,0 +1,146 @@
+package com.example.teumteum.ui.friend
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.example.teumteum.R
+import com.example.teumteum.databinding.FragmentFriendTeumRequestBinding
+import com.example.teumteum.ui.calendar.IDateClickListener
+import com.example.teumteum.ui.calendar.MonthlyCalendarFragment
+import com.example.teumteum.ui.friend.adapter.TeumRequestAdapter
+import com.example.teumteum.ui.friend.adapter.TeumRequestItem
+import com.example.teumteum.ui.main.MainActivity
+import com.example.teumteum.utils.getSavedDateOrToday
+import java.time.LocalDate
+
+class FriendTeumRequestFragment : Fragment() {
+
+    private var _binding: FragmentFriendTeumRequestBinding? = null
+    private val binding get() = _binding!!
+
+    private var selectedDate: LocalDate? = null
+    private val today: LocalDate = LocalDate.now()
+    private val baseDate: LocalDate by lazy { getSavedDateOrToday(requireContext()) }
+    private var currentMonthOffset = 0
+
+    private lateinit var adapter: TeumRequestAdapter
+
+    // 날짜 클릭 시 호출되는 리스너 내부에 RecyclerView 갱신 처리
+    private val onClickListener = object : IDateClickListener {
+        override fun onClickDate(date: LocalDate) {
+            selectedDate = date
+            updateCalendarFragment()
+
+            // 선택한 날짜 포맷 → "25.MM.DD"
+            val formattedDate = "25.${date.monthValue.toString().padStart(2, '0')}.${date.dayOfMonth.toString().padStart(2, '0')}"
+
+            // 선택한 날짜에 맞는 데이터로 리스트 갱신 (예시)
+            val updatedList = listOf(
+                TeumRequestItem(
+                    name = "문혜원",
+                    date = formattedDate,
+                    time = "10:00 ~ 13:00",
+                    title = "중강 기념 한강 피크닉",
+                    description = "중강 기념 한강 피크닉 가자! 돗자리는 내가 챙길게~ 다들 몸만 오세요",
+                    profileImageRes = R.drawable.gray_teum
+                )
+            )
+
+            // RecyclerView 업데이트
+            adapter = TeumRequestAdapter(updatedList)
+            binding.requestHistoryRecyclerView.adapter = adapter
+
+            //  날짜 선택 시에만 보이게
+            binding.requestHistoryRecyclerView.visibility = View.VISIBLE
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentFriendTeumRequestBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        (activity as? MainActivity)?.hideBottomBar()
+        setupNavigationButtons()
+        updateCalendarFragment()
+
+        // RecyclerView 처음엔 안 보이도록
+        binding.requestHistoryRecyclerView.visibility = View.GONE
+
+        //  초기 데이터 연결 제거 또는 주석처리
+        /*
+        val initialList = listOf(
+            TeumRequestItem(
+                name = "문혜원",
+                date = "25.06.05",
+                time = "10:00 ~ 13:00",
+                title = "중강 기념 한강 피크닉",
+                description = "중강 기념 한강 피크닉 가자! 돗자리는 내가 챙길게~ 다들 몸만 오세요",
+                profileImageRes = R.drawable.gray_teum
+            )
+        )
+
+        adapter = TeumRequestAdapter(initialList)
+        binding.requestHistoryRecyclerView.layoutManager = LinearLayoutManager(requireContext())
+        binding.requestHistoryRecyclerView.adapter = adapter
+        */
+
+        // 대신 layoutManager만 설정 (한 번만 하면 됨)
+        binding.requestHistoryRecyclerView.layoutManager = LinearLayoutManager(requireContext())
+
+        binding.btnBack.setOnClickListener {
+            parentFragmentManager.beginTransaction()
+                .replace(R.id.main_frm, FriendFragment())
+                .addToBackStack(null)
+                .commit()
+        }
+    }
+
+    private fun setupNavigationButtons() {
+        binding.homeCalendarPreviousDateIv.setOnClickListener {
+            currentMonthOffset--
+            updateCalendarFragment()
+        }
+
+        binding.homeCalendarNextDateIv.setOnClickListener {
+            currentMonthOffset++
+            updateCalendarFragment()
+        }
+    }
+
+    private fun updateCalendarFragment() {
+        val displayDate = baseDate.plusMonths(currentMonthOffset.toLong())
+        binding.homeSelectedDateTv.text = "${displayDate.year}년 ${displayDate.monthValue}월"
+
+        val calendarFragment = MonthlyCalendarFragment.newInstance(
+            position = Int.MAX_VALUE / 2 + currentMonthOffset,
+            onClickListener = onClickListener,
+            showDot = true
+        ).apply {
+            arguments = Bundle().apply {
+                putSerializable("displayDate", displayDate)
+                putSerializable("selectedDate", selectedDate)
+                putSerializable("today", today)
+            }
+        }
+
+        childFragmentManager.beginTransaction()
+            .replace(binding.calendarContainer.id, calendarFragment)
+            .commit()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/example/teumteum/ui/friend/adapter/TeumRequestAdapter.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/adapter/TeumRequestAdapter.kt
@@ -1,0 +1,65 @@
+package com.example.teumteum.ui.friend.adapter
+
+import android.graphics.Color
+import android.text.SpannableString
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import androidx.recyclerview.widget.RecyclerView
+import com.example.teumteum.R
+import com.example.teumteum.databinding.ItemRequestHistoryBinding
+
+class TeumRequestAdapter(private val itemList: List<TeumRequestItem>) :
+    RecyclerView.Adapter<TeumRequestAdapter.TeumRequestViewHolder>() {
+
+    inner class TeumRequestViewHolder(val binding: ItemRequestHistoryBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: TeumRequestItem) {
+            binding.tvName.text = item.name
+            binding.tvDate.text = "${item.date}     |"
+            binding.tvTime.text = item.time
+            binding.title.text = item.title
+            binding.description.text = item.description
+            binding.imgProfile.setImageResource(item.profileImageRes)
+
+            // api 연결 후 다시 해봐야 됨
+            if (item.isCanceled) {
+                // 약속 취소 상태일 때
+                binding.tvStatus.visibility = View.VISIBLE
+                binding.tvStatus.text = "약속이 취소되었어요"
+
+                // 상단 배경 색 변경
+                binding.root.findViewById<LinearLayout>(R.id.topContainer)
+                    ?.setBackgroundColor(Color.parseColor("#D3D3D3"))
+
+            } else {
+                // 기본 정상 상태
+                binding.tvStatus.visibility = View.GONE
+
+                binding.root.findViewById<LinearLayout>(R.id.topContainer)
+                    ?.setBackgroundColor(Color.parseColor("#7770FE"))
+                binding.tvName.setTextColor(Color.WHITE)
+                binding.tvDate.setTextColor(Color.WHITE)
+                binding.tvTime.setTextColor(Color.WHITE)
+                binding.title.setTextColor(Color.parseColor("#0F0F0F"))
+                binding.description.setTextColor(Color.parseColor("#788084"))
+            }
+        }
+    }
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TeumRequestViewHolder {
+            val binding = ItemRequestHistoryBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+            return TeumRequestViewHolder(binding)
+        }
+
+        override fun onBindViewHolder(holder: TeumRequestViewHolder, position: Int) {
+            holder.bind(itemList[position])
+        }
+
+        override fun getItemCount(): Int = itemList.size
+    }

--- a/app/src/main/java/com/example/teumteum/ui/friend/adapter/TeumRequestItem.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/adapter/TeumRequestItem.kt
@@ -1,0 +1,12 @@
+package com.example.teumteum.ui.friend.adapter
+
+data class TeumRequestItem(
+    val name: String,
+    val date: String,
+    val time: String,
+    val title: String,
+    val description: String,
+    val profileImageRes: Int,
+    val isCanceled: Boolean = false
+)
+

--- a/app/src/main/java/com/example/teumteum/utils/NetworkModule.kt
+++ b/app/src/main/java/com/example/teumteum/utils/NetworkModule.kt
@@ -1,6 +1,6 @@
 package com.example.teumteum.utils
 
-import com.example.teumteum.utils.TEMP_ACCESS_TOKEN
+import com.example.teumteum.TEMP_ACCESS_TOKEN
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory

--- a/app/src/main/res/drawable/bg_bottom_rounded.xml
+++ b/app/src/main/res/drawable/bg_bottom_rounded.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="#F6F6F6" />
+
+    <corners
+        android:bottomLeftRadius="10dp"
+        android:bottomRightRadius="10dp"
+        android:topLeftRadius="0dp"
+        android:topRightRadius="0dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_label_accept.xml
+++ b/app/src/main/res/drawable/bg_label_accept.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="#F6F6F6" />
+
+    <corners android:radius="10dp" />
+</shape>

--- a/app/src/main/res/layout/fragment_friend_teum_request.xml
+++ b/app/src/main/res/layout/fragment_friend_teum_request.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#FFFFFF"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <!-- 뒤로가기 버튼 -->
+    <ImageButton
+        android:id="@+id/btnBack"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="70dp"
+        android:layout_marginStart="16dp"
+        android:src="@drawable/ic_arrow_back"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="뒤로가기"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <TextView
+        android:id="@+id/textView2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="68dp"
+        android:fontFamily="@font/noto_sans_kr_medium"
+        android:includeFontPadding="false"
+        android:text="틈 요청 기록"
+        android:textColor="#0F0F0F"
+        android:textSize="20dp"
+        app:layout_constraintStart_toEndOf="@+id/btnBack"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <!-- 달력 상단 헤더 -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/constraintLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/home_selected_date_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="32dp"
+            android:layout_marginTop="60dp"
+            android:fontFamily="@font/pretendard_medium"
+            android:text="2025년 6월"
+            android:textColor="@color/text_primary"
+            android:textSize="20sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
+            android:id="@+id/home_calendar_previous_date_iv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="163dp"
+            android:layout_marginEnd="18dp"
+            android:src="@drawable/previous"
+            app:layout_constraintEnd_toStartOf="@+id/home_calendar_next_date_iv"
+            app:layout_constraintStart_toEndOf="@+id/home_selected_date_tv"
+            app:layout_constraintTop_toTopOf="@+id/home_selected_date_tv" />
+
+        <ImageView
+            android:id="@+id/home_calendar_next_date_iv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="32dp"
+            android:src="@drawable/next"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/home_selected_date_tv" />
+
+        <LinearLayout
+            android:id="@+id/home_weekly_calendar_day_of_month_ll"
+            android:layout_width="375dp"
+            android:layout_height="40dp"
+            android:layout_marginStart="32dp"
+            android:layout_marginTop="28dp"
+            android:layout_marginEnd="32dp"
+            android:orientation="horizontal"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/home_selected_date_tv">
+
+            <TextView
+                android:id="@+id/home_day_of_week_sun_tv"
+                style="@style/day_of_week_tv"
+                android:text="일" />
+
+            <TextView
+                android:id="@+id/home_day_of_week_mon_tv"
+                style="@style/day_of_week_tv"
+                android:text="월" />
+
+            <TextView
+                android:id="@+id/home_day_of_week_tue_tv"
+                style="@style/day_of_week_tv"
+                android:text="화" />
+
+            <TextView
+                android:id="@+id/home_day_of_week_wed_tv"
+                style="@style/day_of_week_tv"
+                android:text="수" />
+
+            <TextView
+                android:id="@+id/home_day_of_week_thu_tv"
+                style="@style/day_of_week_tv"
+                android:text="목" />
+
+            <TextView
+                android:id="@+id/home_day_of_week_fri_tv"
+                style="@style/day_of_week_tv"
+                android:text="금" />
+
+            <TextView
+                android:id="@+id/home_day_of_week_sat_tv"
+                style="@style/day_of_week_tv"
+                android:text="토" />
+        </LinearLayout>
+
+        <!-- 캘린더 영역 -->
+        <FrameLayout
+            android:id="@+id/home_calendar_container_fl"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/home_weekly_calendar_day_of_month_ll">
+
+            <androidx.viewpager2.widget.ViewPager2
+                android:id="@+id/home_weekly_calendar_week_vp"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+            <androidx.viewpager2.widget.ViewPager2
+                android:id="@+id/home_monthly_calendar_month_vp"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:visibility="gone" />
+        </FrameLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <!-- 달력 -->
+    <FrameLayout
+        android:id="@+id/calendar_container"
+        android:layout_width="match_parent"
+        android:layout_height="300dp"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="0dp"
+        android:layout_marginEnd="20dp"
+        android:layout_marginBottom="60dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/constraintLayout">
+    </FrameLayout>
+
+    <!-- 회색 선 -->
+    <View
+        android:id="@+id/calendar_divider"
+        android:layout_width="350dp"
+        android:layout_height="1dp"
+        android:layout_marginTop="-8dp"
+        android:background="#B1B2B3"
+        app:layout_constraintTop_toBottomOf="@id/calendar_container"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <!-- RecyclerView: 틈 요청 기록 리스트 -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/requestHistoryRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="330dp"
+        android:layout_marginTop="38dp"
+        android:clipToPadding="false"
+        android:layout_marginStart="20dp"
+        android:layout_marginEnd="20dp"
+        android:paddingBottom="24dp"
+        android:visibility="visible"
+        app:layout_constraintTop_toBottomOf="@id/calendar_divider"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:listitem="@layout/item_request_history"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_friend_teum_request.xml
+++ b/app/src/main/res/layout/fragment_friend_teum_request.xml
@@ -37,19 +37,21 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/constraintLayout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/textView2"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
 
         <TextView
             android:id="@+id/home_selected_date_tv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="32dp"
-            android:layout_marginTop="60dp"
+            android:layout_marginTop="33dp"
             android:fontFamily="@font/pretendard_medium"
             android:text="2025년 6월"
             android:textColor="@color/text_primary"
             android:textSize="20sp"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/layout/item_request_history.xml
+++ b/app/src/main/res/layout/item_request_history.xml
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:cardCornerRadius="10dp"
+    app:cardElevation="0dp"
+    app:cardBackgroundColor="@android:color/white">
+
+    <!-- 약속 상태 표시용 TextView (예: 약속이 취소되었어요) -->
+    <TextView
+        android:id="@+id/tvStatus"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="38dp"
+        android:layout_marginStart="19dp"
+        android:text="약속이 취소되었어요"
+        android:textSize="20sp"
+        android:textColor="#0F0F0F"
+        android:fontFamily="@font/noto_sans_kr_medium"
+        android:visibility="gone" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <!-- 상단: 보낸 사람, 날짜, 시간 -->
+        <LinearLayout
+            android:id="@+id/topContainer"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="horizontal"
+            android:background="#7770FE"
+            android:gravity="center_vertical">
+
+            <ImageView
+                android:id="@+id/imgProfile"
+                android:layout_width="38dp"
+                android:layout_height="38dp"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="14dp"
+                android:layout_marginBottom="15dp"
+                android:background="@drawable/freind01_circle_profile"
+                android:scaleType="centerCrop" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/tvName"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="12dp"
+                    android:layout_marginEnd="18dp"
+                    android:layout_weight="1"
+                    android:fontFamily="@font/noto_sans_kr_medium"
+                    android:text="이름"
+                    android:textColor="#FFFFFF"
+                    android:textSize="16sp" />
+
+                <TextView
+                    android:id="@+id/tvDate"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="8.52dp"
+                    android:fontFamily="@font/noto_sans_kr_regular"
+                    android:text="25.05.02     |"
+                    android:textColor="#FFFFFF"
+                    android:textSize="11sp" />
+
+                <ImageView
+                    android:layout_width="13dp"
+                    android:layout_height="13dp"
+                    android:layout_marginEnd="4dp"
+                    android:contentDescription="시간 아이콘"
+                    android:src="@drawable/friend_timer_outline" />
+
+                <TextView
+                    android:id="@+id/tvTime"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="21dp"
+                    android:fontFamily="@font/noto_sans_kr_regular"
+                    android:text="15:20 ~ 16:10"
+                    android:textColor="#FFFFFF"
+                    android:textSize="11sp" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/contentContainer"
+            android:layout_width="match_parent"
+            android:layout_height="95dp"
+            android:orientation="vertical"
+            android:background="@drawable/bg_bottom_rounded">
+
+            <!-- 제목 -->
+            <TextView
+                android:id="@+id/title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="14dp"
+                android:text="종강 기념 한강 피크닉"
+                android:includeFontPadding="false"
+                android:textColor="#0F0F0F"
+                android:textSize="15sp"
+                android:fontFamily="@font/noto_sans_kr_medium" />
+
+            <!-- 설명 -->
+            <TextView
+                android:id="@+id/description"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:layout_marginStart="20dp"
+                android:layout_marginEnd="93.69dp"
+                android:layout_marginBottom="16dp"
+                android:includeFontPadding="false"
+                android:text="종강 기념 한강 피크닉 가자! 돗자리는 내가 챙길\n게~ 다들 몸만 오세요"
+                android:textColor="#788084"
+                android:textSize="12sp"
+                android:fontFamily="@font/noto_sans_kr_regular" />
+        </LinearLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/labelAccept"
+                android:layout_width="56dp"
+                android:layout_height="32dp"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="29dp"
+                android:background="@drawable/bg_label_accept"
+                android:gravity="center"
+                android:text="수락"
+                android:textColor="#5C6569"
+                android:textSize="14sp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/labelCancel"
+                android:layout_width="56dp"
+                android:layout_height="32dp"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="24dp"
+                android:background="@drawable/bg_label_accept"
+                android:gravity="center"
+                android:text="취소"
+                android:textColor="#5C6569"
+                android:textSize="14sp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/labelAccept" />
+
+            <TextView
+                android:id="@+id/labelNoAnswer"
+                android:layout_width="56dp"
+                android:layout_height="32dp"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="24dp"
+                android:background="@drawable/bg_label_accept"
+                android:gravity="center"
+                android:text="미응답"
+                android:textColor="#5C6569"
+                android:textSize="14sp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/labelCancel" />
+
+            <View
+                android:id="@+id/verticalDivider"
+                android:layout_width="1dp"
+                android:layout_height="152dp"
+                android:layout_marginStart="15dp"
+                android:layout_marginBottom="36dp"
+                android:layout_marginTop="25dp"
+                android:background="#CBCCD0"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@id/labelAccept"
+                app:layout_constraintTop_toTopOf="parent" />
+
+
+            <!-- ConstraintLayout 안에 FlexboxLayout으로 사용자 프로필 정렬 -->
+            <com.google.android.flexbox.FlexboxLayout
+                android:id="@+id/profileImageContainer"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="26dp"
+                android:layout_marginEnd="12dp"
+                app:flexWrap="wrap"
+                app:justifyContent="flex_start"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/verticalDivider"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <!-- 더미 사용자 프로필 이미지들 -->
+                <ImageView
+                    android:layout_width="38dp"
+                    android:layout_height="38dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginBottom="8dp"
+                    android:background="@drawable/freind01_circle_profile"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/gray_teum" />
+
+                <ImageView
+                    android:layout_width="38dp"
+                    android:layout_height="38dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginBottom="8dp"
+                    android:background="@drawable/freind01_circle_profile"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/gray_teum" />
+
+                <ImageView
+                    android:layout_width="38dp"
+                    android:layout_height="38dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginBottom="8dp"
+                    android:background="@drawable/freind01_circle_profile"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/gray_teum" />
+
+                <ImageView
+                    android:layout_width="38dp"
+                    android:layout_height="38dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginBottom="8dp"
+                    android:background="@drawable/freind01_circle_profile"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/gray_teum" />
+
+                <!-- 필요한 만큼 반복 추가 가능 -->
+            </com.google.android.flexbox.FlexboxLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
+</androidx.cardview.widget.CardView>
+


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #91

## ✨ 작업 내용
> 
<img width="609" height="688" alt="image" src="https://github.com/user-attachments/assets/e1191b64-497f-4cc3-9c1a-062d03c41741" />


## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 친구 메인 화면에서 검색 창 왼쪽 이미지 버튼을 누르면 틈 요청 기록 화면으로 넘어가는지 확인해주세요 
- [x] 캘린더만 화면에 뜨는지, 그리고 날짜를 선택했을 때 수락 취소 미응답 화면? 이 뜨는지 확인해주세요 ( 이 부분 recyclerview라 위아래로 스크롤 되는지까지 확인해주세요)

## 📸 스크린샷 (선택)
> 
<img width="429" height="879" alt="image" src="https://github.com/user-attachments/assets/758f6642-0b4a-4420-85fe-2cb5b8d9618a" />

<img width="436" height="865" alt="image" src="https://github.com/user-attachments/assets/99489404-0c79-4730-9ded-8ba9732c6b21" />


## 💬 기타 참고 사항
> 사진에서 위 부분 양쪽 깨지는 현상은 무시해주세욥.. + api 연결을 해야 작업 내용이 이미지처럼 화면에 뜨기 때문에 일단 기본 화면만 만들었습니다. api 연결 하면서 추후에 다시 수정할 계획입니다
