### PR TITLE
[FIX/#166] 카카오 로그인 호출을 ViewModel에서 Activity로 이동

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/signin/LoginActivity.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signin/LoginActivity.kt
@@ -9,7 +9,6 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.example.teumteum.ui.signup.SignUpActivity
 import com.example.teumteum.databinding.ActivityLoginBinding
-import com.example.teumteum.ui.main.MainActivity
 import com.example.teumteum.ui.signin.data.LoginResult
 import com.example.teumteum.ui.signin.viewModel.LoginViewModel
 import com.kakao.sdk.user.UserApiClient
@@ -19,7 +18,6 @@ import dagger.hilt.android.AndroidEntryPoint
 class LoginActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityLoginBinding
-
     private val viewModel: LoginViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -34,7 +32,7 @@ class LoginActivity : AppCompatActivity() {
         }
 
         binding.kakaoLoginBtn.setOnClickListener {
-            viewModel.kakaoLogin()
+            startKakaoLogin()
         }
 
         observeViewModel()
@@ -44,18 +42,40 @@ class LoginActivity : AppCompatActivity() {
         viewModel.loginResult.observe(this) { result ->
             when (result) {
                 is LoginResult.Loading -> {
-                    // TODO: 로딩
+                    // TODO: 로딩 처리
                 }
-
                 is LoginResult.Success -> {
                     val intent = Intent(this, SignUpActivity::class.java)
                     startActivity(intent)
                 }
-
-                is LoginResult.Error -> { result
+                is LoginResult.Error -> {
                     Log.d("KakaoLogin", "카카오 로그인 실패 ${result.message}")
+                    Toast.makeText(this, result.message ?: "로그인 실패", Toast.LENGTH_SHORT).show()
                 }
             }
         }
     }
+
+    private fun startKakaoLogin() {
+        val callback: (com.kakao.sdk.auth.model.OAuthToken?, Throwable?) -> Unit = { token, error ->
+            if (error != null) {
+                viewModel.onKakaoLoginFailed(error)
+            } else if (token != null) {
+                viewModel.exchangeKakaoToken(token.accessToken)
+            }
+        }
+
+        if (UserApiClient.instance.isKakaoTalkLoginAvailable(this)) {
+            UserApiClient.instance.loginWithKakaoTalk(this) { token, error ->
+                if (error != null) {
+                    UserApiClient.instance.loginWithKakaoAccount(this, callback = callback)
+                } else {
+                    callback(token, null)
+                }
+            }
+        } else {
+            UserApiClient.instance.loginWithKakaoAccount(this, callback = callback)
+        }
+    }
+
 }

--- a/app/src/main/java/com/example/teumteum/ui/signin/viewModel/LoginViewModel.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signin/viewModel/LoginViewModel.kt
@@ -8,8 +8,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.teumteum.data.remote.login.repository.LoginRepository
 import com.example.teumteum.ui.signin.data.LoginResult
-import com.kakao.sdk.auth.model.OAuthToken
-import com.kakao.sdk.user.UserApiClient
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.launch
@@ -24,24 +22,13 @@ class LoginViewModel @Inject constructor(
     private val _loginResult = MutableLiveData<LoginResult>()
     val loginResult: LiveData<LoginResult> = _loginResult
 
-    fun kakaoLogin() {
+    fun exchangeKakaoToken(kakaoAccessToken: String) {
         _loginResult.value = LoginResult.Loading
+        getJwtFromServer(kakaoAccessToken)
+    }
 
-        // 카카오 SDK 호출
-        val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
-            if (error != null) {
-                _loginResult.postValue(LoginResult.Error("카카오 로그인 실패: ${error.message}"))
-            } else if (token != null) {
-                Log.d("KakaoAccessToken", token.accessToken.toString())
-                getJwtFromServer(token.accessToken)
-            }
-        }
-
-        if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
-            UserApiClient.instance.loginWithKakaoTalk(context, callback = callback)
-        } else {
-            UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
-        }
+    fun onKakaoLoginFailed(t: Throwable) {
+        _loginResult.postValue(LoginResult.Error("카카오 로그인 실패: ${t.message}"))
     }
 
     private fun getJwtFromServer(kakaoAccessToken: String) {


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #166 

## ✨ 작업 내용
- 카카오 로그인 호출 위치를 ViewModel에서 Activity로 이동
- Activity context를 사용하도록 수정하여 `FLAG_ACTIVITY_NEW_TASK` 오류 해결
- 카카오톡 로그인 실패 시 계정 로그인으로 폴백 처리 추가
- ViewModel은 토큰 처리, 서버 요청, 상태 업데이트만 담당하도록 구조 변경

## ✅ 코드 리뷰어 체크리스트
> 리뷰어가 확인해야할 부분
- [ ] Activity에서 카카오 SDK 호출 로직이 정상적으로 동작하는지
- [ ] ViewModel의 토큰 처리/서버 요청 로직이 정상적으로 수행되는지

## 📸 스크린샷 (선택)

<img src="https://github.com/user-attachments/assets/bf9303cb-fa0f-4862-b82c-13afdc5b752b" width="300"/>

## 💬 기타 참고 사항
- ViewModel에서 applicationContext로 카카오 로그인 호출 시 `FLAG_ACTIVITY_NEW_TASK` 예외 발생하여 로그인 시작 로직을 Activity로 이동하여 Activity context 사용, ViewModel은 토큰 처리만 담당하도록 했습니다.
- 현재는 우선 동작할 수 있도록 빠르게 수정한 상태이며, 추후 구조 리팩토링 및 코드 정리를 해주셔도 좋습니다.