### PR TITLE
[FIX/#180] 네트워크 모듈 구조 개선 및 토큰 재발급 로직 수정

### DIFF
--- a/app/src/main/java/com/example/teumteum/utils/ApiModule.kt
+++ b/app/src/main/java/com/example/teumteum/utils/ApiModule.kt
@@ -16,69 +16,70 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
 import javax.inject.Singleton
-import kotlin.jvm.java
 
 @Module
 @InstallIn(SingletonComponent::class)
 class ApiModule {
 
+    // 인증이 필요한 API들 - @AuthRetrofit 사용
     @Provides
     @Singleton
-    fun provideTodoApi(retrofit: Retrofit): TodoService {
+    fun provideTodoApi(@AuthRetrofit retrofit: Retrofit): TodoService {
         return retrofit.create(TodoService::class.java)
     }
 
     @Provides
     @Singleton
-    fun provideWishApi(retrofit: Retrofit): WishService {
+    fun provideWishApi(@AuthRetrofit retrofit: Retrofit): WishService {
         return retrofit.create(WishService::class.java)
     }
 
     @Provides
     @Singleton
-    fun provideAlarmApi(retrofit: Retrofit): AlarmRetrofitInterface {
+    fun provideAlarmApi(@AuthRetrofit retrofit: Retrofit): AlarmRetrofitInterface {
         return retrofit.create(AlarmRetrofitInterface::class.java)
     }
 
     @Provides
     @Singleton
-    fun provideCalendarApi(retrofit: Retrofit): CalendarService {
+    fun provideCalendarApi(@AuthRetrofit retrofit: Retrofit): CalendarService {
         return retrofit.create(CalendarService::class.java)
     }
 
     @Provides
     @Singleton
-    fun provideFriendApi(retrofit: Retrofit): FriendService {
+    fun provideFriendApi(@AuthRetrofit retrofit: Retrofit): FriendService {
         return retrofit.create(FriendService::class.java)
     }
 
     @Provides
     @Singleton
-    fun provideHomeApi(retrofit: Retrofit): HomeService {
+    fun provideHomeApi(@AuthRetrofit retrofit: Retrofit): HomeService {
         return retrofit.create(HomeService::class.java)
     }
 
     @Provides
     @Singleton
-    fun provideOnBoardingApi(retrofit: Retrofit): OnBoardingService {
+    fun provideOnBoardingApi(@AuthRetrofit retrofit: Retrofit): OnBoardingService {
         return retrofit.create(OnBoardingService::class.java)
     }
 
     @Provides
     @Singleton
-    fun provideMyPageApi(retrofit: Retrofit): MyPageService {
+    fun provideMyPageApi(@AuthRetrofit retrofit: Retrofit): MyPageService {
         return retrofit.create(MyPageService::class.java)
     }
 
     @Provides
     @Singleton
-    fun provideActivityApi(retrofit: Retrofit): ActivityService {
+    fun provideActivityApi(@AuthRetrofit retrofit: Retrofit): ActivityService {
         return retrofit.create(ActivityService::class.java)
     }
 
+    // 인증이 필요 없는 API - @NoAuthRetrofit 사용
     @Provides
     @Singleton
-    fun provideLoginApi(retrofit: Retrofit): AuthService {
+    fun provideLoginApi(@NoAuthRetrofit retrofit: Retrofit): AuthService {
         return retrofit.create(AuthService::class.java)
     }
 }

--- a/app/src/main/java/com/example/teumteum/utils/AuthIntercepter.kt
+++ b/app/src/main/java/com/example/teumteum/utils/AuthIntercepter.kt
@@ -1,0 +1,135 @@
+package com.example.teumteum.utils
+
+import android.util.Log
+import com.example.teumteum.BuildConfig
+import com.example.teumteum.data.remote.login.model.ReissueRequest
+import com.example.teumteum.data.remote.login.service.AuthService
+import com.google.gson.Gson
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Response
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Inject
+
+data class ErrorResponse(
+    val isSuccess: Boolean,
+    val code: String,
+    val message: String
+)
+
+class AuthInterceptor @Inject constructor(
+    private val tokenProvider: TokenProvider
+) : Interceptor {
+
+    companion object {
+        private const val AUTH_HEADER = "Authorization"
+        private const val BEARER_PREFIX = "Bearer "
+        private const val JWT_EXPIRED_CODE = "AUTH4113"
+        private const val HTTP_UNAUTHORIZED = 401
+
+        private val NO_AUTH_PATHS = listOf(
+            "/api/auth/social-login/kakao",
+            "/api/auth/reissue"
+        )
+    }
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val originalRequest = chain.request()
+
+        // 토큰이 필요 없는 요청들은 바로 진행
+        if (isNoAuthRequired(originalRequest.url.encodedPath)) {
+            return chain.proceed(originalRequest)
+        }
+
+        val accessToken = tokenProvider.getAccessToken()
+        val refreshToken = tokenProvider.getRefreshToken()
+
+        // Access Token으로 요청 생성
+        val requestWithToken = originalRequest.newBuilder().apply {
+            if (!accessToken.isNullOrEmpty()) {
+                addHeader(AUTH_HEADER, "$BEARER_PREFIX$accessToken")
+            }
+        }.build()
+
+        val response = chain.proceed(requestWithToken)
+
+        // JWT 토큰 만료 확인 (HTTP 401 + 응답 본문의 코드 확인)
+        if (isTokenExpired(response) && !refreshToken.isNullOrEmpty()) {
+            response.close()
+
+            val newAccessToken = refreshAccessToken(refreshToken)
+
+            if (!newAccessToken.isNullOrEmpty()) {
+                val newRequest = originalRequest.newBuilder()
+                    .header(AUTH_HEADER, "$BEARER_PREFIX$newAccessToken")
+                    .build()
+                return chain.proceed(newRequest)
+            }
+        }
+
+        return response
+    }
+
+    private fun isNoAuthRequired(path: String): Boolean {
+        return NO_AUTH_PATHS.any { path.contains(it) }
+    }
+
+    private fun isTokenExpired(response: Response): Boolean {
+        if (response.code != HTTP_UNAUTHORIZED) return false
+
+        return try {
+            val source = response.body?.source()
+            source?.request(Long.MAX_VALUE)
+            val buffer = source?.buffer?.clone()
+            val responseBodyString = buffer?.readUtf8() ?: ""
+
+            if (responseBodyString.isNotEmpty()) {
+                val errorResponse = Gson().fromJson(responseBodyString, ErrorResponse::class.java)
+                errorResponse.code == JWT_EXPIRED_CODE
+            } else {
+                // 응답 본문이 없으면 401만으로 판단
+                true
+            }
+        } catch (e: Exception) {
+            Log.e("AuthInterceptor", "Error parsing response body", e)
+            // JSON 파싱 실패 시에도 401이면 토큰 만료로 처리
+            true
+        }
+    }
+
+    private fun refreshAccessToken(refreshToken: String): String? {
+        return runBlocking {
+            try {
+                val retrofit = Retrofit.Builder()
+                    .baseUrl(BuildConfig.BASE_URL)
+                    .addConverterFactory(GsonConverterFactory.create())
+                    .build()
+
+                val tempAuthService = retrofit.create(AuthService::class.java)
+                val reissueResponse = tempAuthService.reissue(ReissueRequest(refreshToken))
+
+                if (reissueResponse.isSuccessful) {
+                    val newToken = reissueResponse.body()?.result
+                    fun String.mask() = if (length > 10) take(4) + "..." + takeLast(6) else "***"
+
+                    Log.d("AuthInterceptor", "Token refreshed successfully")
+                    Log.d("AuthInterceptor", "NewAccessToken: ${newToken?.accessToken?.mask()}")
+                    Log.d("AuthInterceptor", "NewRefreshToken: ${newToken?.refreshToken?.mask()}")
+
+                    tokenProvider.saveTokens(
+                        accessToken = newToken?.accessToken ?: "",
+                        refreshToken = newToken?.refreshToken ?: refreshToken
+                    )
+                    newToken?.accessToken
+                } else {
+                    Log.e("AuthInterceptor", "Token refresh failed: ${reissueResponse.code()}")
+                    null
+                }
+            } catch (e: Exception) {
+                Log.e("AuthInterceptor", "Token refresh error", e)
+                null
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/teumteum/utils/NetworkModule.kt
+++ b/app/src/main/java/com/example/teumteum/utils/NetworkModule.kt
@@ -1,22 +1,25 @@
 package com.example.teumteum.utils
 
-import android.content.Context
-import android.util.Log
 import com.example.teumteum.BuildConfig
-import com.example.teumteum.data.remote.login.model.ReissueRequest
-import com.example.teumteum.data.remote.login.service.AuthService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.runBlocking
-import okhttp3.Interceptor
 import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
+import javax.inject.Qualifier
 import javax.inject.Singleton
 
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AuthRetrofit
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class NoAuthRetrofit
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -26,96 +29,36 @@ class NetworkModule {
     @Singleton
     fun provideBaseUrl(): String = BuildConfig.BASE_URL
 
-//    @Provides
-//    @Singleton
-//    fun provideAuthInterceptor(): Interceptor {
-//        return Interceptor { chain ->
-//            val newRequest = chain.request().newBuilder()
-//                .addHeader("Authorization", "Bearer ${BuildConfig.TEMP_ACCESS_TOKEN}")
-//                .build()
-//            chain.proceed(newRequest)
-//        }
-//    }
-
     @Provides
     @Singleton
-    fun provideAuthInterceptor(
-        tokenProvider: TokenProvider
-    ): Interceptor {
-        return Interceptor { chain ->
-            val originalRequest = chain.request()
-
-            //토큰 필요없는 요청들
-            val noAuthPaths = listOf("/api/auth/social-login/kakao", "/api/auth/reissue")
-            if (noAuthPaths.any { originalRequest.url.encodedPath.contains(it) }) {
-                // 토큰 필요 없는 요청은 바로 진행
-                return@Interceptor chain.proceed(originalRequest)
+    fun provideHttpLoggingInterceptor(): HttpLoggingInterceptor {
+        return HttpLoggingInterceptor().apply {
+            level = if (BuildConfig.DEBUG) {
+                HttpLoggingInterceptor.Level.BODY
+            } else {
+                HttpLoggingInterceptor.Level.NONE
             }
-
-            var accessToken = tokenProvider.getAccessToken()
-            val refreshToken = tokenProvider.getRefreshToken()
-
-            val requestWithToken = originalRequest.newBuilder().apply {
-                if (!accessToken.isNullOrEmpty()) {
-                    addHeader("Authorization", "Bearer $accessToken")
-                }
-            }.build()
-
-            val response = chain.proceed(requestWithToken)
-
-            // 액세스 토큰이 만료된 경우 (401 응답)
-            if (response.code == 401 && !refreshToken.isNullOrEmpty()) {
-                response.close()
-
-                val newAccessToken = runBlocking {
-                    try {
-                        val retrofit = Retrofit.Builder()
-                            .baseUrl(BuildConfig.BASE_URL)
-                            .addConverterFactory(GsonConverterFactory.create())
-                            .build()
-
-                        val tempAuthService = retrofit.create(AuthService::class.java)
-
-                        val reissueResponse = tempAuthService.reissue(ReissueRequest(refreshToken))
-
-                        if (reissueResponse.isSuccessful) {
-                            val newToken = reissueResponse.body()?.result
-                            Log.d("Reissue", "NewAccessToken: ${newToken?.accessToken}, NewRefreshToken: ${newToken?.refreshToken}")
-                            tokenProvider.saveTokens(
-                                accessToken = newToken?.accessToken ?: "",
-                                refreshToken = newToken?.refreshToken ?: refreshToken
-                            )
-                            newToken?.accessToken
-                        } else null
-                    } catch (e: Exception) {
-                        null
-                    }
-                }
-
-                if (!newAccessToken.isNullOrEmpty()) {
-                    val newRequest = originalRequest.newBuilder()
-                        .header("Authorization", "Bearer $newAccessToken")
-                        .build()
-                    return@Interceptor chain.proceed(newRequest)
-                }
-            }
-
-            return@Interceptor response
         }
     }
 
     @Provides
     @Singleton
     fun provideOkHttpClient(
-        authInterceptor: Interceptor
+        authInterceptor: AuthInterceptor,
+        loggingInterceptor: HttpLoggingInterceptor
     ): OkHttpClient {
         return OkHttpClient.Builder()
             .addInterceptor(authInterceptor)
+            .addInterceptor(loggingInterceptor)
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
             .build()
     }
 
     @Provides
     @Singleton
+    @AuthRetrofit
     fun provideRetrofit(
         baseUrl: String,
         client: OkHttpClient
@@ -126,8 +69,22 @@ class NetworkModule {
             .addConverterFactory(GsonConverterFactory.create())
             .build()
     }
+
+    // 토큰 없이 사용할 Retrofit 인스턴스 (필요한 경우)
+    @Provides
+    @Singleton
+    @NoAuthRetrofit
+    fun provideRetrofitWithoutAuth(
+        baseUrl: String
+    ): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
 }
 
+// 기존 함수들 (호환성을 위해 유지)
 const val BASE_URL = BuildConfig.BASE_URL
 
 fun getRetrofit(): Retrofit {


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #180 

## ✨ 작업 내용
- `AuthInterceptor`를 분리하여 인증 로직 모듈화
- no-auth 경로 화이트리스트 처리로 불필요한 `Authorization` 헤더 전송 방지
- 401 및 `AUTH4113` 응답 시 RefreshToken을 이용한 AccessToken 자동 재발급
- 신규 토큰 저장 후 원 요청 재시도 처리
- `@AuthRetrofit` / `@NoAuthRetrofit` Qualifier로 인증/비인증 Retrofit 인스턴스 분리
- `HttpLoggingInterceptor` 및 타임아웃 설정 추가
- 토큰 로그 출력 시 마스킹 처리로 민감정보 노출 방지

## ✅ 코드 리뷰어 체크리스트
- [ ] `AuthIntercepter` 분리
- [ ] 로그 출력 시 마스킹 처리

## 📸 스크린샷 (선택)
- 없음

## 💬 기타 참고 사항
- 커밋메시지 헤더 안 바꾸고 커밋해버렸습니다.. 참고하시길
- 로컬 서버에서 AT: 1분, RT: 3분으로 두고 테스트 진행했습니다

#### 테스트
```
--> POST /api/users/onboarding/nickname-job
Authorization: Bearer eyJhbGciOiJIUzI1NiJ9... (만료된 토큰)
<-- 401 (34ms)
{"isSuccess":false,"code":"AUTH4113","message":"JWT 토큰이 만료되었습니다."}
```
```
--> POST /api/users/onboarding/nickname-job (자동 재시도)
Authorization: Bearer eyJhbGciOiJIUzI1NiJ9... (새로운 토큰)
<-- 200 (162ms)
{"isSuccess":true,"code":"ONBOARDING2002","message":"닉네임과 분야/직종 등록이 완료되었습니다."}
```

우선 내일까지 마감이니 굴러가도록 구현은 해놨는데 수정보완이 필요할 것 같습니다!!