### PR TITLE
[Feat/#95] 온보딩 수면패턴 API 연동

### DIFF
--- a/app/src/main/java/com/example/teumteum/data/remote/onboarding/OnBoardingRetrofitInterface.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/onboarding/OnBoardingRetrofitInterface.kt
@@ -2,6 +2,8 @@ package com.example.teumteum.data.remote.onboarding
 
 import com.example.teumteum.data.remote.onboarding.dto.NicknameJobRequest
 import com.example.teumteum.data.remote.onboarding.dto.NicknameJobResponse
+import com.example.teumteum.data.remote.onboarding.dto.SleepPatternRequest
+import com.example.teumteum.data.remote.onboarding.dto.SleepPatternResponse
 import retrofit2.Call
 import retrofit2.http.Body
 import retrofit2.http.POST
@@ -11,4 +13,6 @@ interface OnBoardingRetrofitInterface {
     fun postNicknameAndJobField(@Body request: NicknameJobRequest): Call<NicknameJobResponse>
 
 
+    @POST("/api/users/onboarding/sleep-pattern")
+    fun postSleepPattern(@Body request: SleepPatternRequest): Call<SleepPatternResponse>
 }

--- a/app/src/main/java/com/example/teumteum/data/remote/onboarding/OnBoardingRetrofitInterface.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/onboarding/OnBoardingRetrofitInterface.kt
@@ -10,4 +10,5 @@ interface OnBoardingRetrofitInterface {
     @POST("/api/users/onboarding/nickname-job")
     fun postNicknameAndJobField(@Body request: NicknameJobRequest): Call<NicknameJobResponse>
 
+
 }

--- a/app/src/main/java/com/example/teumteum/data/remote/onboarding/OnBoardingService.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/onboarding/OnBoardingService.kt
@@ -48,6 +48,5 @@ class OnBoardingService {
             }
 
         })
-
     }
 }

--- a/app/src/main/java/com/example/teumteum/data/remote/onboarding/OnBoardingService.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/onboarding/OnBoardingService.kt
@@ -3,10 +3,13 @@ package com.example.teumteum.data.remote.onboarding
 import android.util.Log
 import com.example.teumteum.data.remote.onboarding.dto.NicknameJobRequest
 import com.example.teumteum.data.remote.onboarding.dto.NicknameJobResponse
+import com.example.teumteum.data.remote.onboarding.dto.SleepPatternRequest
+import com.example.teumteum.data.remote.onboarding.dto.SleepPatternResponse
 import com.example.teumteum.data.remote.wish.WishRetrofitInterface
 import com.example.teumteum.data.remote.wish.dto.RegisterWishRequest
 import com.example.teumteum.data.remote.wish.dto.RegisterWishResponse
 import com.example.teumteum.ui.signup.view.NicknameJobFieldView
+import com.example.teumteum.ui.signup.view.SleepPatternView
 import com.example.teumteum.utils.getRetrofitWithToken
 import retrofit2.Call
 import retrofit2.Callback
@@ -16,9 +19,14 @@ import kotlin.jvm.java
 class OnBoardingService {
 
     private lateinit var nicknameJobFieldView: NicknameJobFieldView
+    private lateinit var sleepPatternView: SleepPatternView
 
     fun setNicknameJobFieldView(nicknameJobFieldView: NicknameJobFieldView) {
         this.nicknameJobFieldView = nicknameJobFieldView
+    }
+
+    fun setSleepPatternView(sleepPatternView: SleepPatternView){
+        this.sleepPatternView = sleepPatternView
     }
 
     //온보딩 : 닉네임, 직종 입력
@@ -45,6 +53,37 @@ class OnBoardingService {
 
             override fun onFailure(call: Call<NicknameJobResponse>, t: Throwable) {
                 nicknameJobFieldView.onNicknameJobFailure("NETWORK_ERROR", t.localizedMessage)
+            }
+
+        })
+    }
+
+    //수면패턴 등록
+    fun postSleepPattern(request: SleepPatternRequest) {
+        val sleepPatternApi = getRetrofitWithToken().create(OnBoardingRetrofitInterface::class.java)
+        val call = sleepPatternApi.postSleepPattern(request)
+        Log.d("SLEEP_PATTERN_REQUEST", request.toString())
+
+
+        call.enqueue(object : Callback<SleepPatternResponse> {
+            override fun onResponse(
+                call: Call<SleepPatternResponse>,
+                response: Response<SleepPatternResponse>
+            ) {
+                if(response.isSuccessful) {
+                    val body = response.body()
+                    if(body != null && body.code == "ONBOARDING2003") {
+                        sleepPatternView.onSleepPatternSuccess(body.code)
+                    } else {
+                        sleepPatternView.onSleepPatternFailure(body?.code ?: "UNKNOWN", body?.message)
+                    }
+                } else {
+                    sleepPatternView.onSleepPatternFailure("HTTP_${response.code()}", response.errorBody()?.string())
+                }
+            }
+
+            override fun onFailure(call: Call<SleepPatternResponse>, t: Throwable) {
+                sleepPatternView.onSleepPatternFailure("NETWORK_ERROR", t.localizedMessage)
             }
 
         })

--- a/app/src/main/java/com/example/teumteum/data/remote/onboarding/dto/SleepPatternRequest.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/onboarding/dto/SleepPatternRequest.kt
@@ -4,6 +4,6 @@ import com.google.gson.annotations.SerializedName
 import java.time.LocalTime
 
 data class SleepPatternRequest(
-    @SerializedName("sleepTime") val sleepTime: LocalTime,
-    @SerializedName("wakeTime") val wakeTime: LocalTime
+    @SerializedName("sleepTime") val sleepTime: String,
+    @SerializedName("wakeTime") val wakeTime: String
 )

--- a/app/src/main/java/com/example/teumteum/data/remote/onboarding/dto/SleepPatternRequest.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/onboarding/dto/SleepPatternRequest.kt
@@ -1,0 +1,9 @@
+package com.example.teumteum.data.remote.onboarding.dto
+
+import com.google.gson.annotations.SerializedName
+import java.time.LocalTime
+
+data class SleepPatternRequest(
+    @SerializedName("sleepTime") val sleepTime: LocalTime,
+    @SerializedName("wakeTime") val wakeTime: LocalTime
+)

--- a/app/src/main/java/com/example/teumteum/data/remote/onboarding/dto/SleepPatternResponse.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/onboarding/dto/SleepPatternResponse.kt
@@ -1,0 +1,9 @@
+package com.example.teumteum.data.remote.onboarding.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class SleepPatternResponse(
+    @SerializedName("isSuccess") val isSuccess: Boolean,
+    @SerializedName("code") val code: String,
+    @SerializedName("message") val message: String
+)

--- a/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingNicknameFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingNicknameFragment.kt
@@ -91,9 +91,9 @@ class OnBoardingNicknameFragment : Fragment(), NicknameJobFieldView {
 //            }
 
             val request = getNicknameJobRequest()
-            val agreementService = OnBoardingService()
-            agreementService.setNicknameJobFieldView(this)
-            agreementService.postNicknameAndJobField(request)
+            val onBoardingService = OnBoardingService()
+            onBoardingService.setNicknameJobFieldView(this)
+            onBoardingService.postNicknameAndJobField(request)
 
 //            parentFragmentManager.beginTransaction()
 //                .replace(R.id.fragment_container, fragment)

--- a/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingSleepPatternFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingSleepPatternFragment.kt
@@ -1,7 +1,9 @@
 package com.example.teumteum.ui.signup
 
+import android.R.attr.fragment
 import android.graphics.Color
 import android.os.Bundle
+import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
@@ -9,19 +11,65 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.NumberPicker
 import android.widget.TextView
+import android.widget.Toast
 import com.example.teumteum.R
+import com.example.teumteum.data.remote.onboarding.OnBoardingService
+import com.example.teumteum.data.remote.onboarding.dto.NicknameJobRequest
+import com.example.teumteum.data.remote.onboarding.dto.SleepPatternRequest
 import com.example.teumteum.databinding.FragmentOnBoardingSleepPatternBinding
+import com.example.teumteum.ui.signup.view.SleepPatternView
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import java.time.Duration
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 
-class OnBoardingSleepPatternFragment : Fragment() {
+class OnBoardingSleepPatternFragment : Fragment(), SleepPatternView {
 
     private lateinit var binding: FragmentOnBoardingSleepPatternBinding
 
     private var selectedStartTime: LocalTime? = null
     private var selectedEndTime: LocalTime? = null
+
+    override fun onSleepPatternSuccess(code: String) {
+        val msg = "수면패턴 입력 완료 (code: $code)"
+        Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
+        Log.d("SLEEP_PATTERN_FRAGMENT", msg)
+
+        val fragment = OnBoardingScheduleFragment().apply {
+            arguments = Bundle().apply {
+                selectedStartTime?.let { putString("sleepStart", it.toString()) }
+                selectedEndTime?.let { putString("sleepEnd", it.toString()) }
+            }
+        }
+
+        parentFragmentManager.beginTransaction()
+            .replace(R.id.fragment_container, fragment)
+            .addToBackStack(null)
+            .commit()
+    }
+
+    override fun onSleepPatternFailure(code: String, message: String?) {
+        val msg = "수면 패턴 입력 실패 (code: $code, message: ${message ?: "없음"})"
+        Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
+        Log.e("SLEEP_PATTERN_FRAGMENT", msg)
+
+        //온보딩 단계가 아닐 경우 - 이후 테스트를 위해 화면 이동하도록 구현
+        if (message?.contains("ONBOARDING4001") == true) {
+            Toast.makeText(requireContext(), "온보딩 단계가 아닙니다.", Toast.LENGTH_SHORT).show()
+
+            val fragment = OnBoardingScheduleFragment().apply {
+                arguments = Bundle().apply {
+                    selectedStartTime?.let { putString("sleepStart", it.toString()) }
+                    selectedEndTime?.let { putString("sleepEnd", it.toString()) }
+                }
+            }
+
+            parentFragmentManager.beginTransaction()
+                .replace(R.id.fragment_container, fragment)
+                .addToBackStack(null)
+                .commit()
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -41,17 +89,25 @@ class OnBoardingSleepPatternFragment : Fragment() {
         (activity as? SignUpActivity)?.setProgressBar(60)
 
         binding.nextBtn.setOnClickListener {
-            val fragment = OnBoardingScheduleFragment().apply {
-                arguments = Bundle().apply {
-                    selectedStartTime?.let { putString("sleepStart", it.toString()) }
-                    selectedEndTime?.let { putString("sleepEnd", it.toString()) }
+            //입력 값이 있을 때 만 호출
+            if(selectedStartTime != null && selectedEndTime != null){
+                val request = getSleepPatternRequest()
+                val onBoardingService = OnBoardingService()
+                onBoardingService.setSleepPatternView(this)
+                onBoardingService.postSleepPattern(request)
+            }else{
+                val fragment = OnBoardingScheduleFragment().apply {
+                    arguments = Bundle().apply {
+                        selectedStartTime?.let { putString("sleepStart", it.toString()) }
+                        selectedEndTime?.let { putString("sleepEnd", it.toString()) }
+                    }
                 }
-            }
 
-            parentFragmentManager.beginTransaction()
-                .replace(R.id.fragment_container, fragment)
-                .addToBackStack(null)
-                .commit()
+                parentFragmentManager.beginTransaction()
+                    .replace(R.id.fragment_container, fragment)
+                    .addToBackStack(null)
+                    .commit()
+            }
         }
 
         binding.sleepStartContainer.setOnClickListener {
@@ -179,6 +235,13 @@ class OnBoardingSleepPatternFragment : Fragment() {
                 requireContext().getColor(R.color.white)
             else
                 requireContext().getColor(R.color.black)
+        )
+    }
+
+    private fun getSleepPatternRequest(): SleepPatternRequest{
+        return SleepPatternRequest(
+            sleepTime = selectedStartTime.toString(),
+            wakeTime = selectedEndTime.toString()
         )
     }
 

--- a/app/src/main/java/com/example/teumteum/ui/signup/view/SleepPatternView.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/view/SleepPatternView.kt
@@ -1,0 +1,6 @@
+package com.example.teumteum.ui.signup.view
+
+interface SleepPatternView {
+    fun onSleepPatternSuccess(code: String)
+    fun onSleepPatternFailure(code: String, message: String?)
+}


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #95

## ✨ 작업 내용
> 온보딩 수면패턴 API 연동
> - 선택 입력이기 때문에 입력하지 않으면 API 호출이 안됩니다.
> - 현재 서버에서 Success Code가 ONBOARDING2003으로 되어있는데 변경예정이라고 하셔서 나중에 코드가 변경되면 리팩토링 하려고 합니다.

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 수면 패턴 입력 후 다음으로 버튼 클릭 시 API 호출되는지
- [x] 수면 패틴 미입력 시 API 호출 안하고 넘어가는지
- [x] API 호출 후 데이터가 제대로 들어갔는지 - 스웨거에서 홈화면의 오늘의 빈틈확인 API 사용해보시면 확인할 수 있습니다.

## 📸 스크린샷 (선택)
> 수면 시간 선택
<img width="278" height="595" alt="image" src="https://github.com/user-attachments/assets/1b38c2dd-1d2a-4ebb-b367-0a3c6cb47fd1" />

> 다음으로 버튼 클릭 시
<img width="271" height="589" alt="image" src="https://github.com/user-attachments/assets/75f1c9ec-df61-42cf-980c-456aa32db0d7" />

> 로그 확인
<img width="917" height="32" alt="image" src="https://github.com/user-attachments/assets/d6e9e501-c065-46bf-a0a1-e60ef411ce26" />

> 스웨거에서 오늘의 빈틈확인 API로 수면시간 들어갔는지 확인 (01:00 ~ 06:00 으로 위에서 입력한대로 들어감)
<img width="371" height="629" alt="image" src="https://github.com/user-attachments/assets/6fbbe8af-85d6-4d6d-8431-8c53d6eb134c" />


## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항
