### PR TITLE
[Fix/#175] 투두 삭제 시 시간표, 투두 리스트 최신화 문제

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/clock/ChartUtils.kt
+++ b/app/src/main/java/com/example/teumteum/ui/clock/ChartUtils.kt
@@ -115,7 +115,10 @@ object ChartUtils {
         }
 
         val data = PieData(dataSet).apply { setDrawValues(false) }
+        pieChart.clear()
         pieChart.data = data
+        pieChart.data.notifyDataChanged()
+        pieChart.notifyDataSetChanged()
         pieChart.invalidate()
     }
 

--- a/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
@@ -157,6 +157,7 @@ class HomeFragment : Fragment(), IDateClickListener {
         viewModel.teumTimeMinutes.observe(viewLifecycleOwner) { updateTeumTime() }
 
         viewModel.scheduleList.observe(viewLifecycleOwner) {
+            viewModel.refreshTodaySchedule()
             updateTimeChart(isAM)
             updateIndicator(isAM)
         }

--- a/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
@@ -403,7 +403,6 @@ class HomeFragment : Fragment(), IDateClickListener {
     private fun refreshTodolist() {
         val today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
         todoViewModel.getTodoList(date = today)
-        Log.d("TODO_LIST", "TODO_LIST: ${todoViewModel.todolistItems}")
     }
 
     private fun setupObservers() {

--- a/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
@@ -2,6 +2,7 @@ package com.example.teumteum.ui.main
 
 import android.content.res.ColorStateList
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -157,7 +158,6 @@ class HomeFragment : Fragment(), IDateClickListener {
         viewModel.teumTimeMinutes.observe(viewLifecycleOwner) { updateTeumTime() }
 
         viewModel.scheduleList.observe(viewLifecycleOwner) {
-            viewModel.refreshTodaySchedule()
             updateTimeChart(isAM)
             updateIndicator(isAM)
         }
@@ -197,11 +197,13 @@ class HomeFragment : Fragment(), IDateClickListener {
 
         // 투두 수정 성공 이벤트 수신
         parentFragmentManager.setFragmentResultListener("todo_edit", viewLifecycleOwner) { _, _ ->
+            viewModel.refreshTodaySchedule()
             refreshTodolist()
         }
 
         // 투두 삭제 성공 이벤트 수신
         parentFragmentManager.setFragmentResultListener("todo_delete", viewLifecycleOwner) { _, _ ->
+            viewModel.refreshTodaySchedule()
             refreshTodolist()
         }
 
@@ -401,6 +403,7 @@ class HomeFragment : Fragment(), IDateClickListener {
     private fun refreshTodolist() {
         val today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
         todoViewModel.getTodoList(date = today)
+        Log.d("TODO_LIST", "TODO_LIST: ${todoViewModel.todolistItems}")
     }
 
     private fun setupObservers() {

--- a/app/src/main/java/com/example/teumteum/ui/main/viewModel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/teumteum/ui/main/viewModel/HomeViewModel.kt
@@ -10,6 +10,7 @@ import com.example.teumteum.data.remote.home.repository.HomeRepository
 import com.example.teumteum.ui.main.data.TimeBlock
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import retrofit2.adapter.rxjava2.Result.response
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
@@ -90,6 +91,7 @@ class HomeViewModel @Inject constructor(
 
     //스케줄이 변경되었을 때 업데이트
     fun refreshTodaySchedule() {
+        Log.d("asdf", "viewmodel")
         val currentDate = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
         date = currentDate
         getTodaySchedule(currentDate)

--- a/app/src/main/java/com/example/teumteum/ui/todo/TodoEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/TodoEditFragment.kt
@@ -1,5 +1,6 @@
 package com.example.teumteum.ui.todo
 
+import android.R.string.ok
 import android.app.Dialog
 import android.content.Context
 import android.os.Bundle
@@ -22,6 +23,9 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.bumptech.glide.Glide
 import com.example.teumteum.R
 import com.example.teumteum.databinding.FragmentTodoEditBinding
@@ -35,13 +39,16 @@ import com.example.teumteum.databinding.DialogConfirmTodoDeleteBinding
 import com.example.teumteum.databinding.DialogConfirmTodoEditBinding
 import com.example.teumteum.ui.calendar.IDateClickListener
 import com.example.teumteum.ui.calendar.MonthlyCalendarFragment
+import com.example.teumteum.ui.main.HomeFragment
 import com.example.teumteum.ui.main.data.TimeBlock
+import com.example.teumteum.ui.main.viewModel.HomeViewModel
 import com.example.teumteum.ui.myhome.viewModel.MyHomeViewModel
 import com.example.teumteum.ui.todo.viewModel.TodoViewModel
 import com.example.teumteum.utils.combineDateTime
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -69,6 +76,7 @@ class TodoEditFragment : BottomSheetDialogFragment(), IDateClickListener {
 
     private val viewModel: TodoViewModel by activityViewModels()
     private val myHomeViewModel: MyHomeViewModel by activityViewModels()
+//    private val homeViewModel: HomeViewModel by activityViewModels()
 
     private val alarmLabelToMinutes = mapOf(
         "30분 전" to 30,
@@ -612,9 +620,12 @@ class TodoEditFragment : BottomSheetDialogFragment(), IDateClickListener {
             .create()
 
         dialogBinding.todoConfirmTv.setOnClickListener {
-            viewModel.deleteTodo(todoId)
-            dialog.dismiss()
-            dismiss()
+//            viewModel.deleteTodo(todoId)
+//            dialog.dismiss()
+//            dismiss()
+            dialogBinding.todoConfirmTv.isEnabled = false // 중복 클릭 방지
+            dialog.dismiss() // 확인 다이얼로그만 닫기
+            viewModel.deleteTodo(todoId) // 삭제 요청만 보냄
         }
 
         dialogBinding.todoCancelTv.setOnClickListener {
@@ -890,10 +901,18 @@ class TodoEditFragment : BottomSheetDialogFragment(), IDateClickListener {
             if (it == true) {
                 Toast.makeText(requireContext(), "투두가 성공적으로 삭제되었습니다.", Toast.LENGTH_SHORT).show()
                 parentFragmentManager.setFragmentResult("todo_delete", Bundle())
+//                homeViewModel.refreshTodaySchedule()
                 dismiss()  // 현재 바텀시트만 닫기
+
             }
+
         }
 
+        viewModel.errorMessage.observe(viewLifecycleOwner) { errorMsg ->
+            Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
+        }
+
+        // 실패 메시지는 LiveData 그대로
         viewModel.errorMessage.observe(viewLifecycleOwner) { errorMsg ->
             Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
         }


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #175

## ✨ 작업 내용
> 투두 삭제 시에 시간표와 투두 리스트가 최신화 안되는 문제가 있어 해결했습니다.
> 삭제 확인 다이얼로그에서 dismiss()를 먼저 호출해서 TodoEditFragment의 viewLifecycleOwner가 사라져서 제대로 호출이 안되는 문제로 확인하였습니다.

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] 투두 등록, 수정, 삭제했을때 투두 리스트와 원형 시간표가 제대로 최신화되는지 확인해주세요.

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항
