### PR TITLE
[Feat/#184] 자동 로그인 및 로그아웃 로직 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -133,4 +133,7 @@ dependencies {
 
     //shimmer
     implementation("com.facebook.shimmer:shimmer:0.5.0")
+
+    // EncryptedSharedPreferences
+    implementation ("androidx.security:security-crypto:1.1.0")
 }

--- a/app/src/main/java/com/example/teumteum/data/remote/login/repository/LoginRepository.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/login/repository/LoginRepository.kt
@@ -1,18 +1,17 @@
 package com.example.teumteum.data.remote.login.repository
 
 import android.util.Log
-import com.example.teumteum.data.remote.login.model.JwtTokenResponse
 import com.example.teumteum.data.remote.login.model.KakaoLoginRequest
 import com.example.teumteum.data.remote.login.service.AuthService
+import com.example.teumteum.ui.signin.data.SocialLoginResult
 import com.example.teumteum.utils.handleApiResponse
 
 import javax.inject.Inject
 
 class LoginRepository @Inject constructor(
-
     private val authService: AuthService
 ) {
-    suspend fun loginWithKakaoAccessToken(token: String): Result<JwtTokenResponse> = runCatching {
+    suspend fun loginWithKakaoAccessToken(token: String): Result<SocialLoginResult> = runCatching {
         val response = authService.loginWithKakao(KakaoLoginRequest(token))
         Log.d("KakaoLogin", "response = ${response.body()}")
         handleApiResponse(response)

--- a/app/src/main/java/com/example/teumteum/data/remote/login/service/AuthService.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/login/service/AuthService.kt
@@ -3,6 +3,7 @@ package com.example.teumteum.data.remote.login.service
 import com.example.teumteum.data.remote.login.model.JwtTokenResponse
 import com.example.teumteum.data.remote.login.model.KakaoLoginRequest
 import com.example.teumteum.data.remote.login.model.ReissueRequest
+import com.example.teumteum.ui.signin.data.SocialLoginResult
 import com.example.teumteum.utils.ApiResponse
 import retrofit2.Response
 import retrofit2.http.Body
@@ -10,8 +11,10 @@ import retrofit2.http.POST
 
 interface AuthService {
 
-    @POST("api/auth/social-login/kakao")
-    suspend fun loginWithKakao( @Body request: KakaoLoginRequest ): Response<ApiResponse<JwtTokenResponse>>
+    @POST("/api/auth/social-login/kakao")
+    suspend fun loginWithKakao(
+        @Body request: KakaoLoginRequest
+    ): Response<ApiResponse<SocialLoginResult>>
 
     @POST("/api/auth/reissue")
     suspend fun reissue( @Body request: ReissueRequest ): Response<ApiResponse<JwtTokenResponse>>

--- a/app/src/main/java/com/example/teumteum/ui/myhome/MyAccountSettingFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/myhome/MyAccountSettingFragment.kt
@@ -1,30 +1,34 @@
 package com.example.teumteum.ui.myhome
 
+import android.content.Intent
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
 import com.example.teumteum.R
 import com.example.teumteum.databinding.FragmentMyAccountSettingBinding
 import com.example.teumteum.ui.main.MainActivity
+import com.example.teumteum.ui.signin.LoginActivity
+import com.example.teumteum.utils.FlowPrefs
+import com.example.teumteum.utils.TokenProvider
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MyAccountSettingFragment : Fragment() {
 
-    private lateinit var binding: FragmentMyAccountSettingBinding
+    private var _binding: FragmentMyAccountSettingBinding? = null
+    private val binding get() = _binding!!
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-    }
+    @Inject lateinit var tokenProvider: TokenProvider
+    @Inject lateinit var flowPrefs: FlowPrefs
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        binding = FragmentMyAccountSettingBinding.inflate(inflater,container,false)
+    ): View {
+        _binding = FragmentMyAccountSettingBinding.inflate(inflater, container, false)
         return binding.root
     }
 
@@ -38,5 +42,28 @@ class MyAccountSettingFragment : Fragment() {
                 .addToBackStack(null)
                 .commit()
         }
+
+        binding.logoutLl.setOnClickListener {
+            performLogout()
+        }
+    }
+
+    private fun performLogout() {
+        // 토큰과 플로우 상태 초기화
+        tokenProvider.clearTokens()
+        flowPrefs.clear()
+
+        // 로그인 화면으로 이동 (백스택 클리어)
+        val intent = Intent(requireContext(), LoginActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        }
+        startActivity(intent)
+        requireActivity().finish()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        (activity as? MainActivity)?.showBottomBar()
+        _binding = null
     }
 }

--- a/app/src/main/java/com/example/teumteum/ui/signin/LoginActivity.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signin/LoginActivity.kt
@@ -11,6 +11,7 @@ import com.example.teumteum.ui.signup.SignUpActivity
 import com.example.teumteum.databinding.ActivityLoginBinding
 import com.example.teumteum.ui.signin.data.LoginResult
 import com.example.teumteum.ui.signin.viewModel.LoginViewModel
+import com.example.teumteum.utils.NextStep
 import com.kakao.sdk.user.UserApiClient
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -41,16 +42,21 @@ class LoginActivity : AppCompatActivity() {
     private fun observeViewModel() {
         viewModel.loginResult.observe(this) { result ->
             when (result) {
-                is LoginResult.Loading -> {
-                    // TODO: 로딩 처리
-                }
+                is LoginResult.Loading -> { /* 로딩 표시 */ }
                 is LoginResult.Success -> {
-                    val intent = Intent(this, SignUpActivity::class.java)
-                    startActivity(intent)
+                    when (result.nextStep) {
+                        NextStep.AGREEMENT, NextStep.ONBOARDING -> {
+                            startActivity(Intent(this, SignUpActivity::class.java))
+                        }
+                        NextStep.MAIN -> {
+                            startActivity(Intent(this, com.example.teumteum.ui.main.MainActivity::class.java))
+                        }
+                    }
+                    finish()
                 }
                 is LoginResult.Error -> {
                     Log.d("KakaoLogin", "카카오 로그인 실패 ${result.message}")
-                    Toast.makeText(this, result.message ?: "로그인 실패", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this, result.message, Toast.LENGTH_SHORT).show()
                 }
             }
         }

--- a/app/src/main/java/com/example/teumteum/ui/signin/data/LoginResult.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signin/data/LoginResult.kt
@@ -1,7 +1,9 @@
 package com.example.teumteum.ui.signin.data
 
+import com.example.teumteum.utils.NextStep
+
 sealed class LoginResult {
-    data class Success(val jwt: String) : LoginResult()
+    data class Success(val nextStep: NextStep) : LoginResult()
     data class Error(val message: String) : LoginResult()
     object Loading : LoginResult()
 }

--- a/app/src/main/java/com/example/teumteum/ui/signin/data/SocialLoginResult.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signin/data/SocialLoginResult.kt
@@ -1,0 +1,9 @@
+package com.example.teumteum.ui.signin.data
+
+import com.example.teumteum.utils.NextStep
+
+data class SocialLoginResult(
+    val accessToken: String,
+    val refreshToken: String,
+    val nextStep: NextStep
+)

--- a/app/src/main/java/com/example/teumteum/ui/signin/viewModel/LoginViewModel.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signin/viewModel/LoginViewModel.kt
@@ -8,6 +8,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.teumteum.data.remote.login.repository.LoginRepository
 import com.example.teumteum.ui.signin.data.LoginResult
+import com.example.teumteum.utils.FlowPrefs
+import com.example.teumteum.utils.TokenProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.launch
@@ -16,6 +18,8 @@ import javax.inject.Inject
 @HiltViewModel
 class LoginViewModel @Inject constructor(
     private val repository: LoginRepository,
+    private val tokenProvider: TokenProvider,
+    private val flowPrefs: FlowPrefs,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
@@ -33,12 +37,11 @@ class LoginViewModel @Inject constructor(
 
     private fun getJwtFromServer(kakaoAccessToken: String) {
         viewModelScope.launch {
-            Log.d("requestKakaoToken", kakaoAccessToken)
             repository.loginWithKakaoAccessToken(kakaoAccessToken)
-                .onSuccess { jwt ->
-                    Log.d("JwtToken", "AccessToken ${jwt.accessToken}, RefreshToken ${jwt.refreshToken}")
-                    saveTokens(jwt.accessToken, jwt.refreshToken)
-                    _loginResult.value = LoginResult.Success(jwt.accessToken)
+                .onSuccess { res ->
+                    tokenProvider.saveTokens(res.accessToken, res.refreshToken)
+                    flowPrefs.setLastStep(res.nextStep)
+                    _loginResult.value = LoginResult.Success(res.nextStep)
                 }
                 .onFailure { e ->
                     _loginResult.value = LoginResult.Error("서버 로그인 실패: ${e.message}")
@@ -46,12 +49,4 @@ class LoginViewModel @Inject constructor(
         }
     }
 
-    private fun saveTokens(accessToken: String, refreshToken: String) {
-        val prefs = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
-        prefs.edit().apply {
-            putString("accessToken", accessToken)
-            putString("refreshToken", refreshToken)
-            apply()
-        }
-    }
 }

--- a/app/src/main/java/com/example/teumteum/ui/signup/CompleteFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/CompleteFragment.kt
@@ -26,9 +26,6 @@ class CompleteFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        // 프로그래스바 설정
-        (activity as? SignUpActivity)?.setProgressBar(100)
-
         binding.completeBtn.setOnClickListener {
             parentFragmentManager.beginTransaction()
                 .replace(R.id.fragment_container, OnBoardingNicknameFragment())

--- a/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingNicknameFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingNicknameFragment.kt
@@ -34,8 +34,6 @@ class OnBoardingNicknameFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        (activity as? SignUpActivity)?.setProgressBar(20)
-
         observeViewModel()
         setupUI()
     }
@@ -72,6 +70,7 @@ class OnBoardingNicknameFragment : Fragment() {
         binding.nicknameEt.addTextChangedListener(textWatcher)
         binding.fieldEt.addTextChangedListener(textWatcher)
 
+        // 기존에 입력된 데이터가 있으면 복원
         binding.nicknameEt.setText(viewModel.nickname.value)
         binding.fieldEt.setText(viewModel.field.value)
     }
@@ -123,13 +122,7 @@ class OnBoardingNicknameFragment : Fragment() {
     }
 
     private fun navigateToNext() {
-        val fragment = OnBoardingProfileFragment()
-
-        parentFragmentManager.beginTransaction()
-            .replace(R.id.fragment_container, fragment)
-            .addToBackStack(null)
-            .commit()
-
+        (activity as? SignUpActivity)?.proceedToNextOnboardingStep(this)
         viewModel.resetState()
     }
 }

--- a/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingProfileFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingProfileFragment.kt
@@ -48,7 +48,7 @@ class OnBoardingProfileFragment : Fragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        (activity as? SignUpActivity)?.setProgressBar(25)
+        super.onViewCreated(view, savedInstanceState)
 
         val nickname = viewModel.nickname.value
         binding.titleTv.text = "$nickname 님"
@@ -96,11 +96,7 @@ class OnBoardingProfileFragment : Fragment() {
     }
 
     private fun navigateToNext() {
-        parentFragmentManager.beginTransaction()
-            .replace(R.id.fragment_container, OnBoardingSleepPatternFragment())
-            .addToBackStack(null)
-            .commit()
-
+        (activity as? SignUpActivity)?.proceedToNextOnboardingStep(this)
         viewModel.resetState()
     }
 }

--- a/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingRemindFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingRemindFragment.kt
@@ -24,21 +24,18 @@ class OnBoardingRemindFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
     }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        binding = FragmentOnBoardingRemindBinding.inflate(inflater,container,false)
+    ): View {
+        binding = FragmentOnBoardingRemindBinding.inflate(inflater, container, false)
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        (activity as? SignUpActivity)?.setProgressBar(100)
-
         observeViewModel()
 
         binding.nextBtn.setOnClickListener {
@@ -62,31 +59,24 @@ class OnBoardingRemindFragment : Fragment() {
         binding.remind30mSwitch.setOnCheckedChangeListener { _, isChecked ->
             viewModel.toggleReminder(30, isChecked)
         }
-
     }
-
 
     private fun observeViewModel() {
         viewModel.state.observe(viewLifecycleOwner) { state ->
             when (state) {
                 is OnBoardingUiState.Success -> {
-                    navigateToMain()
+                    // 온보딩 완료 - SignUpActivity의 메서드를 통해 메인으로 이동
+                    (activity as? SignUpActivity)?.completeOnboarding()
                 }
                 is OnBoardingUiState.Error -> {
                     if (state.code.contains("ONBOARDING4001")) {
                         Log.d("RemindFragment", "ONBOARDING4001 - 강제 이동")
-                        navigateToMain()
+                        // 온보딩 완료 처리
+                        (activity as? SignUpActivity)?.completeOnboarding()
                     }
                 }
                 else -> Unit
             }
         }
     }
-
-    private fun navigateToMain() {
-        val intent = Intent(requireContext(), MainActivity::class.java)
-        startActivity(intent)
-        requireActivity().finish()
-    }
-
 }

--- a/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingScheduleFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingScheduleFragment.kt
@@ -80,8 +80,6 @@ class OnBoardingScheduleFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        (activity as? SignUpActivity)?.setProgressBar(80)
-
         observeViewModel()
 
         dayTextViews = listOf(
@@ -124,19 +122,29 @@ class OnBoardingScheduleFragment : Fragment() {
 
     private fun updateDayHighlight(selectedIndex: Int) {
         dayTextViews[selectedDayIndex].background = null
-        dayTextViews[selectedDayIndex].setTextColor(ContextCompat.getColor(requireContext(), R.color.black))
+        dayTextViews[selectedDayIndex].setTextColor(
+            ContextCompat.getColor(
+                requireContext(),
+                R.color.black
+            )
+        )
 
-        dayTextViews[selectedIndex].background = ContextCompat.getDrawable(requireContext(), R.drawable.bg_day_selected)
-        dayTextViews[selectedIndex].setTextColor(ContextCompat.getColor(requireContext(), R.color.white))
+        dayTextViews[selectedIndex].background =
+            ContextCompat.getDrawable(requireContext(), R.drawable.bg_day_selected)
+        dayTextViews[selectedIndex].setTextColor(
+            ContextCompat.getColor(
+                requireContext(),
+                R.color.white
+            )
+        )
 
         selectedDayIndex = selectedIndex
-//        scheduleAdapter.submitList(viewModel.scheduleMap[selectedDayIndex] ?: emptyList())
-
         viewModel.updateCurrentDaySchedule(selectedDayIndex)
     }
 
     private fun getScheduleRequest(): ScheduleRequest {
-        val allSchedules = mutableListOf<com.example.teumteum.data.remote.onboarding.model.Schedule>()
+        val allSchedules =
+            mutableListOf<com.example.teumteum.data.remote.onboarding.model.Schedule>()
         val weekMap = mapOf(
             0 to Week.SUNDAY, 1 to Week.MONDAY, 2 to Week.TUESDAY,
             3 to Week.WEDNESDAY, 4 to Week.THURSDAY, 5 to Week.FRIDAY, 6 to Week.SATURDAY
@@ -166,6 +174,7 @@ class OnBoardingScheduleFragment : Fragment() {
                 is OnBoardingUiState.Success -> {
                     navigateToNext()
                 }
+
                 is OnBoardingUiState.Error -> {
                     Toast.makeText(requireContext(), state.message, Toast.LENGTH_SHORT).show()
                     if (state.code == "ONBOARDING4001") {
@@ -173,6 +182,7 @@ class OnBoardingScheduleFragment : Fragment() {
                         navigateToNext()
                     }
                 }
+
                 else -> Unit
             }
         }
@@ -183,11 +193,9 @@ class OnBoardingScheduleFragment : Fragment() {
     }
 
     private fun navigateToNext() {
-        parentFragmentManager.beginTransaction()
-            .replace(R.id.fragment_container, OnBoardingRemindFragment())
-            .addToBackStack(null)
-            .commit()
-
+        // SignUpActivity의 메서드를 통해 다음 단계로 이동
+        (activity as? SignUpActivity)?.proceedToNextOnboardingStep(this)
         viewModel.resetState()
     }
+
 }

--- a/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingSleepPatternFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingSleepPatternFragment.kt
@@ -40,7 +40,7 @@ class OnBoardingSleepPatternFragment : Fragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        (activity as? SignUpActivity)?.setProgressBar(60)
+        super.onViewCreated(view, savedInstanceState)
 
         selectedStartTime = viewModel.sleepStartTime.value
         selectedEndTime = viewModel.sleepEndTime.value
@@ -130,11 +130,8 @@ class OnBoardingSleepPatternFragment : Fragment() {
     }
 
     private fun navigateToNext() {
-        parentFragmentManager.beginTransaction()
-            .replace(R.id.fragment_container, OnBoardingScheduleFragment())
-            .addToBackStack(null)
-            .commit()
-
+        // SignUpActivity의 메서드를 통해 다음 단계로 이동
+        (activity as? SignUpActivity)?.proceedToNextOnboardingStep(this)
         viewModel.resetState()
     }
 

--- a/app/src/main/java/com/example/teumteum/ui/signup/SignUpActivity.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/SignUpActivity.kt
@@ -1,26 +1,72 @@
 package com.example.teumteum.ui.signup
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import com.example.teumteum.R
 import com.example.teumteum.databinding.ActivitySignUpBinding
+import com.example.teumteum.ui.main.MainActivity
+import com.example.teumteum.utils.FlowPrefs
+import com.example.teumteum.utils.NextStep
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class SignUpActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivitySignUpBinding
 
+    @Inject
+    lateinit var flowPrefs: FlowPrefs
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         binding = ActivitySignUpBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        initializeSignUpFlow()
+    }
+
+    private fun initializeSignUpFlow() {
+        val currentStep = flowPrefs.getLastStep()
+
+        when (currentStep) {
+            NextStep.AGREEMENT -> {
+                // 약관 동의 화면부터 시작
+                setProgressBarVisible(true)
+                setProgressBar(50)
+                loadFragment(CompleteFragment())
+            }
+            NextStep.ONBOARDING -> {
+                // 온보딩 첫 번째 단계부터 시작
+                setProgressBarVisible(true)
+                setProgressBar(20)
+                loadFragment(OnBoardingNicknameFragment())
+            }
+            NextStep.MAIN -> {
+                // 이미 모든 과정이 완료된 경우 - 메인으로 이동
+                navigateToMain()
+            }
+            null -> {
+                // NextStep이 설정되지 않은 경우 - 약관 동의부터 시작
+                setProgressBarVisible(false)
+                loadFragment(AgreementFragment())
+            }
+        }
+    }
+
+    private fun loadFragment(fragment: Fragment) {
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.fragment_container, fragment)
+            .commit()
     }
 
     //상단 프로그레스바 제어
-    fun setProgressBar(progress: Int){
+    fun setProgressBar(progress: Int) {
         binding.progressBar.progress = progress
     }
 
@@ -28,4 +74,49 @@ class SignUpActivity : AppCompatActivity() {
     fun setProgressBarVisible(visible: Boolean) {
         binding.progressBar.visibility = if (visible) View.VISIBLE else View.GONE
     }
+
+    /**
+     * 온보딩 단계 진행
+     */
+    fun proceedToNextOnboardingStep(currentFragment: Fragment) {
+        when (currentFragment) {
+            is OnBoardingNicknameFragment -> {
+                setProgressBar(40)
+                loadFragment(OnBoardingProfileFragment())
+            }
+            is OnBoardingProfileFragment -> {
+                setProgressBar(60)
+                loadFragment(OnBoardingSleepPatternFragment())
+            }
+            is OnBoardingSleepPatternFragment -> {
+                setProgressBar(80)
+                loadFragment(OnBoardingScheduleFragment())
+            }
+            is OnBoardingScheduleFragment -> {
+                setProgressBar(100)
+                loadFragment(OnBoardingRemindFragment())
+            }
+            is OnBoardingRemindFragment -> {
+                completeOnboarding()
+            }
+        }
+    }
+
+    /**
+     * 온보딩 완료 후 메인 화면으로 이동
+     */
+    fun completeOnboarding() {
+        flowPrefs.setLastStep(NextStep.MAIN)
+        navigateToMain()
+    }
+
+    /**
+     * 메인 화면으로 이동
+     */
+    private fun navigateToMain() {
+        val intent = Intent(this, MainActivity::class.java)
+        startActivity(intent)
+        finish()
+    }
+
 }

--- a/app/src/main/java/com/example/teumteum/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/example/teumteum/ui/splash/SplashActivity.kt
@@ -9,28 +9,36 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import com.example.teumteum.R
+import com.example.teumteum.ui.main.MainActivity
 import com.example.teumteum.ui.signin.LoginActivity
+import com.example.teumteum.utils.FlowPrefs
+import com.example.teumteum.utils.NextStep
+import com.example.teumteum.utils.TokenProvider
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class SplashActivity : AppCompatActivity() {
+
+    @Inject lateinit var tokenProvider: TokenProvider
+    @Inject lateinit var flowPrefs: FlowPrefs
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContentView(R.layout.activity_splash)
-        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
-            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
-            insets
 
-            Handler(Looper.getMainLooper()).postDelayed({
-                val intent = Intent(this, LoginActivity::class.java)
-                startActivity(intent)
-                finish()
-            }, 2000) //2초
+        Handler(Looper.getMainLooper()).postDelayed({
+            val hasAccess = !tokenProvider.getAccessToken().isNullOrBlank()
+            val last = flowPrefs.getLastStep()
 
-            return@setOnApplyWindowInsetsListener insets
-
-        }
+            val target = if (hasAccess && last == NextStep.MAIN) {
+                Intent(this, MainActivity::class.java)
+            } else {
+                Intent(this, LoginActivity::class.java)
+            }
+            startActivity(target)
+            finish()
+        }, 2000)
     }
 }

--- a/app/src/main/java/com/example/teumteum/utils/AuthIntercepter.kt
+++ b/app/src/main/java/com/example/teumteum/utils/AuthIntercepter.kt
@@ -1,3 +1,4 @@
+// utils/AuthInterceptor.kt
 package com.example.teumteum.utils
 
 import android.util.Log
@@ -19,7 +20,8 @@ data class ErrorResponse(
 )
 
 class AuthInterceptor @Inject constructor(
-    private val tokenProvider: TokenProvider
+    private val tokenProvider: TokenProvider,
+    private val logoutManager: LogoutManager
 ) : Interceptor {
 
     companion object {
@@ -27,6 +29,19 @@ class AuthInterceptor @Inject constructor(
         private const val BEARER_PREFIX = "Bearer "
         private const val JWT_EXPIRED_CODE = "AUTH4113"
         private const val HTTP_UNAUTHORIZED = 401
+
+        // 재발급 대상 제외, 즉시 로그아웃할 코드들
+        private val FORCE_LOGOUT_CODES = setOf(
+            "AUTH4101", // 잘못된 형식
+            "AUTH4102", // 미지원 형식
+            "AUTH4103", // 비어있는 클레임
+            "AUTH4112", // 잘못된 서명
+            "AUTH4114", // AT 대신 RT 사용
+            "AUTH4115", // 블랙리스트 AT
+            "AUTH4131", // 비활성 사용자(탈퇴 등)
+            "USER4001", // 유저 없음
+            "COMMON401" // 기타 인증 필요
+        )
 
         private val NO_AUTH_PATHS = listOf(
             "/api/auth/social-login/kakao",
@@ -37,7 +52,6 @@ class AuthInterceptor @Inject constructor(
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
 
-        // 토큰이 필요 없는 요청들은 바로 진행
         if (isNoAuthRequired(originalRequest.url.encodedPath)) {
             return chain.proceed(originalRequest)
         }
@@ -45,7 +59,6 @@ class AuthInterceptor @Inject constructor(
         val accessToken = tokenProvider.getAccessToken()
         val refreshToken = tokenProvider.getRefreshToken()
 
-        // Access Token으로 요청 생성
         val requestWithToken = originalRequest.newBuilder().apply {
             if (!accessToken.isNullOrEmpty()) {
                 addHeader(AUTH_HEADER, "$BEARER_PREFIX$accessToken")
@@ -54,17 +67,26 @@ class AuthInterceptor @Inject constructor(
 
         val response = chain.proceed(requestWithToken)
 
-        // JWT 토큰 만료 확인 (HTTP 401 + 응답 본문의 코드 확인)
+        // 만료(AUTH4113)면 재발급 시도
         if (isTokenExpired(response) && !refreshToken.isNullOrEmpty()) {
             response.close()
-
             val newAccessToken = refreshAccessToken(refreshToken)
-
             if (!newAccessToken.isNullOrEmpty()) {
                 val newRequest = originalRequest.newBuilder()
                     .header(AUTH_HEADER, "$BEARER_PREFIX$newAccessToken")
                     .build()
                 return chain.proceed(newRequest)
+            } else {
+                return response
+            }
+        }
+
+        // 401 이면서 '만료'가 아닌 특정 코드면 즉시 로그아웃
+        if (response.code == HTTP_UNAUTHORIZED) {
+            val code = extractErrorCode(response)
+            if (code != null && code != JWT_EXPIRED_CODE && FORCE_LOGOUT_CODES.contains(code)) {
+                // 응답은 소비/유지 여부 상관없이 사용자 플로우는 로그아웃으로 전환
+                logoutManager.forceLogout()
             }
         }
 
@@ -75,29 +97,40 @@ class AuthInterceptor @Inject constructor(
         return NO_AUTH_PATHS.any { path.contains(it) }
     }
 
+    // 401 + 본문코드가 AUTH4113(또는 바디 없음/파싱실패) → 만료로 간주
     private fun isTokenExpired(response: Response): Boolean {
         if (response.code != HTTP_UNAUTHORIZED) return false
-
         return try {
             val source = response.body?.source()
             source?.request(Long.MAX_VALUE)
             val buffer = source?.buffer?.clone()
             val responseBodyString = buffer?.readUtf8() ?: ""
-
             if (responseBodyString.isNotEmpty()) {
                 val errorResponse = Gson().fromJson(responseBodyString, ErrorResponse::class.java)
                 errorResponse.code == JWT_EXPIRED_CODE
             } else {
-                // 응답 본문이 없으면 401만으로 판단
                 true
             }
         } catch (e: Exception) {
             Log.e("AuthInterceptor", "Error parsing response body", e)
-            // JSON 파싱 실패 시에도 401이면 토큰 만료로 처리
             true
         }
     }
 
+    // 에러코드만 뽑아보기 (재발급 로직과 분리)
+    private fun extractErrorCode(response: Response): String? = try {
+        val source = response.body?.source()
+        source?.request(Long.MAX_VALUE)
+        val buffer = source?.buffer?.clone()
+        val bodyString = buffer?.readUtf8() ?: ""
+        if (bodyString.isNotEmpty()) {
+            Gson().fromJson(bodyString, ErrorResponse::class.java)?.code
+        } else null
+    } catch (e: Exception) {
+        Log.e("AuthInterceptor", "Error parsing code", e); null
+    }
+
+    // 재발급 로직
     private fun refreshAccessToken(refreshToken: String): String? {
         return runBlocking {
             try {

--- a/app/src/main/java/com/example/teumteum/utils/FlowPrefs.kt
+++ b/app/src/main/java/com/example/teumteum/utils/FlowPrefs.kt
@@ -1,0 +1,26 @@
+package com.example.teumteum.utils
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+enum class NextStep { AGREEMENT, ONBOARDING, MAIN }
+
+@Singleton
+class FlowPrefs @Inject constructor(
+    @ApplicationContext context: Context
+) {
+    private val prefs = context.getSharedPreferences("flow", Context.MODE_PRIVATE)
+
+    fun getLastStep(): NextStep? =
+        prefs.getString("last_step", null)?.let { runCatching { NextStep.valueOf(it) }.getOrNull() }
+
+    fun setLastStep(step: NextStep) {
+        prefs.edit().putString("last_step", step.name).apply()
+    }
+
+    fun clear() {
+        prefs.edit().clear().apply()
+    }
+}

--- a/app/src/main/java/com/example/teumteum/utils/LogoutManager.kt
+++ b/app/src/main/java/com/example/teumteum/utils/LogoutManager.kt
@@ -1,0 +1,35 @@
+package com.example.teumteum.utils
+
+import android.content.Context
+import android.content.Intent
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+import javax.inject.Singleton
+import dagger.hilt.android.qualifiers.ApplicationContext
+import com.example.teumteum.ui.signin.LoginActivity
+
+@Singleton
+class LogoutManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val tokenProvider: TokenProvider,
+    private val flowPrefs: FlowPrefs
+) {
+    private val loggingOut = AtomicBoolean(false)
+
+    fun forceLogout() {
+        // 중복 호출 방지
+        if (!loggingOut.compareAndSet(false, true)) return
+
+        // 로컬 상태 초기화 -> 추후에 로그아웃 API 호출로 변경 예정
+        tokenProvider.clearTokens()
+        flowPrefs.clear()
+
+        // 로그인 화면으로 전환
+        val intent = Intent(context, LoginActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        }
+        context.startActivity(intent)
+
+        loggingOut.set(false)
+    }
+}

--- a/app/src/main/java/com/example/teumteum/utils/TokenProvider.kt
+++ b/app/src/main/java/com/example/teumteum/utils/TokenProvider.kt
@@ -1,6 +1,10 @@
 package com.example.teumteum.utils
 
 import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -9,7 +13,29 @@ import javax.inject.Singleton
 class TokenProvider @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
-    private val prefs = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
+    private val masterKey: MasterKey by lazy {
+        val alias = "my_app_master_key"
+        val spec = KeyGenParameterSpec.Builder(
+            alias,
+            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+        )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setKeySize(256)
+            .build()
+
+        MasterKey.Builder(context, alias)
+            .setKeyGenParameterSpec(spec)
+            .build()
+    }
+
+    private val prefs = EncryptedSharedPreferences.create(
+        context,
+        "auth_encrypted",
+        masterKey,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
 
     fun getAccessToken(): String? = prefs.getString("accessToken", null)
     fun getRefreshToken(): String? = prefs.getString("refreshToken", null)


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #184

## ✨ 작업 내용
- 자동 로그인 추가
  - `SplashActivity`에서 토큰과 `lastStep` 검증 후 메인/로그인 화면 분기
  - 로그인 성공 시 `TokenProvider`로 토큰 저장
- 단계별 진입 흐름 개선
  - 앱 시작 시 `SplashActivity`에서 `NextStep`에 따라 화면 분기
    - `AGREEMENT` → `SignUpActivity`(`AgreementFragment`)
    - `ONBOARDING` → `SignUpActivity`(`OnBoardingNicknameFragment` → …)
    - `MAIN` → `MainActivity`
  - 온보딩 단계는 `SignUpActivity`에서 순차적으로 관리
  - 온보딩 완료 시 `FlowPrefs` 갱신 후 메인으로 이동
- 토큰 저장소 암호화
  - 토큰 저장소를 `SharedPreferences`에서 `EncryptedSharedPreferences`로 변경
- 로그아웃 기능 추가
  - `MyAccountSettingFragment`에서 로그아웃 클릭 시 토큰/`FlowPrefs` 초기화
  - 즉시 `LoginActivity`로 전환, 백스택 전체 제거
- 인증 오류 시 자동 로그아웃
  - `AUTH4113`(AT 만료)은 기존 재발급 로직 유지
  - 그 외 인증 오류 코드 수신 시 즉시 로그아웃
  - `LogoutManager`를 통해 토큰/`FlowPrefs` 초기화 후 `LoginActivity`로 이동

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] 자동 로그인
- [ ] 단계별 진입 (현재 MAIN 단계로 되어 있어 무조건 홈으로 이동하긴 할 겁니다..)
- [ ] 로그아웃

## 📸 스크린샷 (선택)
| 자동 로그인 | 로그아웃 |
|---|---|
| ![틈틈 자동 로그인](https://github.com/user-attachments/assets/738c7de8-6e11-4b28-b19c-d433bdc9c2b1) | ![틈틈 로그아웃](https://github.com/user-attachments/assets/eb46ecfc-7627-47ee-aa54-0382581a763b) |
| AGREEMENT | ONBOARDING |
| ![틈틈 AGREEMENT 단계](https://github.com/user-attachments/assets/0742b773-d738-4cd1-b69b-3e8c17dba6f6) | ![틈틈 ONBOARDING 단계](https://github.com/user-attachments/assets/511c7189-f316-472c-959e-1296fa973107) |
## 💬 기타 참고 사항
- 인증 오류 시 자동 로그아웃은 아직 테스트 해보지 못했습니다.. 아마 로그아웃 자체는 잘 될 것으로 예상하는데 이전 프로젝트에서 자동 로그아웃 후 재로그인 과정에서 오류가 발생했던 기억이 있어 추후에 빠르게 테스트 진행해보겠습니다!!
- 토큰 재발급 로직에 최대한 영향 가지 않도록 구현했습니다
