### PR TITLE
[FEAT/#132] 틈 응답 상태 변경 API 연동

### DIFF
--- a/app/src/main/java/com/example/teumteum/data/remote/friend/model/TeumStatusRequest.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/friend/model/TeumStatusRequest.kt
@@ -1,0 +1,6 @@
+package com.example.teumteum.data.remote.friend.model
+
+data class TeumStatusRequest(
+    val status: String
+)
+

--- a/app/src/main/java/com/example/teumteum/data/remote/friend/model/TeumStatusResult.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/friend/model/TeumStatusResult.kt
@@ -1,0 +1,7 @@
+package com.example.teumteum.data.remote.friend.model
+
+data class TeumStatusResult(
+    val status: String,        // "ACCEPTED" or "REJECTED"
+    val teumCreated: Boolean,  // ACCEPTED인 경우 true
+    val teumId: Int?           // ACCEPTED이면 ID, REJECTED면 null
+)

--- a/app/src/main/java/com/example/teumteum/data/remote/friend/repository/FriendRepository.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/friend/repository/FriendRepository.kt
@@ -48,4 +48,15 @@ class FriendRepository @Inject constructor(
         }
     }
 
+    suspend fun respondToTeum(responseId: Int, status: String): Result<TeumStatusResult> = runCatching {
+        val request = TeumStatusRequest(status)
+        val response = api.patchTeumStatus(responseId, request)
+        val body = response.body()
+        if (response.isSuccessful && body?.isSuccess == true && body.result != null) {
+            body.result
+        } else {
+            throw Exception("${body?.code ?: "HTTP${response.code()}"} - ${body?.message ?: "오류"}")
+        }
+    }
+
 }

--- a/app/src/main/java/com/example/teumteum/data/remote/friend/service/FriendService.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/friend/service/FriendService.kt
@@ -5,6 +5,7 @@ import com.example.teumteum.data.remote.friend.model.*
 import retrofit2.Response  //  이거 추가!
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -25,7 +26,12 @@ interface FriendService {
     suspend fun getReceivedTeumRequests(): Response<ApiResponse<TeumReceivedResult>>
 
     @POST("/api/teums/requests")
-    suspend fun sendTeumRequest(
-        @Body body: TeumRequest
-    ): Response<ApiResponse<TeumRequestResult>>
+    suspend fun sendTeumRequest(@Body body: TeumRequest): Response<ApiResponse<TeumRequestResult>>
+
+    @PATCH("/api/teums/response/{responseId}/status")
+    suspend fun patchTeumStatus(
+        @Path("responseId") responseId: Int,
+        @Body request: TeumStatusRequest
+    ): Response<ApiResponse<TeumStatusResult>>
+
 }

--- a/app/src/main/java/com/example/teumteum/ui/friend/Friend02AcceptBottomSheetFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/Friend02AcceptBottomSheetFragment.kt
@@ -3,14 +3,18 @@ package com.example.teumteum.ui.friend
 import android.app.Dialog
 import android.graphics.Color
 import android.os.Bundle
-import android.text.Spannable
 import android.text.SpannableString
+import android.text.Spannable
 import android.text.style.ForegroundColorSpan
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.activityViewModels
 import com.example.teumteum.R
 import com.example.teumteum.databinding.BottomSheetFriend02AcceptBinding
+import com.example.teumteum.ui.friend.viewModel.FriendViewModel
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
@@ -20,17 +24,15 @@ class Friend02AcceptBottomSheetFragment : BottomSheetDialogFragment() {
 
     private var _binding: BottomSheetFriend02AcceptBinding? = null
     private val binding get() = _binding!!
+    private val viewModel: FriendViewModel by activityViewModels()
 
-    /** ↓ BottomSheetDialog 배경 커스텀 */
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialog = super.onCreateDialog(savedInstanceState) as BottomSheetDialog
-
         dialog.setOnShowListener { dialogInterface ->
             val bottomSheet = (dialogInterface as BottomSheetDialog)
                 .findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
             bottomSheet?.setBackgroundResource(R.drawable.calendar_background)
         }
-
         return dialog
     }
 
@@ -46,30 +48,30 @@ class Friend02AcceptBottomSheetFragment : BottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        // "함께 할래요"만 보라색, 나머지는 검정
         val fullText = "함께 할래요 멘트를 보낼까요?"
         val spannable = SpannableString(fullText).apply {
-            setSpan(
-                ForegroundColorSpan(Color.parseColor("#7770FE")),
-                0, 6,                              // "함께 할래요"
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-            )
-            setSpan(
-                ForegroundColorSpan(Color.parseColor("#0F0F0F")),
-                6, fullText.length,
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-            )
+            setSpan(ForegroundColorSpan(Color.parseColor("#7770FE")), 0, 6, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            setSpan(ForegroundColorSpan(Color.parseColor("#0F0F0F")), 6, fullText.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
         }
         binding.mentText.text = spannable
 
-        // 취소
         binding.btnCancel.setOnClickListener { dismiss() }
 
-        // 전송 후 FriendSendFragment로 이동
         binding.btnSend.setOnClickListener {
+            val responseId = arguments?.getInt("responseId") ?: return@setOnClickListener
+            val status = "accepted"
+
+            //  로그 & 토스트
+            Log.d("ACCEPT_BOTTOM_SHEET", "responseId: $responseId, status: $status")
+            Toast.makeText(requireContext(), "응답: 함께할래요 (id: $responseId)", Toast.LENGTH_SHORT).show()
+
+            //  응답 처리
+            viewModel.respondToTeum(responseId, status)
+
+            //  바텀시트 닫기 + 화면 전환
             dismiss()
             requireActivity().supportFragmentManager.beginTransaction()
-                .replace(R.id.main_frm, FriendSendFragment())   // main_frm 확인 필요
+                .replace(R.id.main_frm, FriendSendFragment())
                 .addToBackStack(null)
                 .commit()
         }
@@ -78,5 +80,15 @@ class Friend02AcceptBottomSheetFragment : BottomSheetDialogFragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    companion object {
+        fun newInstance(responseId: Int): Friend02AcceptBottomSheetFragment {
+            return Friend02AcceptBottomSheetFragment().apply {
+                arguments = Bundle().apply {
+                    putInt("responseId", responseId)
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/teumteum/ui/friend/Friend02PossibleTimeFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/Friend02PossibleTimeFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.example.teumteum.R
+import com.example.teumteum.data.remote.friend.model.TeumReceivedItem
 import com.example.teumteum.databinding.FragmentFriend02PossibleTimeBinding
 import com.example.teumteum.ui.main.MainActivity
 import dagger.hilt.android.AndroidEntryPoint
@@ -18,8 +19,8 @@ class Friend02PossibleTimeFragment : Fragment() {
     private val binding get() = _binding!!
 
     private lateinit var adapter: FriendRequestCardAdapter
-
-
+    private var teumList: List<TeumReceivedItem> = emptyList()
+    private var responseId: Int = -1
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -31,7 +32,18 @@ class Friend02PossibleTimeFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        //  뒤로가기 버튼 처리
+        //  전달받은 데이터 받기
+        teumList = arguments?.getParcelableArrayList("teumList") ?: emptyList()
+        responseId = arguments?.getInt("responseId") ?: -1
+
+        //  어댑터 연결
+        adapter = FriendRequestCardAdapter(teumList)
+        binding.requestViewPager.adapter = adapter
+
+        //  바텀 네비게이션 숨기기
+        (activity as? MainActivity)?.hideBottomBar()
+
+        //  뒤로가기
         binding.backButton.setOnClickListener {
             parentFragmentManager.beginTransaction()
                 .replace(R.id.main_frm, Friend02RequestFragment())
@@ -39,50 +51,37 @@ class Friend02PossibleTimeFragment : Fragment() {
                 .commit()
         }
 
-        //  바텀 네비게이션 숨기기
-        (activity as? MainActivity)?.hideBottomBar()
-
-//        // 1. ViewPager2 + Adapter 연결
-//        adapter = FriendRequestCardAdapter(getDummyList())
-//        binding.requestViewPager.adapter = adapter
-
-        // 함께할래요 버튼 클릭 시 바텀시트 띄우기 + Toast 메시지
+        //  "찾기" 버튼 클릭 시 → Suggest로 넘어갈 때도 teumList, responseId 넘기기
         binding.btnFind.setOnClickListener {
+            val fragment = Friend02SuggestFragment().apply {
+                arguments = Bundle().apply {
+                    putParcelableArrayList("teumList", ArrayList(teumList))
+                    putInt("responseId", responseId)
+                }
+            }
+
             parentFragmentManager.beginTransaction()
-                .replace(R.id.main_frm, Friend02SuggestFragment())
-                .addToBackStack(null)      // 뒤로 가기 가능하게
+                .replace(R.id.main_frm, fragment)
+                .addToBackStack(null)
                 .commit()
 
-            Toast.makeText(requireContext(),
-                "함께할래요 화면으로 이동합니다.", Toast.LENGTH_SHORT).show()
+            Toast.makeText(requireContext(), "함께할래요 화면으로 이동합니다.", Toast.LENGTH_SHORT).show()
         }
-
-
     }
-
-
-    private fun getDummyList(): List<FriendRequestData> {
-        return listOf(
-            FriendRequestData(
-                name = "이름",
-                date = "25.05.02",
-                time = "15:20 ~ 16:10",
-                title = "강아지 산책 가자",
-                desc = "모모랑 초코랑 종합천 한바퀴 쓰윽 돌고\n돌아오는 길에 호떡 먹자!"
-            ),
-            FriendRequestData(
-                name = "보보",
-                date = "25.05.03",
-                time = "11:00 ~ 12:00",
-                title = "산책 좋아하는 보보",
-                desc = "동물병원 들렀다가 간식도 먹고 돌아오자!"
-            )
-        )
-    }
-
 
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    companion object {
+        fun newInstance(teumList: ArrayList<TeumReceivedItem>, responseId: Int): Friend02PossibleTimeFragment {
+            return Friend02PossibleTimeFragment().apply {
+                arguments = Bundle().apply {
+                    putParcelableArrayList("teumList", teumList)
+                    putInt("responseId", responseId)
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/teumteum/ui/friend/Friend02RejectBottomSheetFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/Friend02RejectBottomSheetFragment.kt
@@ -71,9 +71,16 @@ class Friend02RejectBottomSheetFragment : BottomSheetDialogFragment() {
             val responseId = arguments?.getInt("responseId") ?: return@setOnClickListener
 
             if (selectedOption == SelectedOption.SUGGEST) {
+                // Friend02RequestFragment에서 받아온 teumList 전달 필요
+                val parentFragment = parentFragmentManager.fragments.firstOrNull { it is Friend02RequestFragment } as? Friend02RequestFragment
+                val teumList = parentFragment?.teumList ?: emptyList()
+
                 //  시간 제안 화면 이동
                 parentFragmentManager.beginTransaction()
-                    .replace(R.id.main_frm, Friend02PossibleTimeFragment())
+                    .replace(
+                        R.id.main_frm,
+                        Friend02PossibleTimeFragment.newInstance(ArrayList(teumList), responseId)
+                    )
                     .addToBackStack(null)
                     .commit()
                 dismiss()

--- a/app/src/main/java/com/example/teumteum/ui/friend/Friend02RejectBottomSheetFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/Friend02RejectBottomSheetFragment.kt
@@ -4,23 +4,28 @@ import android.app.Dialog
 import android.content.res.ColorStateList
 import android.graphics.Color
 import android.os.Bundle
-import android.text.Spannable
 import android.text.SpannableString
+import android.text.Spannable
 import android.text.style.ForegroundColorSpan
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.fragment.app.activityViewModels
 import com.example.teumteum.R
 import com.example.teumteum.databinding.BottomSheetFriend02RejectBinding
+import com.example.teumteum.ui.friend.viewModel.FriendViewModel
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class Friend02RejectBottomSheetFragment : BottomSheetDialogFragment() {
+
     private var _binding: BottomSheetFriend02RejectBinding? = null
     private val binding get() = _binding!!
+    private val viewModel: FriendViewModel by activityViewModels()
 
     private var selectedOption: SelectedOption = SelectedOption.REJECT
 
@@ -28,16 +33,13 @@ class Friend02RejectBottomSheetFragment : BottomSheetDialogFragment() {
         REJECT, SUGGEST
     }
 
-    /** ↓ BottomSheetDialog 배경 커스텀 */
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialog = super.onCreateDialog(savedInstanceState) as BottomSheetDialog
-
         dialog.setOnShowListener { dialogInterface ->
             val bottomSheet = (dialogInterface as BottomSheetDialog)
                 .findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
             bottomSheet?.setBackgroundResource(R.drawable.calendar_background)
         }
-
         return dialog
     }
 
@@ -51,14 +53,10 @@ class Friend02RejectBottomSheetFragment : BottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        // 초기 텍스트 설정
         binding.btnRejectMent.text = getColoredText("이때는 시간이 안돼요", " 멘트 보내기")
         binding.btnSuggestTime.text = getColoredText("가능한 다른 시간대", " 제안하기")
-
-        // 기본 선택
         updateSelection(SelectedOption.REJECT)
 
-        // 클릭 리스너
         binding.btnRejectMent.setOnClickListener {
             updateSelection(SelectedOption.REJECT)
         }
@@ -70,16 +68,26 @@ class Friend02RejectBottomSheetFragment : BottomSheetDialogFragment() {
         binding.btnCancel.setOnClickListener { dismiss() }
 
         binding.btnSend.setOnClickListener {
+            val responseId = arguments?.getInt("responseId") ?: return@setOnClickListener
+
             if (selectedOption == SelectedOption.SUGGEST) {
-                // 화면 전환 (가능한 시간 제안)
+                //  시간 제안 화면 이동
                 parentFragmentManager.beginTransaction()
                     .replace(R.id.main_frm, Friend02PossibleTimeFragment())
                     .addToBackStack(null)
                     .commit()
                 dismiss()
             } else {
-                // 단순 거절 멘트 전송
-                Toast.makeText(requireContext(), "멘트가 전송되었습니다.", Toast.LENGTH_SHORT).show()
+                val status = "rejected"
+
+                //  로그 & 토스트
+                Log.d("REJECT_BOTTOM_SHEET", "responseId: $responseId, status: $status")
+                Toast.makeText(requireContext(), "응답: 시간이 안돼요 (id: $responseId)", Toast.LENGTH_SHORT).show()
+
+                //  응답 처리
+                viewModel.respondToTeum(responseId, status)
+
+                //  바텀시트 닫기
                 dismiss()
             }
         }
@@ -110,34 +118,29 @@ class Friend02RejectBottomSheetFragment : BottomSheetDialogFragment() {
     private fun getColoredText(purplePart: String, blackPart: String): SpannableString {
         val fullText = purplePart + blackPart
         return SpannableString(fullText).apply {
-            setSpan(
-                ForegroundColorSpan(Color.parseColor("#7770FE")),
-                0,
-                purplePart.length,
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-            )
-            setSpan(
-                ForegroundColorSpan(Color.parseColor("#0F0F0F")),
-                purplePart.length,
-                fullText.length,
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-            )
+            setSpan(ForegroundColorSpan(Color.parseColor("#7770FE")), 0, purplePart.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            setSpan(ForegroundColorSpan(Color.parseColor("#0F0F0F")), purplePart.length, fullText.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
         }
     }
 
     private fun getGrayText(fullText: String): SpannableString {
         return SpannableString(fullText).apply {
-            setSpan(
-                ForegroundColorSpan(Color.parseColor("#D3D3D3")),
-                0,
-                fullText.length,
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-            )
+            setSpan(ForegroundColorSpan(Color.parseColor("#D3D3D3")), 0, fullText.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
         }
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    companion object {
+        fun newInstance(responseId: Int): Friend02RejectBottomSheetFragment {
+            return Friend02RejectBottomSheetFragment().apply {
+                arguments = Bundle().apply {
+                    putInt("responseId", responseId)
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/teumteum/ui/friend/Friend02RequestFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/Friend02RequestFragment.kt
@@ -67,17 +67,26 @@ class Friend02RequestFragment : Fragment() {
         binding.dotsIndicator.setViewPager2(binding.requestViewPager)
 
         // 7. 버튼 이벤트
-        binding.btnReject.setOnClickListener {
-            val bottomSheet = Friend02RejectBottomSheetFragment()
+        binding.btnAccept.setOnClickListener {
+            val currentItem = binding.requestViewPager.currentItem
+            val responseId = teumList.getOrNull(currentItem)?.responseId ?: return@setOnClickListener
+
+            val bottomSheet = Friend02AcceptBottomSheetFragment.newInstance(responseId)
             bottomSheet.show(parentFragmentManager, bottomSheet.tag)
-            Toast.makeText(requireContext(), "거절 버튼이 눌렸습니다.", Toast.LENGTH_SHORT).show()
+
+//            Toast.makeText(requireContext(), "함께할래요 버튼이 눌렸습니다.", Toast.LENGTH_SHORT).show()
         }
 
-        binding.btnAccept.setOnClickListener {
-            val bottomSheet = Friend02AcceptBottomSheetFragment()
+        binding.btnReject.setOnClickListener {
+            val currentItem = binding.requestViewPager.currentItem
+            val responseId = teumList.getOrNull(currentItem)?.responseId ?: return@setOnClickListener
+
+            val bottomSheet = Friend02RejectBottomSheetFragment.newInstance(responseId)
             bottomSheet.show(parentFragmentManager, bottomSheet.tag)
-            Toast.makeText(requireContext(), "함께할래요 버튼이 눌렸습니다.", Toast.LENGTH_SHORT).show()
+
+//            Toast.makeText(requireContext(), "거절 버튼이 눌렸습니다.", Toast.LENGTH_SHORT).show()
         }
+
 
         // 8. 뒤로가기
         binding.backButton.setOnClickListener {

--- a/app/src/main/java/com/example/teumteum/ui/friend/Friend02SuggestFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/Friend02SuggestFragment.kt
@@ -5,12 +5,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
-import android.widget.ImageButton
 import android.widget.NumberPicker
 import android.widget.TextView
 import androidx.fragment.app.Fragment
-import androidx.navigation.fragment.findNavController
 import com.example.teumteum.R
+import com.example.teumteum.data.remote.friend.model.TeumReceivedItem
 import com.example.teumteum.databinding.FragmentFriend02SuggestBinding
 import com.example.teumteum.ui.main.MainActivity
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -23,6 +22,8 @@ class Friend02SuggestFragment : Fragment() {
     private val binding get() = _binding!!
 
     private lateinit var adapter: FriendRequestCardAdapter
+    private var teumList: List<TeumReceivedItem> = emptyList()
+    private var responseId: Int = -1
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -36,20 +37,24 @@ class Friend02SuggestFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        //  뒤로가기 버튼 처리
-        binding.backButton.setOnClickListener {
-            parentFragmentManager.beginTransaction()
-                .replace(R.id.main_frm, Friend02PossibleTimeFragment())
-                .addToBackStack(null)
-                .commit()
-        }
+        //  전달받은 데이터 꺼내기
+        teumList = arguments?.getParcelableArrayList("teumList") ?: emptyList()
+        responseId = arguments?.getInt("responseId") ?: -1
+
+        //  어댑터 연결
+        adapter = FriendRequestCardAdapter(teumList)
+        binding.requestViewPager.adapter = adapter
 
         // 바텀 네비게이션 숨기기
         (activity as? MainActivity)?.hideBottomBar()
 
-//        // ViewPager2 + Adapter 연결
-//        adapter = FriendRequestCardAdapter(getDummyList())
-//        binding.requestViewPager.adapter = adapter
+        //  뒤로가기 버튼 처리
+        binding.backButton.setOnClickListener {
+            parentFragmentManager.beginTransaction()
+                .replace(R.id.main_frm, Friend02PossibleTimeFragment.newInstance(ArrayList(teumList), responseId))
+                .addToBackStack(null)
+                .commit()
+        }
 
         // 시간 카드 1 클릭 시
         binding.startTime1.setOnClickListener {
@@ -71,7 +76,7 @@ class Friend02SuggestFragment : Fragment() {
             highlightSelectedCard(isFirst = false)
         }
 
-        // 전송 버튼 클릭 시 이동
+        //  전송 버튼 클릭 시 → FriendSendFragment 이동
         binding.btnSend.setOnClickListener {
             parentFragmentManager.beginTransaction()
                 .replace(R.id.main_frm, FriendSendFragment())
@@ -87,10 +92,8 @@ class Friend02SuggestFragment : Fragment() {
         val ampmPicker = dialogView.findViewById<NumberPicker>(R.id.ampmPicker01Np)
         val hourPicker = dialogView.findViewById<NumberPicker>(R.id.hourPicker01Np)
         val minutePicker = dialogView.findViewById<NumberPicker>(R.id.minutePicker01Np)
-
         val minuteValues = arrayOf("00", "10", "20", "30", "40", "50")
 
-        // Picker 초기화
         ampmPicker.minValue = 0
         ampmPicker.maxValue = 1
         ampmPicker.displayedValues = arrayOf("AM", "PM")
@@ -107,28 +110,29 @@ class Friend02SuggestFragment : Fragment() {
         val dialog = BottomSheetDialog(requireContext())
         dialog.setContentView(dialogView)
 
-        // ✅ 배경 적용
         dialog.setOnShowListener { dialogInterface ->
-            val bottomSheet = (dialogInterface as BottomSheetDialog)
-                .findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
-            bottomSheet?.setBackgroundResource(R.drawable.calendar_background)
+            (dialogInterface as? BottomSheetDialog)?.let { bottomSheetDialog ->
+                bottomSheetDialog.behavior.addBottomSheetCallback(object :
+                    com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback() {
+                    override fun onStateChanged(bottomSheet: View, newState: Int) {
+                        // 상태 변경 시
+                    }
+
+                    override fun onSlide(bottomSheet: View, slideOffset: Float) {
+                        // 배경 변경
+                        bottomSheet.setBackgroundResource(R.drawable.calendar_background)
+                    }
+                })
+            }
         }
 
-        // 취소 버튼
-        dialogView.findViewById<Button>(R.id.btnCancel).setOnClickListener {
-            dialog.dismiss()
-        }
-
-        // 확인 버튼
+        dialogView.findViewById<Button>(R.id.btnCancel).setOnClickListener { dialog.dismiss() }
         dialogView.findViewById<Button>(R.id.btnOk).setOnClickListener {
             val isAm = ampmPicker.value == 0
             var hour = hourPicker.value % 12
             if (!isAm) hour += 12
-            if (hour == 0) hour = 0 // 12AM → 0시로
-
             val minute = minuteValues[minutePicker.value]
             val timeText = String.format("%02d:%s", hour, minute)
-
             targetTextView.text = timeText
             dialog.dismiss()
         }
@@ -147,26 +151,19 @@ class Friend02SuggestFragment : Fragment() {
         }
     }
 
-    /** 예시 데이터 */
-    private fun getDummyList(): List<FriendRequestData> = listOf(
-        FriendRequestData(
-            name = "이름",
-            date = "25.05.02",
-            time = "15:20 ~ 16:10",
-            title = "강아지 산책 가자",
-            desc = "모모랑 초코랑 종합천 한바퀴 쓰윽 돌고\n돌아오는 길에 호떡 먹자!"
-        ),
-        FriendRequestData(
-            name = "보보",
-            date = "25.05.03",
-            time = "11:00 ~ 12:00",
-            title = "산책 좋아하는 보보",
-            desc = "동물병원 들렀다가 간식도 먹고 돌아오자!"
-        )
-    )
-
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    companion object {
+        fun newInstance(responseId: Int, teumList: ArrayList<TeumReceivedItem>): Friend02SuggestFragment {
+            return Friend02SuggestFragment().apply {
+                arguments = Bundle().apply {
+                    putInt("responseId", responseId)
+                    putParcelableArrayList("teumList", teumList)
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/teumteum/ui/friend/viewModel/FriendViewModel.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/viewModel/FriendViewModel.kt
@@ -133,4 +133,29 @@ class FriendViewModel @Inject constructor(
                 }
         }
     }
+
+    // 5. 틈 응답 상태 변경
+    fun respondToTeum(responseId: Int, status: String) {
+        viewModelScope.launch {
+            repository.respondToTeum(responseId, status)
+                .onSuccess { result: TeumStatusResult ->
+                    _successMessage.value = when (result.status) {
+                        "ACCEPTED" -> "틈 요청을 수락했어요!"
+                        "REJECTED" -> "틈 요청을 거절했어요."
+                        else -> "응답 상태가 처리되었습니다."
+                    }
+                }
+                .onFailure { e ->
+                    val msg = when {
+                        e.message?.contains("TEUM4002") == true -> "이미 마감된 요청입니다."
+                        e.message?.contains("TEUM4030") == true -> "요청 또는 응답에 대한 권한이 없습니다."
+                        e.message?.contains("TEUM4041") == true -> "존재하지 않는 틈 응답입니다."
+                        e.message?.contains("TEUM4006") == true -> "응답 status 값은 accepted 또는 rejected 이어야 합니다."
+                        else -> "틈 응답 실패 (${e.message})"
+                    }
+                    _errorMessage.value = msg
+                }
+        }
+    }
+
 }


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #132

## ✨ 작업 내용
> 틈 응답 상태 변경 API 연동 

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 바텀시트에서 함께할래요 -> 전송 -> 틈 요청 조회 성공
- [x] 바텀시트에서 이때는 시간안돼요 -> 이때는 시간이 안돼요 멘트 보내기 -> 전송 -> 틈 요청 조회 거절
- [x] 함께 할래요나 시간이 안돼요 버튼 누르고 친구 화면에서 그 해당하는 카드가 사라져야 합니다

## 📸 스크린샷 (선택)
> 
<img width="344" height="727" alt="image" src="https://github.com/user-attachments/assets/8b73f907-36f8-4a01-80dc-4cee422daba6" />

<img width="336" height="719" alt="image" src="https://github.com/user-attachments/assets/b1600c6c-2a54-4c50-baab-633ee8b9d6ca" />

<img width="345" height="717" alt="image" src="https://github.com/user-attachments/assets/2a8a2a28-4f93-45a1-95f3-d78fa363e1c2" />

<img width="357" height="714" alt="image" src="https://github.com/user-attachments/assets/592959d4-21a4-40c5-a271-fc69c87765f8" />

<img width="347" height="722" alt="image" src="https://github.com/user-attachments/assets/70dda3d9-9c4b-4c67-92c6-6ebd19094bd9" />

<img width="1009" height="41" alt="image" src="https://github.com/user-attachments/assets/00dc7039-a547-464e-9603-4b99dae15f0b" />



## 💬 기타 참고 사항
> x
