### PR TITLE
[FIX/#194] 온보딩 진입 단계 문제 해결

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/signup/CompleteFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/CompleteFragment.kt
@@ -26,6 +26,9 @@ class CompleteFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        // 프로그래스바 설정
+        (activity as? SignUpActivity)?.setProgressBar(100)
+
         binding.completeBtn.setOnClickListener {
             parentFragmentManager.beginTransaction()
                 .replace(R.id.fragment_container, OnBoardingNicknameFragment())

--- a/app/src/main/java/com/example/teumteum/ui/signup/SignUpActivity.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/SignUpActivity.kt
@@ -38,8 +38,8 @@ class SignUpActivity : AppCompatActivity() {
             NextStep.AGREEMENT -> {
                 // 약관 동의 화면부터 시작
                 setProgressBarVisible(true)
-                setProgressBar(50)
-                loadFragment(CompleteFragment())
+                setProgressBar(0)
+                loadFragment(AgreementFragment())
             }
             NextStep.ONBOARDING -> {
                 // 온보딩 첫 번째 단계부터 시작


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #199 

## ✨ 작업 내용
- step이 AGREEMENT일 때 약관동의 화면이 아니라 약관동의 완료 화면으로 넘어가게 되어있었던 문제 해결
- 약관동의 완료 화면의 ProgressBar 퍼센테이지도 지정

## ✅ 코드 리뷰어 체크리스트
- [ ] 약관동의 화면이 잘 뜨는지
- [ ] 프로그레스바가 제대로 설정되어 있는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
- 약관동의를 진행하지 않고 다음 단계로 넘어가서 User의 step이 AGREEMENT에 머물면서 닉네임, 수면 패턴 등 다른 온보딩의 API 호출이 불가능해 APK에서 문제가 발생
