### PR TITLE
[Refactor/#92] 등록한 위시가 존재하지 않는 경우 컴포넌트 뜨게 하기

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/calendar/MonthlyCalendarFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/calendar/MonthlyCalendarFragment.kt
@@ -116,7 +116,7 @@ class MonthlyCalendarFragment : Fragment() {
                 columnSpec = GridLayout.spec(index % 7)
                 width = GridLayout.LayoutParams.WRAP_CONTENT
                 height = GridLayout.LayoutParams.WRAP_CONTENT
-                setMargins(20, 8, 24, 8)
+                setMargins(0, 6, 1, 6)
             }
             cellView.layoutParams = params
 

--- a/app/src/main/java/com/example/teumteum/ui/calendar/MonthlyCalendarFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/calendar/MonthlyCalendarFragment.kt
@@ -116,7 +116,7 @@ class MonthlyCalendarFragment : Fragment() {
                 columnSpec = GridLayout.spec(index % 7)
                 width = GridLayout.LayoutParams.WRAP_CONTENT
                 height = GridLayout.LayoutParams.WRAP_CONTENT
-                setMargins(20, 8, 29, 8)
+                setMargins(20, 8, 24, 8)
             }
             cellView.layoutParams = params
 

--- a/app/src/main/java/com/example/teumteum/ui/calendar/WeeklyCalendarFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/calendar/WeeklyCalendarFragment.kt
@@ -36,7 +36,8 @@ class WeeklyCalendarFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         val newDate = calculateNewDate()
         calculateDatesOfWeek(newDate)
-        setOneWeekDateIntoTextView()
+        val baseMonth = newDate.monthValue
+        setOneWeekDateIntoTextView(baseMonth)
         selectTodayIfInWeek()
     }
 
@@ -47,7 +48,7 @@ class WeeklyCalendarFragment : Fragment() {
 
     override fun onPause() {
         super.onPause()
-        resetUi()
+        resetUi(calculateNewDate().monthValue)
     }
 
     private fun initViews() {
@@ -72,9 +73,8 @@ class WeeklyCalendarFragment : Fragment() {
         dates = (0..6).map { startOfWeek.plusDays(it.toLong()) }
     }
 
-    private fun setOneWeekDateIntoTextView() {
+    private fun setOneWeekDateIntoTextView(baseMonth: Int) {
         val today = LocalDate.now()
-        val baseMonth = dates[6].monthValue // 토요일 기준
 
         for (i in textViewList.indices) {
             val date = dates[i]
@@ -84,14 +84,15 @@ class WeeklyCalendarFragment : Fragment() {
             textView.text = date.dayOfMonth.toString()
             dotView.visibility = if (date == today) View.VISIBLE else View.GONE
 
-            if (date.monthValue != baseMonth) {
-                textView.setTextColor(requireContext().getColor(R.color.teumteum_deactive))
-            } else {
-                textView.setTextColor(requireContext().getColor(R.color.text_primary))
-            }
+            textView.setTextColor(
+                if (date.monthValue == baseMonth)
+                    requireContext().getColor(R.color.text_primary)
+                else
+                    requireContext().getColor(R.color.teumteum_deactive)
+            )
 
             textView.setOnClickListener {
-                resetUi()
+                resetUi(baseMonth)
                 setSelectedDate(requireContext(), textView)
                 saveSelectedDate(requireContext(), date)
                 onClickListener.onClickDate(date)
@@ -119,9 +120,8 @@ class WeeklyCalendarFragment : Fragment() {
         }
     }
 
-    private fun resetUi() {
+    private fun resetUi(baseMonth: Int) {
         val today = LocalDate.now()
-        val baseMonth = dates[6].monthValue
 
         for (i in textViewList.indices) {
             val date = dates[i]
@@ -137,10 +137,10 @@ class WeeklyCalendarFragment : Fragment() {
             }
 
             textView.setTextColor(
-                if (date.monthValue != baseMonth)
-                    requireContext().getColor(R.color.teumteum_deactive)
-                else
+                if (date.monthValue == baseMonth)
                     requireContext().getColor(R.color.text_primary)
+                else
+                    requireContext().getColor(R.color.teumteum_deactive)
             )
         }
     }

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishlistEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishlistEditFragment.kt
@@ -39,15 +39,31 @@ class WishlistEditFragment() : Fragment(), DeleteWishesView {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-
-        adapter = WishlistEditRVAdapter(editedWishlist)
-        binding.wishlistRv.adapter = adapter
-
         // 바텀 내비게이션 숨기기
         val bottomNav = activity?.findViewById<BottomNavigationView>(R.id.main_bnv)
         bottomNav?.visibility = View.GONE
 
-        setupButtons()
+        // ViewModel에서 데이터 복사
+        editedWishlist = wishlistViewModel.wishlistItems.map { it.copy() }.toMutableList()
+
+        if (editedWishlist.isEmpty()) {
+            // 위시가 없을 경우
+            binding.wishlistRv.visibility = View.GONE
+            binding.wishNotExistsCv.visibility = View.VISIBLE
+        } else {
+            // 위시가 있을 경우
+            binding.wishlistRv.visibility = View.VISIBLE
+            binding.wishNotExistsCv.visibility = View.GONE
+
+            adapter = WishlistEditRVAdapter(editedWishlist)
+            binding.wishlistRv.adapter = adapter
+
+            setupButtons()
+        }
+
+        binding.backArrowIv.setOnClickListener {
+            parentFragmentManager.popBackStack()
+        }
     }
 
     private fun setupButtons() {

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishlistFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishlistFragment.kt
@@ -104,33 +104,42 @@ class WishlistFragment() : Fragment(), WishlistView {
         val button1h = binding.btnWishlistTime05
 
         allButton.setOnClickListener {
-            adapter.updateList(wishlistItems) // 전체 표시
-            updateTimeButtonUI(allButton)
+            filterAndUpdate(duration = "all", button = allButton)
         }
 
         button10m.setOnClickListener {
-            val filtered = wishlistItems.filter { it.estimatedDuration == "10m" }
-            adapter.updateList(filtered)
-            updateTimeButtonUI(button10m)
+            filterAndUpdate(duration = "10m", button = button10m)
         }
 
         button20m.setOnClickListener {
-            val filtered = wishlistItems.filter { it.estimatedDuration == "20m" }
-            adapter.updateList(filtered)
-            updateTimeButtonUI(button20m)
+            filterAndUpdate(duration = "20m", button = button20m)
         }
 
         button30m.setOnClickListener {
-            val filtered = wishlistItems.filter { it.estimatedDuration == "30m" }
-            adapter.updateList(filtered)
-            updateTimeButtonUI(button30m)
+            filterAndUpdate(duration = "30m", button = button30m)
         }
 
         button1h.setOnClickListener {
-            val filtered = wishlistItems.filter { it.estimatedDuration == "1h" }
-            adapter.updateList(filtered)
-            updateTimeButtonUI(button1h)
+            filterAndUpdate(duration = "1h", button = button1h)
         }
+    }
+
+    private fun filterAndUpdate(duration: String, button: MaterialButton) {
+        val filteredList = when (duration) {
+            "all" -> wishlistItems
+            else -> wishlistItems.filter { it.estimatedDuration == duration }
+        }
+
+        if (filteredList.isEmpty()) {
+            binding.wishlistRv.visibility = View.GONE
+            binding.wishNotExistsCv.visibility = View.VISIBLE
+        } else {
+            binding.wishlistRv.visibility = View.VISIBLE
+            binding.wishNotExistsCv.visibility = View.GONE
+            adapter.updateList(filteredList)
+        }
+
+        updateTimeButtonUI(button)
     }
 
     private fun updateTimeButtonUI(selectedButton: MaterialButton) {

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishlistFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishlistFragment.kt
@@ -163,10 +163,21 @@ class WishlistFragment() : Fragment(), WishlistView {
         getList(duration = "all", page = 1)
     }
 
-    override fun onGetWishListSuccess(wishlistItems: List<WishlistItem>) {
-        this.wishlistItems = wishlistItems
-        adapter.updateList(wishlistItems)
+    override fun onGetWishListSuccess(wishlist: List<WishlistItem>) {
+        this.wishlistItems = wishlist
+
+        if (wishlist.isEmpty()) {
+            // 위시가 없을 때
+            binding.wishlistRv.visibility = View.GONE
+            binding.wishNotExistsCv.visibility = View.VISIBLE
+        } else {
+            // 위시가 있을 때
+            binding.wishlistRv.visibility = View.VISIBLE
+            binding.wishNotExistsCv.visibility = View.GONE
+            adapter.updateList(wishlist)
+        }
     }
+
 
     override fun onGetWishListFailure(code: String, message: String?) {
         val errorMessage = when {

--- a/app/src/main/java/com/example/teumteum/utils/CalendarUtils.kt
+++ b/app/src/main/java/com/example/teumteum/utils/CalendarUtils.kt
@@ -20,13 +20,13 @@ fun getSavedDateOrToday(context: Context): LocalDate {
 }
 
 fun setSelectedDate(context: Context, textView: TextView) {
-    textView.background = ContextCompat.getDrawable(context, R.drawable.bg_date_selected)
+    textView.background = ContextCompat.getDrawable(context, R.drawable.bg_day_selected)
     textView.backgroundTintList = ColorStateList.valueOf(ContextCompat.getColor(context, R.color.main_1))
     textView.setTextColor(ContextCompat.getColor(context, R.color.white))
 }
 
 fun setTodayStyle(context: Context, textView: TextView) {
-    textView.background = ContextCompat.getDrawable(context, R.drawable.bg_date_selected)
+    textView.background = ContextCompat.getDrawable(context, R.drawable.bg_day_selected)
     textView.backgroundTintList = ColorStateList.valueOf(ContextCompat.getColor(context, R.color.teumteum_gray))
     textView.setTextColor(ContextCompat.getColor(context, R.color.white))
 }

--- a/app/src/main/java/com/example/teumteum/utils/NetworkModule.kt
+++ b/app/src/main/java/com/example/teumteum/utils/NetworkModule.kt
@@ -1,6 +1,6 @@
 package com.example.teumteum.utils
 
-import com.example.teumteum.utils.TEMP_ACCESS_TOKEN
+import com.example.teumteum.TEMP_ACCESS_TOKEN
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory

--- a/app/src/main/res/drawable/bg_date_selected.xml
+++ b/app/src/main/res/drawable/bg_date_selected.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="@color/main_1"/>
-    <size android:width="20dp" android:height="20dp" />
-    <corners android:radius="50dp"/>
-</shape>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -199,14 +199,14 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="35dp"
-                    android:layout_marginStart="20dp"
-                    android:layout_marginEnd="20dp">
+                    android:layout_marginStart="25dp"
+                    android:layout_marginEnd="25dp">
 
                     <TextView
                         android:id="@+id/home_selected_date_tv"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginStart="15dp"
+                        android:layout_marginStart="14dp"
                         android:fontFamily="@font/pretendard_medium"
                         android:gravity="center"
                         android:text="2025년 6월"
@@ -277,7 +277,7 @@
 
                     <LinearLayout
                         android:id="@+id/home_weekly_calendar_day_of_month_ll"
-                        android:layout_width="375dp"
+                        android:layout_width="match_parent"
                         android:layout_height="40dp"
                         android:layout_marginTop="28dp"
                         android:orientation="horizontal"

--- a/app/src/main/res/layout/fragment_monthly_calendar.xml
+++ b/app/src/main/res/layout/fragment_monthly_calendar.xml
@@ -11,7 +11,6 @@
         android:id="@+id/monthly_calendar_grid"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="-3dp"
         app:columnCount="7"
         app:useDefaultMargins="false"
         android:clipChildren="false"

--- a/app/src/main/res/layout/fragment_todo_edit.xml
+++ b/app/src/main/res/layout/fragment_todo_edit.xml
@@ -137,9 +137,9 @@
 
                         <LinearLayout
                             android:id="@+id/home_calendar_view_ll"
-                            android:layout_width="375dp"
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginEnd="15dp"
+                            android:layout_marginEnd="5dp"
                             android:orientation="vertical"
                             android:visibility="gone"
                             app:layout_constraintTop_toBottomOf="@id/start_date_tv"
@@ -275,9 +275,9 @@
 
                         <LinearLayout
                             android:id="@+id/home_calendar_view_02_ll"
-                            android:layout_width="375dp"
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginEnd="15dp"
+                            android:layout_marginEnd="5dp"
                             android:orientation="vertical"
                             android:visibility="gone"
                             app:layout_constraintTop_toBottomOf="@id/start_date_tv"

--- a/app/src/main/res/layout/fragment_todo_register.xml
+++ b/app/src/main/res/layout/fragment_todo_register.xml
@@ -150,9 +150,9 @@
 
                         <LinearLayout
                             android:id="@+id/home_calendar_view_ll"
-                            android:layout_width="375dp"
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginEnd="15dp"
+                            android:layout_marginEnd="5dp"
                             android:orientation="vertical"
                             android:visibility="gone"
                             app:layout_constraintTop_toBottomOf="@id/start_date_tv"
@@ -288,9 +288,9 @@
 
                         <LinearLayout
                             android:id="@+id/home_calendar_view_02_ll"
-                            android:layout_width="375dp"
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginEnd="15dp"
+                            android:layout_marginEnd="5dp"
                             android:orientation="vertical"
                             android:visibility="gone"
                             app:layout_constraintTop_toBottomOf="@id/start_date_tv"

--- a/app/src/main/res/layout/fragment_weekly_calendar.xml
+++ b/app/src/main/res/layout/fragment_weekly_calendar.xml
@@ -16,7 +16,7 @@
             android:id="@+id/dot1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
+            android:layout_marginTop="6dp"
             android:src="@drawable/dot_schedule_exists"
             android:visibility="gone" />
     </LinearLayout>
@@ -30,7 +30,7 @@
             android:id="@+id/dot2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
+            android:layout_marginTop="6dp"
             android:src="@drawable/dot_schedule_exists"
             android:visibility="gone" />
     </LinearLayout>
@@ -44,7 +44,7 @@
             android:id="@+id/dot3"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
+            android:layout_marginTop="6dp"
             android:src="@drawable/dot_schedule_exists"
             android:visibility="gone" />
     </LinearLayout>
@@ -58,7 +58,7 @@
             android:id="@+id/dot4"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
+            android:layout_marginTop="6dp"
             android:src="@drawable/dot_schedule_exists"
             android:visibility="gone" />
     </LinearLayout>
@@ -72,7 +72,7 @@
             android:id="@+id/dot5"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
+            android:layout_marginTop="6dp"
             android:src="@drawable/dot_schedule_exists"
             android:visibility="gone" />
     </LinearLayout>
@@ -86,7 +86,7 @@
             android:id="@+id/dot6"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
+            android:layout_marginTop="6dp"
             android:src="@drawable/dot_schedule_exists"
             android:visibility="gone" />
     </LinearLayout>
@@ -100,7 +100,7 @@
             android:id="@+id/dot7"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
+            android:layout_marginTop="6dp"
             android:src="@drawable/dot_schedule_exists"
             android:visibility="gone" />
     </LinearLayout>

--- a/app/src/main/res/layout/fragment_wishlist.xml
+++ b/app/src/main/res/layout/fragment_wishlist.xml
@@ -148,6 +148,54 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/wishlist_time_container"
             tools:listitem="@layout/item_wishlist" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/wish_not_exists_cv"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="10dp"
+            android:layout_marginTop="230dp"
+            android:backgroundTint="@color/white"
+            android:visibility="gone"
+            app:cardCornerRadius="10dp"
+            app:cardElevation="0dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/wishlist_time_container"
+            app:strokeWidth="0dp">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <ImageView
+                    android:id="@+id/wish_not_exists_iv"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:src="@drawable/ic_teum_char_sleep_sv"
+                    app:layout_constraintBottom_toTopOf="@id/wish_not_exists_tv"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/wish_not_exists_tv"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/noto_sans_kr_medium"
+                    android:includeFontPadding="false"
+                    android:text="등록해 놓은 위시가 없어요"
+                    android:textColor="@color/teumteum_gray"
+                    android:textSize="15sp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/wish_not_exists_iv" />
+
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.google.android.material.card.MaterialCardView>
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <ImageView

--- a/app/src/main/res/layout/fragment_wishlist_edit.xml
+++ b/app/src/main/res/layout/fragment_wishlist_edit.xml
@@ -73,6 +73,54 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/select_wish_to_delete_tv"
             tools:listitem="@layout/item_wishlist_edit" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/wish_not_exists_cv"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="10dp"
+            android:layout_marginTop="237dp"
+            android:backgroundTint="@color/white"
+            android:visibility="gone"
+            app:cardCornerRadius="10dp"
+            app:cardElevation="0dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/select_wish_to_delete_tv"
+            app:strokeWidth="0dp">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <ImageView
+                    android:id="@+id/wish_not_exists_iv"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:src="@drawable/ic_teum_char_sleep_sv"
+                    app:layout_constraintBottom_toTopOf="@id/wish_not_exists_tv"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/wish_not_exists_tv"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/noto_sans_kr_medium"
+                    android:includeFontPadding="false"
+                    android:text="등록해 놓은 위시가 없어요"
+                    android:textColor="@color/teumteum_gray"
+                    android:textSize="15sp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/wish_not_exists_iv" />
+
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.google.android.material.card.MaterialCardView>
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <LinearLayout

--- a/app/src/main/res/layout/fragment_wishlist_edit.xml
+++ b/app/src/main/res/layout/fragment_wishlist_edit.xml
@@ -131,7 +131,7 @@
         android:layout_gravity="bottom"
         android:background="@color/white"
         android:orientation="horizontal"
-        android:padding="10dp"
+        android:padding="14dp"
         android:weightSum="2">
 
         <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/layout/item_day_cell.xml
+++ b/app/src/main/res/layout/item_day_cell.xml
@@ -1,15 +1,16 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="0dp"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginVertical="4dp"
+    android:layout_marginVertical="8dp"
+    android:paddingHorizontal="10.5dp"
     android:orientation="vertical"
     android:gravity="center"
     android:layout_weight="1">
 
     <TextView
         android:id="@+id/day_text"
-        android:layout_width="35dp"
-        android:layout_height="35dp"
+        android:layout_width="30dp"
+        android:layout_height="30dp"
         android:layout_gravity="center"
         android:gravity="center"
         android:text="1"

--- a/app/src/main/res/layout/item_day_cell.xml
+++ b/app/src/main/res/layout/item_day_cell.xml
@@ -24,7 +24,7 @@
         android:id="@+id/dot_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
+        android:layout_marginTop="6dp"
         android:layout_gravity="center_horizontal|bottom"
         android:src="@drawable/dot_schedule_exists"
         android:visibility="gone" />

--- a/app/src/main/res/layout/item_day_cell.xml
+++ b/app/src/main/res/layout/item_day_cell.xml
@@ -1,10 +1,10 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
+    android:layout_width="0dp"
     android:layout_height="wrap_content"
     android:layout_marginVertical="4dp"
-    android:layout_marginHorizontal="4dp"
     android:orientation="vertical"
-    android:layout_columnWeight="1">
+    android:gravity="center"
+    android:layout_weight="1">
 
     <TextView
         android:id="@+id/day_text"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="day_of_week_tv">
-        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_width">0dp</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:textSize">12sp</item>
         <item name="android:layout_weight">1</item>
@@ -11,12 +11,10 @@
     </style>
 
     <style name="calendar_date_layout">
-        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_width">0dp</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:gravity">center</item>
         <item name="android:layout_weight">1</item>
-        <item name="android:layout_marginStart">-5dp</item>
-        <item name="android:layout_marginEnd">-2dp</item>
         <item name="android:orientation">vertical</item>
         <item name="android:textColor">@color/text_primary</item>
     </style>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -20,26 +20,14 @@
     </style>
 
     <style name="calendar_date_tv">
-        <item name="android:layout_width">35dp</item>
-        <item name="android:layout_height">35dp</item>
+        <item name="android:layout_width">30dp</item>
+        <item name="android:layout_height">30dp</item>
         <item name="android:gravity">center</item>
         <item name="android:layout_gravity">center</item>
         <item name="android:textAlignment">center</item>
         <item name="android:textSize">12sp</item>
         <item name="android:textColor">@color/text_primary</item>
         <item name="android:fontFamily">@font/noto_sans_kr_regular</item>
-    </style>
-
-    <style name="CalendarToggleTextStyle">
-        <item name="android:layout_width">60dp</item>
-        <item name="android:layout_height">30dp</item>
-        <item name="android:gravity">center</item>
-        <item name="android:paddingStart">16dp</item>
-        <item name="android:paddingEnd">16dp</item>
-        <item name="android:textSize">12sp</item>
-        <item name="android:minWidth">64dp</item>
-        <item name="android:background">?attr/selectableItemBackground</item>
-        <item name="android:textStyle">bold</item>
     </style>
 
     <style name="TopRoundedCard" parent="">


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #92 

## ✨ 작업 내용 + 기타 참고 사항
위시리스트 화면에 컴포넌트 추가한 것 외에 캘린더 ui 일부 수정하였습니다.

ex) 등록한 위시가 존재하지 않는 상태에서 시간이 20m인 위시를 등록한 경우, "전체"와 "20m" 시간칩에서만 해당 위시가 조회되고 나머지 시간칩에서는 컴포넌트가 뜨는게 정상입니다.

캘린더 ui에서는 텍스트 크기와 간격, 그리고 예를 들어 7월 27일~8월 2일 기간에 오늘 날짜가 7월 29일인데 금요일 기준으로 날짜 계산하여 회색 텍스트 처리하였던 부분 수정하였습니다. -> 즉, 오늘 날짜가 7월에 해당하면 8월 날짜 텍스트를 회색 처리, 8월에 해당하면 7월 날짜 텍스트를 회색 처리. 이부분은 테스트해봐야 알 수 있을 것 같습니다.

+) 오늘 날짜가 7월 29일이기 때문에 처음 ui에만 2025년 7월이라고 표시되고 다른 주로 캘린더를 넘겼다가 다시 돌아오면 2025년 8월이라고 표시되는 문제가 있는데.. 다음에 수정해보겠습니다.

++) 위시리스트 편집 화면에서 위시를 삭제했는데 삭제했던 위시가 잠깐 보이는 버그가 있는 것 같습니다. 다른 분들도 동일한 문제를 겪으신 적 있을까요?

### 투두 바텀시트 토글 부분 수정 중입니다 pr 확인하지 말아주세요!!!

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 등록한 위시가 없을 때 관련 컴포넌트가 뜨는지(필터링했을때도 위시가 존재하지 않으면 컴포넌트가 떠야함.)
- [x] 캘린더 ui 확인하기

## 📸 스크린샷 (선택)
- 등록한 위시가 없을 때 뜨는 컴포넌트
<img width="373" height="805" alt="image" src="https://github.com/user-attachments/assets/24b572b3-1220-40b4-9c86-bac8387254d1" />

- 시간이 1h인 위시를 등록한 경우
<img width="370" height="801" alt="image" src="https://github.com/user-attachments/assets/6a3bcfb0-7023-472e-aa97-5ac4ea246ede" />
<img width="373" height="800" alt="image" src="https://github.com/user-attachments/assets/a3ee8e49-977c-4b2d-b4d8-e12ab8bc030f" />

- 다른 시간칩에서는 조회되지 않는게 정상(ex. 10m 시간칩)
<img width="375" height="801" alt="image" src="https://github.com/user-attachments/assets/bd5b50d9-b060-4ec9-92f1-57a7ba5308ea" />


- 캘린더 ui 일부 수정(수정 전 캘린더와 비교하면 날짜 텍스트 크기 등이 작아진 것을 알 수 있는데 아직 수정 필요합니다. 보라색 배경 크기가 더 작아야한다거나.. -> 주별캘린더 보라색 원 위치가 살짝 이상한데 나중에 수정하겠습니다 ㅜ)
<img width="370" height="802" alt="image" src="https://github.com/user-attachments/assets/0f7f1bbe-0a31-4657-bbb8-438887b7b54a" />
<img width="370" height="798" alt="image" src="https://github.com/user-attachments/assets/b60e5fa3-1972-4ba9-bf90-969211cee156" />


아래의 이미지가 아마도 수정 전 캘린더?
<img width="390" height="830" alt="image" src="https://github.com/user-attachments/assets/62b41c88-f6a5-42d1-9c35-80fbcd74a193" />