### PR TITLE
[FEAT/#115] 친구 사용자 찾기 API 연동

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,6 +72,10 @@ dependencies {
     // 프로필
     implementation ("com.google.android.flexbox:flexbox:3.0.0")
 
+    // profileImageUrl
+    implementation ("com.github.bumptech.glide:glide:4.15.1")
+    kapt ("com.github.bumptech.glide:compiler:4.15.1")
+
 
 
     implementation(libs.androidx.core.ktx)

--- a/app/src/main/java/com/example/teumteum/data/remote/friend/dto/FriendSearchResponse.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/friend/dto/FriendSearchResponse.kt
@@ -1,0 +1,18 @@
+package com.example.teumteum.data.remote.friend.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class FriendSearchResponse(
+    @SerializedName("isSuccess") val isSuccess: Boolean,
+    @SerializedName("code") val code: String,
+    @SerializedName("message") val message: String,
+    @SerializedName("result") val result: List<FriendSearchResult>?
+)
+
+data class FriendSearchResult(
+    @SerializedName("userId") val userId: Int,
+    @SerializedName("nickname") val nickname: String,
+    @SerializedName("profileImageUrl") val profileImageUrl: String,
+    @SerializedName("job") val job: String
+)
+

--- a/app/src/main/java/com/example/teumteum/data/remote/friend/dto/FriendSearchService.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/friend/dto/FriendSearchService.kt
@@ -1,0 +1,53 @@
+package com.example.teumteum.data.remote.friend.dto
+
+import com.example.teumteum.data.remote.friend.search.FriendSearchRetrofitInterface
+import com.example.teumteum.ui.friend.view.FriendSearchView
+import com.example.teumteum.utils.getRetrofitWithToken
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+class FriendSearchService {
+
+    private lateinit var friendSearchView: FriendSearchView
+
+    fun setFriendSearchView(friendSearchView: FriendSearchView) {
+        this.friendSearchView = friendSearchView
+    }
+
+    fun searchUser(nickname: String) {
+        val friendSearchApi = getRetrofitWithToken().create(FriendSearchRetrofitInterface::class.java)
+        val call = friendSearchApi.searchUserByNickname(nickname)
+
+        call.enqueue(object : Callback<FriendSearchResponse> {
+            override fun onResponse(
+                call: Call<FriendSearchResponse>,
+                response: Response<FriendSearchResponse>
+            ) {
+                if (response.isSuccessful) {
+                    val body = response.body()
+                    if (body?.isSuccess == true && body.result != null) {
+                        friendSearchView.onSearchSuccess(body.result)
+                    } else {
+                        friendSearchView.onSearchFailure(
+                            body?.code ?: "UNKNOWN",
+                            body?.message ?: "에러 메시지 없음"
+                        )
+                    }
+                } else {
+                    friendSearchView.onSearchFailure(
+                        "HTTP_${response.code()}",
+                        response.errorBody()?.string() ?: "서버 응답 오류"
+                    )
+                }
+            }
+
+            override fun onFailure(call: Call<FriendSearchResponse>, t: Throwable) {
+                friendSearchView.onSearchFailure(
+                    "NETWORK_ERROR",
+                    t.localizedMessage ?: "알 수 없는 네트워크 오류"
+                )
+            }
+        })
+    }
+}

--- a/app/src/main/java/com/example/teumteum/data/remote/friend/search/FriendSearchRetrofitInterface.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/friend/search/FriendSearchRetrofitInterface.kt
@@ -1,0 +1,12 @@
+package com.example.teumteum.data.remote.friend.search
+
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.Query
+import com.example.teumteum.data.remote.friend.dto.FriendSearchResponse
+
+interface FriendSearchRetrofitInterface {
+    @GET("/api/users/search")
+    fun searchUserByNickname(@Query("keyword") nickname: String): Call<FriendSearchResponse>
+
+}

--- a/app/src/main/java/com/example/teumteum/ui/friend/FollowUsuer.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FollowUsuer.kt
@@ -1,7 +1,0 @@
-package com.example.teumteum.ui.friend
-
-data class FollowUser(
-    val name: String,
-    val job: String,
-    var isFavorite: Boolean = false
-)

--- a/app/src/main/java/com/example/teumteum/ui/friend/Friend01SearchFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/Friend01SearchFragment.kt
@@ -63,9 +63,22 @@ class Friend01SearchFragment : Fragment() {
             if (isSearchAction || isEnterKey) {
                 val keyword = binding.searchEditText.text.toString().trim()
                 if (keyword.isNotEmpty()) {
+                    // 1. 최근 검색어 추가
                     recentKeywords.add(keyword)
                     binding.searchEditText.text.clear()
                     updateSearchList()
+
+                    // 2. 검색 결과 프래그먼트로 이동
+                    val bundle = Bundle().apply {
+                        putString("searchKeyword", keyword)
+                    }
+                    val fragment = Friend01SearchResultFragment()
+                    fragment.arguments = bundle
+
+                    parentFragmentManager.beginTransaction()
+                        .replace(R.id.main_frm, fragment)
+                        .addToBackStack(null)
+                        .commit()
                 }
                 true
             } else {
@@ -92,7 +105,7 @@ class Friend01SearchFragment : Fragment() {
 
             binding.recentSearchList.addView(textView)
 
-            // ✅ 항상 선 추가 (마지막 항목도 포함)
+            //  항상 선 추가 (마지막 항목도 포함)
             val dividerHeightPx = (1.2 * resources.displayMetrics.density).toInt().coerceAtLeast(1)
             val divider = View(requireContext()).apply {
                 layoutParams = LinearLayout.LayoutParams(

--- a/app/src/main/java/com/example/teumteum/ui/friend/Friend01SearchResultFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/Friend01SearchResultFragment.kt
@@ -1,0 +1,109 @@
+package com.example.teumteum.ui.friend
+
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.example.teumteum.R
+import com.example.teumteum.data.remote.friend.dto.FriendSearchResult
+import com.example.teumteum.data.remote.friend.dto.FriendSearchService
+import com.example.teumteum.databinding.FragmentFriend01SearchResultBinding
+import com.example.teumteum.ui.friend.adapter.SearchResultAdapter
+import com.example.teumteum.ui.friend.view.FriendSearchView
+import com.example.teumteum.ui.main.MainActivity
+
+class Friend01SearchResultFragment : Fragment(), FriendSearchView {
+
+    private var _binding: FragmentFriend01SearchResultBinding? = null
+    private val binding get() = _binding!!
+
+    private lateinit var adapter: SearchResultAdapter
+    private lateinit var service: FriendSearchService
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentFriend01SearchResultBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        (activity as? MainActivity)?.hideBottomBar()
+
+        val keyword = arguments?.getString("searchKeyword") ?: return
+
+        // RecyclerView 초기화
+        adapter = SearchResultAdapter(emptyList()) { userId ->
+            navigateToProfile(userId)
+        }
+
+        binding.searchResultRecyclerView.layoutManager = LinearLayoutManager(requireContext())
+        binding.searchResultRecyclerView.adapter = adapter
+
+        // 검색 서비스 실행
+        service = FriendSearchService()
+        service.setFriendSearchView(this)
+        service.searchUser(keyword)
+
+        binding.backButton.setOnClickListener {
+            parentFragmentManager.popBackStack()
+        }
+    }
+
+    override fun onSearchSuccess(result: List<FriendSearchResult>) {
+        if (result.isEmpty()) {
+            val msg = "사용자 검색 실패 (code: USER4040, message: 존재하지 않는 사용자입니다.)"
+            Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
+            Log.e("SEARCH_RESULT_FRAGMENT", msg)
+            return
+        }
+
+        val msg = "사용자 검색 성공 (code: USER2000)"
+        Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
+        Log.d("SEARCH_RESULT_FRAGMENT", msg)
+
+        adapter = SearchResultAdapter(result) { userId ->
+            navigateToProfile(userId)
+        }
+        binding.searchResultRecyclerView.adapter = adapter
+    }
+
+    override fun onSearchFailure(code: String, message: String) {
+        val errorMsg = when (code) {
+            "USER4040" -> "사용자 검색 실패 (code: $code, message: 존재하지 않는 사용자입니다.)"
+            "NETWORK_ERROR" -> "사용자 검색 실패 (code: $code, message: 네트워크 오류)"
+            else -> "사용자 검색 실패 (code: $code, message: $message)"
+        }
+
+        Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+        Log.e("SEARCH_RESULT_FRAGMENT", errorMsg)
+    }
+
+
+    // 프로필 선택 시 FriendProfileFollowFragment로 이동
+    private fun navigateToProfile(userId: Int) {
+        val fragment = FriendProfileFollowFragment().apply {
+            arguments = Bundle().apply {
+                putInt("userId", userId)
+            }
+        }
+
+        parentFragmentManager.beginTransaction()
+            .replace(R.id.main_frm, fragment)
+            .addToBackStack(null)
+            .commit()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendFragment.kt
@@ -13,6 +13,8 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.teumteum.R
 import com.example.teumteum.databinding.FragmentFriendBinding
 import com.example.teumteum.ui.friend.adapter.FollowerAdapter
+import com.example.teumteum.ui.friend.RecommendAdapter
+import com.example.teumteum.ui.friend.adapter.FollowingAdapter
 import com.example.teumteum.ui.friend.data.FollowerData
 import com.example.teumteum.ui.main.MainActivity
 
@@ -68,7 +70,6 @@ class FriendFragment : Fragment() {
                 .commit()
         }
 
-        // 틈 요청 기록 화면으로 이동
         binding.btnAlarm.setOnClickListener {
             parentFragmentManager.beginTransaction()
                 .replace(R.id.main_frm, FriendTeumRequestFragment())
@@ -87,22 +88,17 @@ class FriendFragment : Fragment() {
                 .commit()
         }
 
-        val dummyFollowingList = listOf(
-            FollowUser("문혜원", "UX 디자이너"),
-            FollowUser("하수연", "UX 디자이너"),
-            FollowUser("장채미", "UX 디자이너"),
-            FollowUser("이솔민", "UX 디자이너"),
-            FollowUser("이솔", "UX 디자이너"),
-            FollowUser("이솔", "UX 디자이너"),
-            FollowUser("이솔", "UX 디자이너")
-        )
-
-        // Adapter에 프로필 클릭/비행기 클릭 콜백 전달
+        // API 연결 후 서버에서 받아온 데이터로 이 부분 수정 필요
         val followingAdapter = FollowingAdapter(
-            data = dummyFollowingList,
+            data = emptyList(),
             onProfileClick = { user ->
+                val fragment = FriendProfileFollowFragment().apply {
+                    arguments = Bundle().apply {
+                        putInt("userId", user.userId)
+                    }
+                }
                 parentFragmentManager.beginTransaction()
-                    .replace(R.id.main_frm, FriendProfileFollowFragment())
+                    .replace(R.id.main_frm, fragment)
                     .addToBackStack(null)
                     .commit()
             },
@@ -114,20 +110,10 @@ class FriendFragment : Fragment() {
             }
         )
 
-        // 팔로우 예시
-        val followerList = listOf(
-            FollowerData("홍길동", "UX 디자이너", R.drawable.gray_teum),
-            FollowerData("김영희", "기획자", R.drawable.gray_teum),
-            FollowerData("이준호", "iOS 개발자", R.drawable.gray_teum)
-        )
+        val followerAdapter = FollowerAdapter(emptyList())
 
-        // 팔로우
-        val followerAdapter = FollowerAdapter(followerList)
         binding.followerRecyclerView.adapter = followerAdapter
-        // ✅ 이 줄이 있어야 리스트가 정상적으로 출력됩니다!
         binding.followerRecyclerView.layoutManager = LinearLayoutManager(requireContext())
-
-
 
         binding.followingRecyclerView.apply {
             layoutManager = LinearLayoutManager(requireContext())
@@ -135,11 +121,8 @@ class FriendFragment : Fragment() {
         }
 
         binding.tabFollowing.setOnClickListener {
-            // 탭 색상 변경
-            binding.tabFollowing.setTextColor(Color.parseColor("#0F0F0F"))  // 진하게
-            binding.tabFollower.setTextColor(Color.parseColor("#B1B2B3"))  // 연하게
-
-            // 리스트 전환
+            binding.tabFollowing.setTextColor(Color.parseColor("#0F0F0F"))
+            binding.tabFollower.setTextColor(Color.parseColor("#B1B2B3"))
             binding.followingRecyclerView.visibility = View.VISIBLE
             binding.followerRecyclerView.visibility = View.GONE
         }
@@ -147,11 +130,9 @@ class FriendFragment : Fragment() {
         binding.tabFollower.setOnClickListener {
             binding.tabFollowing.setTextColor(Color.parseColor("#B1B2B3"))
             binding.tabFollower.setTextColor(Color.parseColor("#0F0F0F"))
-
             binding.followingRecyclerView.visibility = View.GONE
             binding.followerRecyclerView.visibility = View.VISIBLE
         }
-
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/example/teumteum/ui/friend/adapter/FollowingAdapter.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/adapter/FollowingAdapter.kt
@@ -1,4 +1,4 @@
-package com.example.teumteum.ui.friend
+package com.example.teumteum.ui.friend.adapter
 
 import android.view.LayoutInflater
 import android.view.View
@@ -7,11 +7,12 @@ import android.widget.ImageButton
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.example.teumteum.R
+import com.example.teumteum.ui.friend.data.FollowData
 
 class FollowingAdapter(
-    private val data: List<FollowUser>,
-    private val onProfileClick: (FollowUser) -> Unit,
-    private val onSendClick: (FollowUser) -> Unit  //  추가: sendBtn 클릭용 콜백
+    private val data: List<FollowData>,
+    private val onProfileClick: (FollowData) -> Unit,
+    private val onSendClick: (FollowData) -> Unit  //  추가: sendBtn 클릭용 콜백
 ) : RecyclerView.Adapter<FollowingAdapter.ViewHolder>() {
 
     inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
@@ -21,18 +22,20 @@ class FollowingAdapter(
         private val profileBtn: ImageButton = itemView.findViewById(R.id.profileLayout)
         private val sendBtn: ImageButton = itemView.findViewById(R.id.sendBtn) //  추가
 
-        fun bind(user: FollowUser) {
+        fun bind(user: FollowData) {
             // 이름/직업 세팅
             nameTv.text = user.name
-            jobTv.text = " · ${user.job}"
+            jobTv.text = " · ${user.field}"
 
             // 별 아이콘 토글
             starIv.setImageResource(
-                if (user.isFavorite) R.drawable.friend01_fill_star
+                if (user.favorite) R.drawable.friend01_fill_star
                 else R.drawable.friend01_star
             )
+
+            // 즐겨찾기 토글
             starIv.setOnClickListener {
-                user.isFavorite = !user.isFavorite
+                user.favorite = !user.favorite
                 notifyItemChanged(adapterPosition)
             }
 

--- a/app/src/main/java/com/example/teumteum/ui/friend/adapter/SearchResultAdapter.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/adapter/SearchResultAdapter.kt
@@ -1,0 +1,55 @@
+package com.example.teumteum.ui.friend.adapter
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageButton
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.example.teumteum.R
+import com.example.teumteum.data.remote.friend.dto.FriendSearchResult
+import com.google.android.material.imageview.ShapeableImageView
+
+class SearchResultAdapter(
+    private val results: List<FriendSearchResult>,
+    private val onItemClick: (userId: Int) -> Unit
+) : RecyclerView.Adapter<SearchResultAdapter.ViewHolder>() {
+
+    inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val profileImage: ShapeableImageView = itemView.findViewById(R.id.profileLayout)
+        private val nameText: TextView = itemView.findViewById(R.id.nameTv)
+        private val jobText: TextView = itemView.findViewById(R.id.jobTv)
+
+        fun bind(item: FriendSearchResult) {
+            nameText.text = item.nickname
+            jobText.text = " · ${item.job}"
+
+            Glide.with(itemView.context)
+                .load(item.profileImageUrl)
+                .placeholder(R.drawable.gray_teum)
+                .error(R.drawable.gray_teum)
+                .into(profileImage)
+
+            itemView.setOnClickListener {
+                onItemClick(item.userId)
+            }
+
+            profileImage.setOnClickListener {
+                onItemClick(item.userId)
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_search_user, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(results[position])
+    }
+
+    override fun getItemCount(): Int = results.size
+}

--- a/app/src/main/java/com/example/teumteum/ui/friend/data/FollowData.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/data/FollowData.kt
@@ -1,0 +1,10 @@
+package com.example.teumteum.ui.friend.data
+
+data class FollowData(
+    val userId: Int,
+    val name: String,
+    val profileImageUrl: String,
+    val field: String,
+    val following: Boolean,
+    var favorite: Boolean
+)

--- a/app/src/main/java/com/example/teumteum/ui/friend/view/FriendSearchView.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/view/FriendSearchView.kt
@@ -1,0 +1,8 @@
+package com.example.teumteum.ui.friend.view
+
+import com.example.teumteum.data.remote.friend.dto.FriendSearchResult
+
+interface FriendSearchView {
+    fun onSearchSuccess(result: List<FriendSearchResult>)
+    fun onSearchFailure(code: String, message: String)
+}

--- a/app/src/main/res/layout/fragment_friend01_search_result.xml
+++ b/app/src/main/res/layout/fragment_friend01_search_result.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white">
+
+    <!-- 상단 뒤로가기 + 검색창 -->
+    <LinearLayout
+        android:id="@+id/searchBarLayout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="58dp"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <ImageButton
+            android:id="@+id/backButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:background="@android:color/transparent"
+            android:src="@drawable/ic_arrow_back"
+            android:scaleType="centerInside" />
+
+        <EditText
+            android:id="@+id/searchEditText"
+            android:layout_width="0dp"
+            android:layout_height="50dp"
+            android:layout_weight="1"
+            android:layout_marginStart="12dp"
+            android:layout_marginEnd="20dp"
+            android:includeFontPadding="false"
+            android:lineSpacingExtra="0dp"
+            android:background="@drawable/friend_search_edittext_bg"
+            android:hint="닉네임을 입력하세요."
+            android:drawableStart="@drawable/friend01_search"
+            android:drawablePadding="8dp"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:textSize="14sp"
+            android:singleLine="true"
+            android:imeOptions="actionSearch" />
+    </LinearLayout>
+
+    <!-- 최근 검색어 -->
+    <LinearLayout
+        android:id="@+id/recentSearchLayout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintTop_toBottomOf="@id/searchBarLayout"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="24dp"
+            android:text="검색 결과"
+            android:textSize="14sp"
+            android:textColor="#788084"
+            android:fontFamily="@font/noto_sans_kr_regular"/>
+
+        <Button
+            android:id="@+id/btnDeleteRecent"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="48dp"
+            android:layout_marginEnd="14dp"
+            android:text="삭제"
+            android:paddingStart="8dp"
+            android:paddingEnd="8dp"
+            android:textColor="#788084"
+            android:textSize="14sp"
+            android:fontFamily="@font/noto_sans_kr_regular"
+            android:background="@android:color/transparent"
+            android:gravity="center_vertical"/>
+    </LinearLayout>
+
+    <!-- 최근 검색어 아래 구분선 -->
+    <View
+        android:id="@+id/dividerView"
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:layout_marginStart="20dp"
+        android:layout_marginEnd="20dp"
+        android:layout_marginTop="-9dp"
+        android:background="#EAEAEA"
+        app:layout_constraintTop_toBottomOf="@id/recentSearchLayout"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+
+    <!-- 검색 결과 RecyclerView -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/searchResultRecyclerView"
+        android:layout_width="0dp"
+        android:layout_height="700dp"
+        android:layout_marginStart="17dp"
+        android:layout_marginEnd="20dp"
+        android:layout_marginTop="10dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/dividerView" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_search_user.xml
+++ b/app/src/main/res/layout/item_search_user.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="horizontal"
+    android:padding="12dp"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <com.google.android.material.imageview.ShapeableImageView
+        android:id="@+id/profileLayout"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:background="@color/gray"
+        android:scaleType="centerCrop"
+        app:shapeAppearanceOverlay="@style/CircleImage" />
+
+    <!-- 이름 + 직업 -->
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <TextView
+            android:id="@+id/nameTv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="이름"
+            android:layout_marginStart="11dp"
+            android:textSize="16sp"
+            android:textColor="#0F0F0F"
+            android:fontFamily="@font/noto_sans_kr_medium" />
+
+        <TextView
+            android:id="@+id/jobTv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text=" · UX디자이너"
+            android:textSize="16sp"
+            android:textColor="#D3D3D3"
+            android:layout_marginStart="8dp"
+            android:fontFamily="@font/noto_sans_kr_medium" />
+    </LinearLayout>
+</LinearLayout>


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #115

## ✨ 작업 내용
>
이 화면 추가되었습니다
 <img width="303" height="653" alt="image" src="https://github.com/user-attachments/assets/9ddd1381-c0de-4cef-aae3-261b08e11189" />
+ 친구 사용자 찾기 API 연동 

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] 친구 메인 화면에서 검색하기 버튼을 누르면 검색창이 떠서 사용자 닉네임을 검색되는지 확인해주세요 
- [ ] 닉네임을 검색하면 프로필, 닉네임, 직업이 화면에 뜨는지 확인해주세요 (* 없는 사용자나 본인을 검색했을 때는 사용자 검색 실패 log가 뜹니다)

## 📸 스크린샷 (선택)
> 
팔로잉, 팔로워 부분 아무것도 없는게 맞습니다.. 나중에 팔로잉, 팔로워 api연동해야 되기 때문에..~
<img width="428" height="882" alt="image" src="https://github.com/user-attachments/assets/b6c9a871-0c09-4d42-9b0f-cba3ea9e5b17" />

<img width="411" height="879" alt="image" src="https://github.com/user-attachments/assets/830103be-9095-4625-ba49-477aabd068b5" />

조회 결
<img width="421" height="873" alt="image" src="https://github.com/user-attachments/assets/0569baf0-f9ff-4625-ac6a-069b84d870f0" />

본임 검색이거나 없는 사용자일 경우
<img width="406" height="838" alt="image" src="https://github.com/user-attachments/assets/0968545a-db3c-4e85-9198-638fdcf23964" />

<img width="1406" height="39" alt="image" src="https://github.com/user-attachments/assets/00013c00-6b4d-4147-a966-b2371ad63a52" />

<img width="1651" height="40" alt="image" src="https://github.com/user-attachments/assets/27969d7d-632e-4109-b6e2-3fbfd2e22e1d" />


## 💬 기타 참고 사항
> 아마 우진, 다현 검색했을 때 프로필, 닉네임, 직업이 뜨는거같아요..  
