### PR TITLE
[Fix/#178] 투두 조회화면에서 친구와 약속된 틈일 경우 수정

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/todo/TodoEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/TodoEditFragment.kt
@@ -26,6 +26,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
 import com.example.teumteum.R
 import com.example.teumteum.databinding.FragmentTodoEditBinding
@@ -43,6 +44,7 @@ import com.example.teumteum.ui.main.HomeFragment
 import com.example.teumteum.ui.main.data.TimeBlock
 import com.example.teumteum.ui.main.viewModel.HomeViewModel
 import com.example.teumteum.ui.myhome.viewModel.MyHomeViewModel
+import com.example.teumteum.ui.todo.adapter.TeumProfileAdapter
 import com.example.teumteum.ui.todo.viewModel.TodoViewModel
 import com.example.teumteum.utils.combineDateTime
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -64,6 +66,8 @@ class TodoEditFragment : BottomSheetDialogFragment(), IDateClickListener {
     private var currentTargetTextView: TextView? = null
 
     private var todoId: Long = -1
+
+    private val profileAdapter by lazy { TeumProfileAdapter() }
 
     private val selectedItems = mutableSetOf<String>()
     private val alarmOptions = listOf("30분 전", "10분 전", "5분 전", "3분 전", "1분 전")
@@ -130,6 +134,15 @@ class TodoEditFragment : BottomSheetDialogFragment(), IDateClickListener {
             val end = it.getString("sleepEnd")
             sleepStart = start?.let { LocalTime.parse(it) }
             sleepEnd = end?.let { LocalTime.parse(it) }
+        }
+
+        binding.profileImageRc.apply {
+            layoutManager = LinearLayoutManager(
+                requireContext(),
+                LinearLayoutManager.HORIZONTAL,
+                false
+            )
+            adapter = profileAdapter
         }
 
         // isAlarmOn 값에 따른 알림 바텀시트 변경
@@ -203,17 +216,17 @@ class TodoEditFragment : BottomSheetDialogFragment(), IDateClickListener {
             toggleCalendarVisibility()
         }
 
-        myHomeViewModel.profileImageUrl.observe(viewLifecycleOwner) { imageUrl ->
-            if (!imageUrl.isNullOrBlank()) {
-                Glide.with(this)
-                    .load(imageUrl)
-                    .placeholder(R.drawable.gray_teum) // 기본 이미지 리소스
-                    .error(R.drawable.gray_teum)       // 에러 시 이미지
-                    .into(binding.profileIv)
-            } else {
-                binding.profileIv.setImageResource(R.drawable.gray_teum)
-            }
-        }
+//        myHomeViewModel.profileImageUrl.observe(viewLifecycleOwner) { imageUrl ->
+//            if (!imageUrl.isNullOrBlank()) {
+//                Glide.with(this)
+//                    .load(imageUrl)
+//                    .placeholder(R.drawable.gray_teum) // 기본 이미지 리소스
+//                    .error(R.drawable.gray_teum)       // 에러 시 이미지
+//                    .into(binding.profileIv)
+//            } else {
+//                binding.profileIv.setImageResource(R.drawable.gray_teum)
+//            }
+//        }
 
         setupObservers()
 
@@ -777,6 +790,11 @@ class TodoEditFragment : BottomSheetDialogFragment(), IDateClickListener {
             binding.alarmLayoutContainer.removeAllViews()
             selectedItems.clear()
 
+            val urls: List<String> = todo.profileUrl ?: emptyList()
+            profileAdapter.submitList(urls)
+            Log.d("profiles", urls.toString())
+            binding.profileImageRc.isVisible = urls.isNotEmpty()
+
             todo.remindAlarm?.forEach { remindAlarm ->
                 val minutes = remindAlarm.alarm
                 val isOn = (remindAlarm.status == AlarmStatus.ACTIVE)
@@ -916,5 +934,6 @@ class TodoEditFragment : BottomSheetDialogFragment(), IDateClickListener {
         viewModel.errorMessage.observe(viewLifecycleOwner) { errorMsg ->
             Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
         }
+
     }
 }

--- a/app/src/main/java/com/example/teumteum/ui/todo/TodoEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/TodoEditFragment.kt
@@ -56,6 +56,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
 import java.util.Locale
 
 @AndroidEntryPoint
@@ -773,8 +774,10 @@ class TodoEditFragment : BottomSheetDialogFragment(), IDateClickListener {
 
             binding.todoTitleEt.setText(todo.title)
 
-            val startDateTime = LocalDateTime.parse(todo.startTime)
-            val endDateTime = LocalDateTime.parse(todo.endTime)
+//            val startDateTime = LocalDateTime.parse(todo.startTime)
+//            val endDateTime = LocalDateTime.parse(todo.endTime)
+            val startDateTime = parseApiDateTime(todo.startTime)
+            val endDateTime   = parseApiDateTime(todo.endTime)
 
             val dateFormatter = DateTimeFormatter.ofPattern("M월 d일 (E)", Locale.KOREAN)
             val timeFormatter = DateTimeFormatter.ofPattern("a h:mm", Locale.KOREAN)
@@ -851,6 +854,7 @@ class TodoEditFragment : BottomSheetDialogFragment(), IDateClickListener {
             originalIncludeTeum = todo.includeTeum
             originalRemindAlarm = (todo.remindAlarm ?: emptyList()).map { it.alarm }
 
+            //반복일정은 삭제만 가능
             if (todo.type == ScheduleType.ROUTINE) {
                 val deactiveColor = ContextCompat.getColor(requireContext(), R.color.teumteum_deactive)
 
@@ -888,7 +892,7 @@ class TodoEditFragment : BottomSheetDialogFragment(), IDateClickListener {
                 binding.publicToggle01Iv.isEnabled = false
                 binding.includeToggle01Iv.isEnabled = false
 
-                binding.btnTodoDelete.isEnabled = false
+//                binding.btnTodoDelete.isEnabled = false
                 binding.btnTodoSave.isEnabled = false
 
                 for (i in 0 until binding.alarmLayoutContainer.childCount) {
@@ -909,6 +913,66 @@ class TodoEditFragment : BottomSheetDialogFragment(), IDateClickListener {
                 }
 
                 Toast.makeText(requireContext(), "반복일정은 편집할 수 없습니다.", Toast.LENGTH_SHORT).show()
+            }
+
+            //약속된 틈은 일부 수정 가능(공개 설정, 빈틈시간 기록 포함, 상세 내용)
+            if (todo.type == ScheduleType.TEUM) {
+                val deactiveColor = ContextCompat.getColor(requireContext(), R.color.teumteum_deactive)
+
+                binding.todoTitleEt.setTextColor(deactiveColor)
+                binding.timerIconIv.setColorFilter(deactiveColor)
+                binding.startDateTv.setTextColor(deactiveColor)
+                binding.startTimeTv.setTextColor(deactiveColor)
+                binding.endDateTv.setTextColor(deactiveColor)
+                binding.endTimeTv.setTextColor(deactiveColor)
+//                binding.alarmIconIv.setColorFilter(deactiveColor)
+//                binding.alarmSet01Tv.setTextColor(deactiveColor)
+//                binding.alarmSet02Tv.setTextColor(deactiveColor)
+//                binding.addAlarmTv.setTextColor(deactiveColor)
+//                binding.publicIconIv.setColorFilter(deactiveColor)
+//                binding.publicSettingTv.setTextColor(deactiveColor)
+//                binding.includeIconIv.setColorFilter(deactiveColor)
+//                binding.includeReportTv.setTextColor(deactiveColor)
+//                binding.detailTextIv.setColorFilter(deactiveColor)
+//                binding.detailTextEt.setTextColor(deactiveColor)
+//                binding.detailTextEt.setHintTextColor(deactiveColor)
+
+                binding.todoTitleEt.isEnabled = false
+                binding.startDateTv.isEnabled = false
+                binding.startTimeTv.isEnabled = false
+                binding.endDateTv.isEnabled = false
+                binding.endTimeTv.isEnabled = false
+//                binding.alarmSet01Tv.isEnabled = false
+//                binding.alarmSet02Tv.isEnabled = false
+//                binding.addAlarmTv.isEnabled = false
+//                binding.btnPlus.isEnabled = false
+//                binding.detailTextEt.isEnabled = false
+
+//                binding.alarmToggle01Iv.isEnabled = false
+//                binding.alarmToggle02Iv.isEnabled = false
+//                binding.publicToggle01Iv.isEnabled = false
+//                binding.includeToggle01Iv.isEnabled = false
+
+//                binding.btnTodoDelete.isEnabled = false
+//                binding.btnTodoSave.isEnabled = false
+
+                for (i in 0 until binding.alarmLayoutContainer.childCount) {
+                    val alarmView = binding.alarmLayoutContainer.getChildAt(i)
+
+                    if (alarmView is ViewGroup) {
+                        for (j in 0 until alarmView.childCount) {
+                            val child = alarmView.getChildAt(j)
+
+                            (child as? TextView)?.setTextColor(deactiveColor)
+                            (child as? SwitchCompat)?.apply {
+                                isEnabled = false
+                                trackDrawable = ContextCompat.getDrawable(context, R.drawable.style_toggle_disabled_btn)
+                                thumbDrawable = ContextCompat.getDrawable(context, R.drawable.style_toggle_disabled_thumb)
+                            }
+                        }
+                    }
+                }
+
             }
 
             parentFragmentManager.setFragmentResult("todo_get", Bundle())
@@ -943,5 +1007,20 @@ class TodoEditFragment : BottomSheetDialogFragment(), IDateClickListener {
             Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
         }
 
+    }
+
+    private fun parseApiDateTime(raw: String): LocalDateTime {
+        return try {
+            LocalDateTime.parse(raw) // 정상(0~23시)인 경우
+        } catch (e: DateTimeParseException) {
+            // 24:MM[:SS] 대응 (예: 2025-08-14T24:00 또는 2025-08-14T24:00:00)
+            val m = Regex("""^(\d{4}-\d{2}-\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$""").matchEntire(raw)
+                ?: throw e
+            val date = LocalDate.parse(m.groupValues[1])
+            val hour = m.groupValues[2].toInt()
+            val minute = m.groupValues[3].toInt()
+            val second = m.groupValues.getOrNull(4)?.takeIf { it.isNotEmpty() }?.toInt() ?: 0
+            if (hour == 24) date.plusDays(1).atTime(0, minute, second) else throw e
+        }
     }
 }

--- a/app/src/main/java/com/example/teumteum/ui/todo/TodoEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/TodoEditFragment.kt
@@ -40,6 +40,7 @@ import com.example.teumteum.databinding.DialogConfirmTodoDeleteBinding
 import com.example.teumteum.databinding.DialogConfirmTodoEditBinding
 import com.example.teumteum.ui.calendar.IDateClickListener
 import com.example.teumteum.ui.calendar.MonthlyCalendarFragment
+import com.example.teumteum.ui.friend.viewModel.FriendViewModel
 import com.example.teumteum.ui.main.HomeFragment
 import com.example.teumteum.ui.main.data.TimeBlock
 import com.example.teumteum.ui.main.viewModel.HomeViewModel
@@ -80,6 +81,7 @@ class TodoEditFragment : BottomSheetDialogFragment(), IDateClickListener {
 
     private val viewModel: TodoViewModel by activityViewModels()
     private val myHomeViewModel: MyHomeViewModel by activityViewModels()
+    private val friendViewModel: FriendViewModel by activityViewModels()
 //    private val homeViewModel: HomeViewModel by activityViewModels()
 
     private val alarmLabelToMinutes = mapOf(
@@ -638,7 +640,14 @@ class TodoEditFragment : BottomSheetDialogFragment(), IDateClickListener {
 //            dismiss()
             dialogBinding.todoConfirmTv.isEnabled = false // 중복 클릭 방지
             dialog.dismiss() // 확인 다이얼로그만 닫기
-            viewModel.deleteTodo(todoId) // 삭제 요청만 보냄
+            val type = viewModel.todo.value?.type
+            if (type == ScheduleType.TEUM) {
+                // 친구와 약속된 TEUM이면 다른 API 호출
+                friendViewModel.cancelTeumSchedule(todoId.toInt())
+            } else {
+                // 기존 투두 삭제 API
+                viewModel.deleteTodo(todoId)
+            }
         }
 
         dialogBinding.todoCancelTv.setOnClickListener {
@@ -792,7 +801,6 @@ class TodoEditFragment : BottomSheetDialogFragment(), IDateClickListener {
 
             val urls: List<String> = todo.profileUrl ?: emptyList()
             profileAdapter.submitList(urls)
-            Log.d("profiles", urls.toString())
             binding.profileImageRc.isVisible = urls.isNotEmpty()
 
             todo.remindAlarm?.forEach { remindAlarm ->

--- a/app/src/main/java/com/example/teumteum/ui/todo/adapter/TeumProfileAdapter.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/adapter/TeumProfileAdapter.kt
@@ -1,0 +1,44 @@
+package com.example.teumteum.ui.todo.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.example.teumteum.R
+import com.example.teumteum.databinding.ItemProfileImageBinding
+
+class TeumProfileAdapter :
+    ListAdapter<String, TeumProfileAdapter.ProfileVH>(diff) {
+
+    companion object {
+        private val diff = object : DiffUtil.ItemCallback<String>() {
+            override fun areItemsTheSame(oldItem: String, newItem: String) = oldItem == newItem
+            override fun areContentsTheSame(oldItem: String, newItem: String) = oldItem == newItem
+        }
+    }
+
+    inner class ProfileVH(private val binding: ItemProfileImageBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(url: String) {
+            Glide.with(binding.profileIv)
+                .load(url)
+                .placeholder(R.drawable.gray_teum) // 로딩 중
+                .error(R.drawable.gray_teum)       // 실패 시
+                .centerCrop()
+                .into(binding.profileIv)
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProfileVH {
+        val inflater = LayoutInflater.from(parent.context)
+        val binding = ItemProfileImageBinding.inflate(inflater, parent, false)
+        return ProfileVH(binding)
+    }
+
+    override fun onBindViewHolder(holder: ProfileVH, position: Int) {
+        holder.bind(getItem(position))
+    }
+}

--- a/app/src/main/res/layout/fragment_todo_edit.xml
+++ b/app/src/main/res/layout/fragment_todo_edit.xml
@@ -85,12 +85,19 @@
                         android:scaleType="centerCrop"
                         android:src="@drawable/ic_horizon_sv" />
 
-                    <ImageView
-                        android:id="@+id/profile_iv"
-                        android:layout_width="38dp"
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/profile_image_rc"
+                        android:layout_width="match_parent"
                         android:layout_height="38dp"
                         android:layout_marginTop="20dp"
-                        android:src="@drawable/dot_circle_gray" />
+                        />
+
+<!--                    <ImageView-->
+<!--                        android:id="@+id/profile_iv"-->
+<!--                        android:layout_width="38dp"-->
+<!--                        android:layout_height="38dp"-->
+<!--                        android:layout_marginTop="20dp"-->
+<!--                        android:src="@drawable/dot_circle_gray" />-->
 
                     <LinearLayout
                         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_todo_register.xml
+++ b/app/src/main/res/layout/fragment_todo_register.xml
@@ -98,12 +98,21 @@
                         android:scaleType="centerCrop"
                         android:src="@drawable/ic_horizon_sv" />
 
-                    <ImageView
+<!--                    <ImageView-->
+<!--                        android:id="@+id/profile_iv"-->
+<!--                        android:layout_width="38dp"-->
+<!--                        android:layout_height="38dp"-->
+<!--                        android:layout_marginTop="20dp"-->
+<!--                        android:src="@drawable/dot_circle_gray" />-->
+
+                    <com.google.android.material.imageview.ShapeableImageView
                         android:id="@+id/profile_iv"
                         android:layout_width="38dp"
                         android:layout_height="38dp"
                         android:layout_marginTop="20dp"
-                        android:src="@drawable/dot_circle_gray" />
+                        android:background="@color/gray"
+                        android:scaleType="centerCrop"
+                        app:shapeAppearanceOverlay="@style/CircleImage" />
 
                     <LinearLayout
                         android:layout_width="match_parent"

--- a/app/src/main/res/layout/item_profile_image.xml
+++ b/app/src/main/res/layout/item_profile_image.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="38dp"
+    android:layout_height="38dp"
+    android:layout_marginEnd="10dp"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <com.google.android.material.imageview.ShapeableImageView
+        android:id="@+id/profile_iv"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:background="@color/gray"
+        android:scaleType="centerCrop"
+        app:shapeAppearanceOverlay="@style/CircleImage" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #178

## ✨ 작업 내용
> UI 변경점
> 1. 투두 조회(수정) 화면에서 프로필 사진을 원형으로 변경
> 2. 투두 조회(수정) 화면에서 친구와 약속된 틈일 경우 친구의 프로필 사진도 포함해야해서 RecyclerView를 사용했습니다.
> 2-1. 투두 등록 화면에서는 자신의 프로필만 나오면 되기 때문에 RecyclerView로 변경하지는 않았습니다.
> 3. 반복일정과 약속된 틈일 경우 수정화면에서 수정할 수 있는 내용이 각각 달라서 타입을 조사하여 일부 UI를 비활성화하였습니다.
> 3-1. 반복일정 : 삭제만 가능(반복일정 자체가 삭제되는 것이 아닌 해당날짜에 반복일정이 투두로 등록되었을때 그 투두를 삭제하는 것입니다.)
> 3-2. 약속된 틈 : 제목, 시간, 날짜 제외 수정, 삭제 가능

> API 변경점
> 1. 약속된 틈의 경우, 삭제 버튼을 클릭했을 때 투두 삭제 API가 아닌 약속된 틈 취소 API를 호출하도록 변경하였습니다.
> 1-1. 약속된 틈을 취소할 경우 BE의 데이터베이스에 ScheduleType이 CANCELLED로 변경되는데, CANCELLED인 투두는 투두리스트 조회에서 제외되도록 BE로직이 수정되어 투두 삭제 API를 호출하지 않아도 투두리스트에 나오지 않게 됩니다! 친구입장에서도 투두리스트에 나타나지 않는다는 것을 승현님께 확인받았습니다.

> 추가 수정사항
> 1. 틈 요청에서 자정시간을 포함하여 요청할 수 있는데.. 해당 요청을 수락 후 투두 리스트에서 조회하면 LocalTime으로 파싱하는 과정에서 24:00시를 허용하지 않아 오류가 발생하고 앱이 종료되는 현상이 있습니다. 그래서 BE에 자정처리를 부탁하였고, 양쪽에서 안전하게 처리하기 위해 24:00을 다음날 00:00시로 변경하는 로직을 추가하였습니다.

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] 반복일정 삭제 확인(제 계정은 반복일정이 없어서.. 확인해주시면 감사하겠습니다.)
- [ ] 약속된 틈 수정, 삭제 확인
- [ ] 자정이 포함된 투두 조회 확인

## 📸 스크린샷 (선택)
> 9월 10일에 자정이 포함된 투두(지애님 계정과의 약속된 틈)
<img width="284" height="469" alt="image" src="https://github.com/user-attachments/assets/2efcd43f-d81e-470d-b7a0-8b92baecd1bb" />

> 위의 투두 조회 (다음날 오전 12:00으로 변경됨)
<img width="299" height="640" alt="image" src="https://github.com/user-attachments/assets/c4766813-9e7a-4cf2-8edb-9e334f305e58" />

> 틈 약속 수정(제목, 날짜, 시간 제외 수정 가능)
<img width="301" height="632" alt="image" src="https://github.com/user-attachments/assets/0caf64c4-dbcf-45a6-89a8-c80058aa7d7a" />

> 틈 약속 삭제
<img width="298" height="643" alt="image" src="https://github.com/user-attachments/assets/9b304a68-2f26-4da7-b375-2ba8c0c50bc6" />

> 9월 10일 투두 리스트 확인 
<img width="292" height="635" alt="image" src="https://github.com/user-attachments/assets/b304f807-43f0-4b5a-ad73-4a89eac68573" />

## 💬 기타 참고 사항
> 직접 등록한 투두는 삭제 시 바로 최신화가 되는데.. 또 약속한 틈은 삭제 시에 바로 최신화가 안되고 다른 날짜를 클릭해야 하더라구요..

