### PR TITLE
[FIX/#173] 투두 등록 시 성공 토스트 중복 노출 방지

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/todo/TodoRegisterFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/TodoRegisterFragment.kt
@@ -20,6 +20,9 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.bumptech.glide.Glide
 import com.example.teumteum.databinding.FragmentTodoRegisterBinding
 import com.example.teumteum.R
@@ -40,6 +43,7 @@ import com.example.teumteum.ui.todo.viewModel.TodoViewModel
 import com.example.teumteum.utils.combineDateTime
 import com.google.gson.Gson
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 import java.time.LocalDate
 import java.time.LocalTime
@@ -638,23 +642,24 @@ class TodoRegisterFragment : BottomSheetDialogFragment(), IDateClickListener{
 //    }
 
     private fun setupObservers() {
+        // 성공 이벤트는 Flow 수집으로 1회성 처리
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.registerSuccess.collect {
+                    Toast.makeText(requireContext(), "투두가 성공적으로 등록되었습니다.", Toast.LENGTH_SHORT).show()
+                    parentFragmentManager.setFragmentResult("todo_register", Bundle())
 
-//        viewModel.onBoardingReminders.observe(viewLifecycleOwner) { minutes: List<Int> ->
-//            applyRemindersFromMinutes(minutes)
-//        }
-
-        viewModel.registerSuccess.observe(viewLifecycleOwner) {
-            Toast.makeText(requireContext(), "투두가 성공적으로 등록되었습니다.", Toast.LENGTH_SHORT).show()
-            parentFragmentManager.setFragmentResult("todo_register", Bundle())
-
-            // 모든 바텀시트 닫기
-            (requireActivity().supportFragmentManager.fragments).forEach { fragment ->
-                if (fragment is BottomSheetDialogFragment) {
-                    fragment.dismissAllowingStateLoss()
+                    // 모든 바텀시트 닫기
+                    (requireActivity().supportFragmentManager.fragments).forEach { fragment ->
+                        if (fragment is BottomSheetDialogFragment) {
+                            fragment.dismissAllowingStateLoss()
+                        }
+                    }
                 }
             }
         }
 
+        // 실패 메시지는 LiveData 그대로
         viewModel.errorMessage.observe(viewLifecycleOwner) { errorMsg ->
             Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
         }

--- a/app/src/main/java/com/example/teumteum/ui/todo/viewModel/TodoViewModel.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/viewModel/TodoViewModel.kt
@@ -12,6 +12,9 @@ import com.example.teumteum.data.remote.todo.model.RegisterTodoRequest
 import com.example.teumteum.data.remote.todo.model.TodoListResult
 import com.example.teumteum.data.remote.todo.repository.TodoRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -35,8 +38,8 @@ class TodoViewModel @Inject constructor(
     private val _alarmStatusUpdated = MutableLiveData<Boolean>()
     val alarmStatusUpdated: LiveData<Boolean> get() = _alarmStatusUpdated
 
-    private val _registerSuccess = MutableLiveData<Boolean>()
-    val registerSuccess: LiveData<Boolean> get() = _registerSuccess
+    private val _registerSuccess = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val registerSuccess: SharedFlow<Unit> = _registerSuccess.asSharedFlow()
 
     private val _editSuccess = MutableLiveData<Boolean>()
     val editSuccess: LiveData<Boolean> get() = _editSuccess
@@ -49,8 +52,7 @@ class TodoViewModel @Inject constructor(
         viewModelScope.launch {
             val result = todoRepository.registerTodo(request)
             result.onSuccess {
-                _registerSuccess.value = true
-                _registerSuccess.value = false
+                _registerSuccess.tryEmit(Unit)
             }
             result.onFailure { e ->
                 _errorMessage.value = e.localizedMessage ?: "투두 등록에 실패했습니다."


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #173

## ✨ 작업 내용
- registerSuccess를 LiveData<Boolean>에서 SharedFlow<Unit>으로 변경하여 원타임 이벤트 처리
- TodoRegisterFragment에서 collect 사용해 성공 토스트 1회성 실행
- 바텀시트 재오픈 시 신규 등록 없이 성공 토스트가 뜨는 문제 해결

## ✅ 코드 리뷰어 체크리스트
- [x] SharedFlow 변경이 정상적으로 이벤트를 한 번만 발행하는지
- [x] Fragment에서 collect 로직이 의도대로 동작하는지
- [x] 기존 기능(투두 등록/실패 처리) 동작에 영향이 없는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
- 동일 패턴의 edit/delete 성공 이벤트에도 적용을 고려할 수 있음
- 현재 edit에서는 Fragment에서 값 체크하는 방식 사용 중
