### PR TITLE
[BUG/#126] 위시 mvvm 구조 변경하면서 발생한 문제 해결

### DIFF
--- a/app/src/main/java/com/example/teumteum/data/remote/wish/repository/WishRepository.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/wish/repository/WishRepository.kt
@@ -54,9 +54,11 @@ class WishRepository @Inject constructor(
                 val apiResponse = response.body()
                     ?: return Result.failure(Exception("서버 응답이 비어 있습니다."))
 
-                apiResponse.result?.let { data ->
-                    Result.success(data)
-                } ?: Result.failure(Exception("서버 응답이 올바르지 않습니다."))
+                if (apiResponse.isSuccess && apiResponse.result != null) {
+                    Result.success(apiResponse.result)
+                } else {
+                    Result.failure(Exception(apiResponse.message))
+                }
             } else {
                 Result.failure(Exception("서버 오류 발생"))
             }
@@ -68,7 +70,7 @@ class WishRepository @Inject constructor(
     }
 
     // 특정 위시 편집
-    suspend fun editWish(wishId: Long, request: EditWishRequest): Result<EditWishResponse> {
+    suspend fun editWish(wishId: Long, request: EditWishRequest): Result<Unit> {
         return try {
             val response = wishService.editWish(wishId, request)
 
@@ -76,9 +78,11 @@ class WishRepository @Inject constructor(
                 val apiResponse = response.body()
                     ?: return Result.failure(Exception("서버 응답이 비어 있습니다."))
 
-                apiResponse.result?.let { data ->
-                    Result.success(data)
-                } ?: Result.failure(Exception("서버 응답이 올바르지 않습니다."))
+                if (apiResponse.isSuccess) {
+                    Result.success(Unit)
+                } else {
+                    Result.failure(Exception(apiResponse.message))
+                }
             } else {
                 Result.failure(Exception("서버 오류 발생"))
             }
@@ -90,7 +94,7 @@ class WishRepository @Inject constructor(
     }
 
     // 특정 위시 삭제
-    suspend fun deleteWish(request: DeleteWishesRequest): Result<DeleteWishesResponse> {
+    suspend fun deleteWish(request: DeleteWishesRequest): Result<Unit> {
         return try {
             val response = wishService.deleteWishes(request)
 
@@ -98,9 +102,11 @@ class WishRepository @Inject constructor(
                 val apiResponse = response.body()
                     ?: return Result.failure(Exception("서버 응답이 비어 있습니다."))
 
-                apiResponse.result?.let { data ->
-                    Result.success(data)
-                } ?: Result.failure(Exception("서버 응답이 올바르지 않습니다."))
+                if (apiResponse.isSuccess) {
+                    Result.success(Unit)
+                } else {
+                    Result.failure(Exception(apiResponse.message))
+                }
             } else {
                 Result.failure(Exception("서버 오류 발생"))
             }
@@ -121,9 +127,11 @@ class WishRepository @Inject constructor(
                 val apiResponse = response.body()
                     ?: return Result.failure(Exception("서버 응답이 비어 있습니다."))
 
-                apiResponse.result?.let { data ->
-                    Result.success(data)
-                } ?: Result.failure(Exception("서버 응답이 올바르지 않습니다."))
+                if (apiResponse.isSuccess && apiResponse.result != null) {
+                    Result.success(apiResponse.result)
+                } else {
+                    Result.failure(Exception(apiResponse.message))
+                }
             } else {
                 Result.failure(Exception("서버 오류 발생"))
             }

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishEditFragment.kt
@@ -101,6 +101,7 @@ class WishEditFragment : BottomSheetDialogFragment() {
 
     private fun setupObservers() {
         wishViewModel.wish.observe(viewLifecycleOwner) { wish ->
+            if (wish == null) return@observe
 
             binding.wishTitleEt.setText(wish.title)
             binding.detailTextEt.setText(wish.content)
@@ -114,24 +115,28 @@ class WishEditFragment : BottomSheetDialogFragment() {
             originalCategoryIds = wish.categories.map { it.categoryId }.sorted()
         }
 
-        wishViewModel.errorMessage.observe(viewLifecycleOwner) { errorMessage ->
-            Log.e("WishGet", "위시 조회 실패: $errorMessage")
-        }
-
-        wishViewModel.successMessage.observe(viewLifecycleOwner) {
-            Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
-            parentFragmentManager.setFragmentResult("wish_edit", Bundle())
-
-            // 모든 바텀시트 닫기
-            (requireActivity().supportFragmentManager.fragments).forEach {
-                if (it is BottomSheetDialogFragment) {
-                    it.dismissAllowingStateLoss()
-                }
+        wishViewModel.editSuccess.observe(viewLifecycleOwner) {
+            if (it == true) {
+                Toast.makeText(requireContext(), "위시가 성공적으로 수정되었습니다.", Toast.LENGTH_SHORT).show()
+                parentFragmentManager.setFragmentResult("wish_edit", Bundle())
+                dismiss()  // 현재 바텀시트만 닫기
             }
         }
 
-        wishViewModel.errorMessage.observe(viewLifecycleOwner) {
-            Log.e("WishEdit", "수정 실패: $it")
+        // 삭제 성공 시
+        wishViewModel.deleteSuccess.observe(viewLifecycleOwner) {
+            if (it == true) {
+                Toast.makeText(requireContext(), "위시가 성공적으로 삭제되었습니다.", Toast.LENGTH_SHORT).show()
+                parentFragmentManager.setFragmentResult("wish_delete", Bundle())
+                dismiss()  // 현재 바텀시트만 닫기
+            }
+        }
+
+        wishViewModel.errorMessage.observe(viewLifecycleOwner) { errorMessage ->
+            errorMessage?.let {
+                Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
+                Log.e("WishError", it)
+            }
         }
     }
 
@@ -189,18 +194,7 @@ class WishEditFragment : BottomSheetDialogFragment() {
 
         dialogBinding.wishConfirmTv.setOnClickListener {
             wishViewModel.deleteWishes(request)
-
-            wishViewModel.successMessage.observe(viewLifecycleOwner) {
-                Toast.makeText(requireContext(), "위시가 성공적으로 삭제되었습니다.", Toast.LENGTH_SHORT).show()
-                parentFragmentManager.setFragmentResult("wish_delete", Bundle())
-                dialog.dismiss()
-                dismiss() // 바텀시트 닫기
-            }
-
-            wishViewModel.errorMessage.observe(viewLifecycleOwner) { errorMessage ->
-                Toast.makeText(requireContext(), "위시 삭제에 실패했어요: $errorMessage", Toast.LENGTH_SHORT).show()
-                dialog.dismiss()
-            }
+            dialog.dismiss()
         }
 
         dialogBinding.wishCancelTv.setOnClickListener {

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishRegisterFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishRegisterFragment.kt
@@ -181,13 +181,16 @@ class WishRegisterFragment : BottomSheetDialogFragment() {
     }
 
     private fun setupObservers() {
-        wishViewModel.successMessage.observe(viewLifecycleOwner) {
-            Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
-            parentFragmentManager.setFragmentResult("wish_register", Bundle())
+        wishViewModel.registerSuccess.observe(viewLifecycleOwner) { isSuccess ->
+            if (isSuccess) {
+                Toast.makeText(requireContext(), "위시가 등록되었습니다.", Toast.LENGTH_SHORT).show()
+                parentFragmentManager.setFragmentResult("wish_register", Bundle())
 
-            (requireActivity().supportFragmentManager.fragments).forEach { fragment ->
-                if (fragment is BottomSheetDialogFragment) {
-                    fragment.dismissAllowingStateLoss()
+                // 모든 바텀시트 닫기
+                (requireActivity().supportFragmentManager.fragments).forEach { fragment ->
+                    if (fragment is BottomSheetDialogFragment) {
+                        fragment.dismissAllowingStateLoss()
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishlistEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishlistEditFragment.kt
@@ -100,21 +100,23 @@ class WishlistEditFragment() : Fragment() {
     }
 
     private fun setupObservers() {
-        wishViewModel.successMessage.observe(viewLifecycleOwner) { _ ->
-            Toast.makeText(requireContext(), "삭제가 완료되었어요.", Toast.LENGTH_SHORT).show()
+        wishViewModel.deleteSuccess.observe(viewLifecycleOwner) { isSuccess ->
+            if (isSuccess) {
+                Toast.makeText(requireContext(), "삭제가 완료되었어요.", Toast.LENGTH_SHORT).show()
 
-            // ViewModel에서 삭제 반영
-            val deletedIds = editedWishlist.filter { it.isDeleted }.map { it.id }
-            val updatedList = wishViewModel.wishlistItems.value?.filterNot { it.id in deletedIds } ?: emptyList()
-            wishViewModel.wishlistItems.value = updatedList
+                // ViewModel 내 리스트 갱신
+                val deletedIds = editedWishlist.filter { it.isDeleted }.map { it.id }
+                val updatedList = wishViewModel.wishlistItems.value?.filterNot { it.id in deletedIds } ?: emptyList()
+                wishViewModel.updateWishlistItems(updatedList)
 
-            // 결과 전달
-            parentFragmentManager.setFragmentResult("wish_delete", Bundle())
+                // 삭제 결과 전달
+                parentFragmentManager.setFragmentResult("wish_delete", Bundle())
 
-            // 뒤로 이동
-            parentFragmentManager.beginTransaction()
-                .replace(R.id.main_frm, WishlistFragment())
-                .commit()
+                // 위시리스트 화면으로 이동
+                parentFragmentManager.beginTransaction()
+                    .replace(R.id.main_frm, WishlistFragment())
+                    .commit()
+            }
         }
 
         wishViewModel.errorMessage.observe(viewLifecycleOwner) { error ->

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishlistFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishlistFragment.kt
@@ -37,7 +37,8 @@ class WishlistFragment() : Fragment() {
 
         binding.editTv.setOnClickListener {
             val currentList = wishViewModel.wishlistItems.value ?: emptyList()
-            wishViewModel.wishlistItems.value = currentList.toMutableList()
+            wishViewModel.updateWishlistItems(currentList.toMutableList())
+
             parentFragmentManager.beginTransaction()
                 .replace(R.id.main_frm, WishlistEditFragment())
                 .addToBackStack(null)

--- a/app/src/main/java/com/example/teumteum/ui/wish/viewModel/WishViewModel.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/viewModel/WishViewModel.kt
@@ -19,23 +19,30 @@ class WishViewModel @Inject constructor(
     private val wishRepository: WishRepository
 ) : ViewModel() {
 
-    private val _successMessage = MutableLiveData<String>()
-    val successMessage: LiveData<String> = _successMessage
-
     private val _errorMessage = MutableLiveData<String?>()
     val errorMessage: LiveData<String?> get() = _errorMessage
 
     private val _wish = MutableLiveData<Wish>()
     val wish: LiveData<Wish> = _wish
 
-    val wishlistItems = MutableLiveData<List<WishlistItem>>()
+    private val _wishlistItems = MutableLiveData<List<WishlistItem>>()
+    val wishlistItems: LiveData<List<WishlistItem>> get() = _wishlistItems
+
+    private val _registerSuccess = MutableLiveData<Boolean>()
+    val registerSuccess: LiveData<Boolean> get() = _registerSuccess
+
+    private val _editSuccess = MutableLiveData<Boolean>()
+    val editSuccess: LiveData<Boolean> get() = _editSuccess
+
+    private val _deleteSuccess = MutableLiveData<Boolean>()
+    val deleteSuccess: LiveData<Boolean> get() = _deleteSuccess
 
     // 위시 등록
     fun registerWish(request: RegisterWishRequest) {
         viewModelScope.launch {
             val result = wishRepository.registerWish(request)
             result.onSuccess {
-                _successMessage.value = "위시가 등록되었습니다."
+                _registerSuccess.value = true
             }
             result.onFailure { e ->
                 _errorMessage.value = e.localizedMessage ?: "위시 등록에 실패했습니다."
@@ -49,8 +56,7 @@ class WishViewModel @Inject constructor(
             val result = wishRepository.getWishlist(duration, page)
 
             result.onSuccess { response ->
-                wishlistItems.value = response.wishlist
-                _successMessage.value = "위시리스트가 성공적으로 조회되었습니다."
+                _wishlistItems.value = response.wishlist
             }.onFailure { e ->
                 _errorMessage.value = e.localizedMessage ?: "위시리스트 조회에 실패했습니다."
             }
@@ -62,9 +68,8 @@ class WishViewModel @Inject constructor(
         viewModelScope.launch {
             val result = wishRepository.getWish(wishId)
 
-            result.onSuccess { response ->
-                _wish.value = response
-                _successMessage.value = "위시가 성공적으로 조회되었습니다."
+            result.onSuccess {
+                _wish.value = it
             }.onFailure { e ->
                 _errorMessage.value = e.localizedMessage ?: "위시 조회에 실패했습니다."
             }
@@ -75,22 +80,24 @@ class WishViewModel @Inject constructor(
     fun editWish(wishId: Long, request: EditWishRequest) {
         viewModelScope.launch {
             val result = wishRepository.editWish(wishId, request)
-            _successMessage.value = result.toString()
             result.onSuccess {
-                _successMessage.value = "위시가 성공적으로 수정되었습니다."
+                _editSuccess.value = true
             }.onFailure { e ->
                 _errorMessage.value = e.localizedMessage ?: "위시 수정에 실패했습니다."
             }
         }
     }
 
+    fun updateWishlistItems(updated: List<WishlistItem>) {
+        _wishlistItems.value = updated
+    }
+
     // 위시 삭제(리스트 형태)
     fun deleteWishes(request: DeleteWishesRequest) {
         viewModelScope.launch {
             val result = wishRepository.deleteWish(request)
-            _successMessage.value = result.toString()
             result.onSuccess {
-                _successMessage.value = "위시가 성공적으로 삭제되었습니다."
+                _deleteSuccess.value = true
             }.onFailure { e ->
                 _errorMessage.value = e.localizedMessage ?: "위시 삭제에 실패했습니다."
             }


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #126 

브랜치 새로 생성해놓고 바보같이 이전 브랜치에서 작업하느라 pr 올리는게 조금 늦었습니다............

## ✨ 작업 내용
> 기존 MVP 구조일 때 성공적으로 테스트되었던 위시 api들이, MVVM 구조로 변경하고 viewmodel, 공통 응답 형식 통일 등을 적용하다 보니 위시 조회가 제대로 되지 않거나 수정이 안되는 등 몇 가지 문제들이 있었습니다.

[해결 방법]
utils 패키지에 있는 ApiResponse.kt는 아래와 같이 선언하였습니다.
```kotlin
data class ApiResponse<T>(
    val isSuccess: Boolean,
    val code: String,
    val message: String,
    val result: T? = null
)
``` 
위시 수정 api의 응답 결과를 예시로 들겠습니다.
```kotlin
{
  "isSuccess": true,
  "code": "HOME2008",
  "message": "위시 정보가 성공적으로 수정되었습니다."
}
``` 

위시 수정, 위시 삭제 등에는 result가 포함되어 있지 않기 때문에 dto로 처리하게 되면 result가 null이 되어 에러가 발생하는 것이었습니다. 그래서 저는 `Unit`이라는 타입을 사용하였으며 이는 "반환값이 없음"을 표현하고 Java의 `void`와 같은 역할을 한다고 합니다.

Result<T>는 성공/실패를 포장하는 래퍼 클래스이며  T에 Unit을 넣으면 "성공했지만 반환할 값은 없다"는 뜻입니다. 이에 따라 repository에서 apiResponse.isSuccess가 참인 경우 아래의 코드를 선언해주었으며, "성공적으로 완료되었고, 반환할 데이터는 없지만 문제가 없음을 나타냄" 이라는 의미를 가지고 있다고 합니다.

```kotlin
return Result.success(Unit)
``` 
Unit 말고 더 좋은 대안이 있다면 피드백 반영하여 리팩토링 작업하겠습니다!

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] check

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항
