### PR TITLE
[FEAT/#188] 틈 요청 플로우 종료 후 스택 정리

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendSendFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendSendFragment.kt
@@ -9,6 +9,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import com.example.teumteum.R
 import com.example.teumteum.databinding.FragmentFriendSendBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -43,9 +44,9 @@ class FriendSendFragment : Fragment() {
 
         // 버튼 클릭 시 FriendFragment로 이동
         binding.btnGoHome.setOnClickListener {
+            parentFragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
             parentFragmentManager.beginTransaction()
                 .replace(R.id.main_frm, FriendFragment())
-                .addToBackStack(null)
                 .commit()
         }
     }


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #188 

## ✨ 작업 내용
- 틈 요청 종료 후 뒤로가기 시 다시 틈 요청 화면으로 이동하는 걸 방지하기 위하여
- 스택 정리 진행

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] 뒤로가기 시 틈 요청으로 이동되지 않ㄴ는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
- 원래는 대부분의 플로우에 진행하려고 했으나 위시나 채움 등 화면이 너무 쪼개져 있어서 우선은 틈 요청에 한해 진행했습니다..
- 로그인 화면에 대한 스택 정리는 자동 로그인에서 함께 진행했습니다