### PR TITLE
[Feat/#93] 온보딩 닉네임, 직종 입력 API 연동

### DIFF
--- a/app/src/main/java/com/example/teumteum/data/remote/onboarding/OnBoardingRetrofitInterface.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/onboarding/OnBoardingRetrofitInterface.kt
@@ -1,0 +1,13 @@
+package com.example.teumteum.data.remote.onboarding
+
+import com.example.teumteum.data.remote.onboarding.dto.NicknameJobRequest
+import com.example.teumteum.data.remote.onboarding.dto.NicknameJobResponse
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface OnBoardingRetrofitInterface {
+    @POST("/api/users/onboarding/nickname-job")
+    fun postNicknameAndJobField(@Body request: NicknameJobRequest): Call<NicknameJobResponse>
+
+}

--- a/app/src/main/java/com/example/teumteum/data/remote/onboarding/OnBoardingService.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/onboarding/OnBoardingService.kt
@@ -1,0 +1,53 @@
+package com.example.teumteum.data.remote.onboarding
+
+import android.util.Log
+import com.example.teumteum.data.remote.onboarding.dto.NicknameJobRequest
+import com.example.teumteum.data.remote.onboarding.dto.NicknameJobResponse
+import com.example.teumteum.data.remote.wish.WishRetrofitInterface
+import com.example.teumteum.data.remote.wish.dto.RegisterWishRequest
+import com.example.teumteum.data.remote.wish.dto.RegisterWishResponse
+import com.example.teumteum.ui.signup.view.NicknameJobFieldView
+import com.example.teumteum.utils.getRetrofitWithToken
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import kotlin.jvm.java
+
+class OnBoardingService {
+
+    private lateinit var nicknameJobFieldView: NicknameJobFieldView
+
+    fun setNicknameJobFieldView(nicknameJobFieldView: NicknameJobFieldView) {
+        this.nicknameJobFieldView = nicknameJobFieldView
+    }
+
+    //온보딩 : 닉네임, 직종 입력
+    fun postNicknameAndJobField(request: NicknameJobRequest) {
+        val nicknameJobApi = getRetrofitWithToken().create(OnBoardingRetrofitInterface::class.java)
+        val call = nicknameJobApi.postNicknameAndJobField(request)
+
+        call.enqueue(object : Callback<NicknameJobResponse> {
+            override fun onResponse(
+                call: Call<NicknameJobResponse>,
+                response: Response<NicknameJobResponse>
+            ) {
+                if(response.isSuccessful) {
+                    val body = response.body()
+                    if(body != null && body.code == "ONBOARDING2002") {
+                        nicknameJobFieldView.onNicknameJobSuccess(body.code)
+                    } else {
+                        nicknameJobFieldView.onNicknameJobFailure(body?.code ?: "UNKNOWN", body?.message)
+                    }
+                } else {
+                    nicknameJobFieldView.onNicknameJobFailure("HTTP_${response.code()}", response.errorBody()?.string())
+                }
+            }
+
+            override fun onFailure(call: Call<NicknameJobResponse>, t: Throwable) {
+                nicknameJobFieldView.onNicknameJobFailure("NETWORK_ERROR", t.localizedMessage)
+            }
+
+        })
+
+    }
+}

--- a/app/src/main/java/com/example/teumteum/data/remote/onboarding/dto/NicknameJobRequest.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/onboarding/dto/NicknameJobRequest.kt
@@ -1,0 +1,8 @@
+package com.example.teumteum.data.remote.onboarding.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class NicknameJobRequest(
+    @SerializedName("nickname") val nickname: String,
+    @SerializedName("jobField") val jobField: String
+)

--- a/app/src/main/java/com/example/teumteum/data/remote/onboarding/dto/NicknameJobResponse.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/onboarding/dto/NicknameJobResponse.kt
@@ -1,0 +1,9 @@
+package com.example.teumteum.data.remote.onboarding.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class NicknameJobResponse(
+    @SerializedName("isSuccess") val isSuccess: String,
+    @SerializedName("code") val code: String,
+    @SerializedName("message") val message: String,
+)

--- a/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingNicknameFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingNicknameFragment.kt
@@ -50,9 +50,20 @@ class OnBoardingNicknameFragment : Fragment(), NicknameJobFieldView {
             binding.nicknameErrorTv.visibility = View.VISIBLE
         }
 
-        //온보딩 단계가 아닐 경우
+        //온보딩 단계가 아닐 경우 - 이후 테스트를 위해 화면 이동하도록 구현
         if (message?.contains("ONBOARDING4001") == true) {
             Toast.makeText(requireContext(), "온보딩 단계가 아닙니다.", Toast.LENGTH_SHORT).show()
+
+            val fragment = OnBoardingProfileFragment().apply {
+                arguments = Bundle().apply {
+                    putString("nickname", binding.nicknameEt.text.toString())
+                }
+            }
+
+            parentFragmentManager.beginTransaction()
+                .replace(R.id.fragment_container, fragment)
+                .addToBackStack(null)
+                .commit()
         }
     }
 

--- a/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingNicknameFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingNicknameFragment.kt
@@ -50,8 +50,9 @@ class OnBoardingNicknameFragment : Fragment(), NicknameJobFieldView {
             binding.nicknameErrorTv.visibility = View.VISIBLE
         }
 
+        //온보딩 단계가 아닐 경우
         if (message?.contains("ONBOARDING4001") == true) {
-            binding.nicknameErrorTv.visibility = View.VISIBLE
+            Toast.makeText(requireContext(), "온보딩 단계가 아닙니다.", Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingNicknameFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingNicknameFragment.kt
@@ -1,19 +1,59 @@
 package com.example.teumteum.ui.signup
 
+import android.R.attr.fragment
 import android.graphics.Color
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
+import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import com.example.teumteum.R
+import com.example.teumteum.data.remote.onboarding.OnBoardingService
+import com.example.teumteum.data.remote.onboarding.dto.NicknameJobRequest
 import com.example.teumteum.databinding.FragmentOnBoardingNicknameBinding
+import com.example.teumteum.ui.signup.view.NicknameJobFieldView
 
-class OnBoardingNicknameFragment : Fragment() {
+class OnBoardingNicknameFragment : Fragment(), NicknameJobFieldView {
 
     private lateinit var binding: FragmentOnBoardingNicknameBinding
+
+    override fun onNicknameJobSuccess(code: String) {
+        val msg = "닉네임, 직종 입력 성공 (code: $code)"
+        Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
+        Log.d("NICKNAME_FRAGMENT", msg)
+
+        binding.nicknameErrorTv.visibility = View.INVISIBLE
+
+        val fragment = OnBoardingProfileFragment().apply {
+            arguments = Bundle().apply {
+                putString("nickname", binding.nicknameEt.text.toString())
+            }
+        }
+
+        parentFragmentManager.beginTransaction()
+                .replace(R.id.fragment_container, fragment)
+                .addToBackStack(null)
+                .commit()
+    }
+
+    override fun onNicknameJobFailure(code: String, message: String?) {
+        val msg = "닉네임 직종 입력 실패 (code: $code, message: ${message ?: "없음"})"
+        Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
+        Log.e("NICKNAME_FRAGMENT", msg)
+
+        //닉네임 중복
+        if (message?.contains("ONBOARDING4091") == true) {
+            binding.nicknameErrorTv.visibility = View.VISIBLE
+        }
+
+        if (message?.contains("ONBOARDING4001") == true) {
+            binding.nicknameErrorTv.visibility = View.VISIBLE
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -32,16 +72,21 @@ class OnBoardingNicknameFragment : Fragment() {
         (activity as? SignUpActivity)?.setProgressBar(20)
 
         binding.nextBtn.setOnClickListener {
-            val fragment = OnBoardingProfileFragment().apply {
-                arguments = Bundle().apply {
-                    putString("nickname", binding.nicknameEt.text.toString())
-                }
-            }
+//            val fragment = OnBoardingProfileFragment().apply {
+//                arguments = Bundle().apply {
+//                    putString("nickname", binding.nicknameEt.text.toString())
+//                }
+//            }
 
-            parentFragmentManager.beginTransaction()
-                .replace(R.id.fragment_container, fragment)
-                .addToBackStack(null)
-                .commit()
+            val request = getNicknameJobRequest()
+            val agreementService = OnBoardingService()
+            agreementService.setNicknameJobFieldView(this)
+            agreementService.postNicknameAndJobField(request)
+
+//            parentFragmentManager.beginTransaction()
+//                .replace(R.id.fragment_container, fragment)
+//                .addToBackStack(null)
+//                .commit()
         }
 
         binding.nicknameClearBtn.setOnClickListener {
@@ -51,34 +96,34 @@ class OnBoardingNicknameFragment : Fragment() {
             binding.fieldEt.setText("")
         }
 
-        binding.nicknameEt.addTextChangedListener(object: TextWatcher{
-            //텍스트 변경 전 호출
-            override fun beforeTextChanged(
-                s: CharSequence?,
-                start: Int,
-                count: Int,
-                after: Int
-            ) {
-                //Todo: 닉네임 중복 검사
-            }
-
-            override fun onTextChanged(
-                s: CharSequence?,
-                start: Int,
-                before: Int,
-                count: Int
-            ) {
-                //Todo: 닉네임 중복 검사
-                updateNextButtonState()
-            }
-
-            override fun afterTextChanged(s: Editable?) {
-
-                //Todo: 닉네임 중복 검사
-                updateNextButtonState()
-            }
-
-        })
+//        binding.nicknameEt.addTextChangedListener(object: TextWatcher{
+//            //텍스트 변경 전 호출
+//            override fun beforeTextChanged(
+//                s: CharSequence?,
+//                start: Int,
+//                count: Int,
+//                after: Int
+//            ) {
+//                //Todo: 닉네임 중복 검사
+//            }
+//
+//            override fun onTextChanged(
+//                s: CharSequence?,
+//                start: Int,
+//                before: Int,
+//                count: Int
+//            ) {
+//                //Todo: 닉네임 중복 검사
+//                updateNextButtonState()
+//            }
+//
+//            override fun afterTextChanged(s: Editable?) {
+//
+//                //Todo: 닉네임 중복 검사
+//                updateNextButtonState()
+//            }
+//
+//        })
 
         binding.fieldEt.addTextChangedListener(object: TextWatcher{
             //텍스트 변경 전 호출
@@ -128,6 +173,13 @@ class OnBoardingNicknameFragment : Fragment() {
                 requireContext().getColor(R.color.white)
             else
                 requireContext().getColor(R.color.black)
+        )
+    }
+
+    private fun getNicknameJobRequest(): NicknameJobRequest{
+        return NicknameJobRequest(
+            nickname = binding.nicknameEt.text.toString(),
+            jobField = binding.fieldEt.text.toString()
         )
     }
 }

--- a/app/src/main/java/com/example/teumteum/ui/signup/view/NicknameJobFieldView.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/view/NicknameJobFieldView.kt
@@ -1,0 +1,6 @@
+package com.example.teumteum.ui.signup.view
+
+interface NicknameJobFieldView {
+    fun onNicknameJobSuccess(code: String)
+    fun onNicknameJobFailure(code: String, message: String?)
+}

--- a/app/src/main/java/com/example/teumteum/utils/NetworkModule.kt
+++ b/app/src/main/java/com/example/teumteum/utils/NetworkModule.kt
@@ -1,6 +1,6 @@
 package com.example.teumteum.utils
 
-import com.example.teumteum.utils.TEMP_ACCESS_TOKEN
+import com.example.teumteum.TEMP_ACCESS_TOKEN
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory

--- a/app/src/main/res/layout/fragment_on_boarding_nickname.xml
+++ b/app/src/main/res/layout/fragment_on_boarding_nickname.xml
@@ -98,7 +98,7 @@
         app:layout_constraintStart_toStartOf="@id/nickname_form"
         android:layout_marginTop="8dp"
         android:layout_marginStart="15dp"
-        android:visibility="visible"
+        android:visibility="invisible"
         />
 
     <TextView


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #93

## ✨ 작업 내용
> 온보딩 닉네임, 직종 입력 API 연동
> - 닉네임이 중복인 경우 중복입니다 메세지 출력
> - 중복이 아니면 다음화면으로 이동
> - 온보딩 단계가 아닐 경우에도 테스트를 위해 다음화면으로 이동하도록 구현

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 닉네임을 "다현"으로 입력했을 때 닉네임 중복 처리가 되는지(BE에서 닉네임이 "다현"인 유저 데이터를 넣어주셨습니다!) 
- [x] 중복되지 않은 닉네임을 입력했을 때 다음화면으로 이동되는지

## 📸 스크린샷 (선택)
> 첫 화면
<img width="289" height="618" alt="image" src="https://github.com/user-attachments/assets/202f6c54-a43b-4fd0-bc91-11ef271dc88d" />

> 닉네임 중복처리 확인
<img width="287" height="612" alt="image" src="https://github.com/user-attachments/assets/459a0f9e-8369-4018-a3c6-d189402d8a71" />

> 중복되지 않은 닉네임 입력
<img width="287" height="614" alt="image" src="https://github.com/user-attachments/assets/529355dd-08d6-42eb-b12b-7b6cb0c099fa" />
<img width="292" height="621" alt="image" src="https://github.com/user-attachments/assets/5fb4e626-ec8c-432b-89b9-dce3c3d63afc" />

> 스웨거에서 마이페이지 조회를 통해 데이터가 잘 입력되었는지 확인할 수 있습니다. 
<img width="954" height="590" alt="image" src="https://github.com/user-attachments/assets/d37a3cb6-7113-4d9b-aadd-725dfb2e0b95" />

## 💬 기타 참고 사항
> x
