### PR TITLE
[BUG#106] 투두 바텀시트 에러 코드 삭제

### DIFF
--- a/app/src/main/res/layout/fragment_todo_edit.xml
+++ b/app/src/main/res/layout/fragment_todo_edit.xml
@@ -58,8 +58,7 @@
                     android:background="@drawable/calendar_background"
                     android:orientation="vertical"
                     app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintBottom_toTopOf="@id/todo_bottom_bar">
+                    app:layout_constraintStart_toStartOf="parent">
 
                     <EditText
                         android:id="@+id/todo_title_et"

--- a/app/src/main/res/layout/fragment_todo_register.xml
+++ b/app/src/main/res/layout/fragment_todo_register.xml
@@ -71,8 +71,7 @@
                     android:background="@drawable/calendar_background"
                     android:orientation="vertical"
                     app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintBottom_toTopOf="@id/btn_todo_register">
+                    app:layout_constraintStart_toStartOf="parent">
 
                     <EditText
                         android:id="@+id/todo_title_et"


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #106 

## ✨ 작업 내용
기존에 투두/위시 칩 바텀시트 + framelayout 구조로 구현하였다가 변경하게 되면서 선언하지 않은 아이디(todo_bottom_bar 등)를 참조하게 되어 에러가 발생한 것 같습니다.

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 정상적으로 실행되는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항
