### PR TITLE
[FIX/#176] 친구 목록 및 프로필 즐겨찾기 상태 표시 로직 수정

### DIFF
--- a/app/src/main/java/com/example/teumteum/data/remote/friend/model/FollowingResult.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/friend/model/FollowingResult.kt
@@ -7,5 +7,5 @@ data class FollowingResult(
     @SerializedName("nickname") val nickname: String,
     @SerializedName("job") val job: String,
     @SerializedName("profileImageUrl") val profileImageUrl: String,
-    @SerializedName("isfavorite") val isFavorite: Boolean
+    @SerializedName("isFavorite") val isFavorite: Boolean
 )

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendProfileFollowingFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendProfileFollowingFragment.kt
@@ -55,10 +55,11 @@ class FriendProfileFollowingFragment : Fragment() {
             .error(R.drawable.gray_teum)
             .into(binding.profileIv)
 
-        //  빈틈 시간 조회
         if (targetUserId != -1) {
+            viewModel.getFriendProfile(targetUserId) { /* 필요 시 콜백 사용 */ } // <-- 추가
             viewModel.loadFriendTeumTime(targetUserId)
-            viewModel.loadSharedTeumTime(targetUserId)   //  서로의(함께한) 시간 추가
+            viewModel.loadSharedTeumTime(targetUserId)
+            viewModel.fetchRecentPublicTodos(targetUserId)
         }
 
         //  빈틈 시간 옵저브
@@ -69,11 +70,6 @@ class FriendProfileFollowingFragment : Fragment() {
         // 서로의 빈틈(함께한) 시간
         viewModel.sharedTeumTimeText.observe(viewLifecycleOwner) { text ->
             binding.nicknameTv?.text = text
-        }
-
-        // 프로필/시간 조회 아래에 붙이기
-        if (targetUserId != -1) {
-            viewModel.fetchRecentPublicTodos(targetUserId)
         }
 
         // 뒤로가기 버튼 클릭 시
@@ -91,7 +87,7 @@ class FriendProfileFollowingFragment : Fragment() {
             }
         }
 
-        // star_btn 클릭 처리
+        // star_btn 클릭 처리 (ViewModel 공용 토글 사용)
         binding.starBtn.setOnClickListener {
             if (targetUserId != -1) {
                 viewModel.toggleFavorite(targetUserId)
@@ -177,12 +173,19 @@ class FriendProfileFollowingFragment : Fragment() {
             }
         }
 
-        // favoriteMap 관찰해서 버튼 아이콘 바꾸기
-        viewModel.favoriteMap.observe(viewLifecycleOwner) { map ->
-            val isFav = map[targetUserId] ?: false
-            binding.starBtn.setImageResource(
-                if (isFav) R.drawable.friend_profile_fill_star else R.drawable.friend_profile_star
-            )
+        // 프로필 LiveData도 관찰해서 서버 favorite 수신 시 반영
+        viewModel.friendProfile.observe(viewLifecycleOwner) { profile ->
+            if (profile.userId == targetUserId) {
+                binding.profileNicknameTv.text = profile.name
+                binding.profileFieldTv.text = profile.field
+                Glide.with(requireContext()).load(profile.profileImageUrl)
+                updateStarIcon() // 아래 함수
+            }
+        }
+
+        // favoriteMap(오버라이드) 변경시에도 별 갱신
+        viewModel.favoriteMap.observe(viewLifecycleOwner) {
+            updateStarIcon()
         }
 
         //  최근 공개 투두 관찰
@@ -197,6 +200,22 @@ class FriendProfileFollowingFragment : Fragment() {
                 Log.d("FRIEND_PROFILE_FOLLOWING_FRAGMENT", msg.toString())
             }
         }
+    }
+
+    // 최종 표시값 계산: 오버라이드 > 서버값 > 기본(false)
+    private fun updateStarIcon() {
+        val serverFav = viewModel.friendProfile.value
+            ?.takeIf { it.userId == targetUserId }
+            ?.favorite
+
+        val overrideFav = viewModel.favoriteMap.value?.get(targetUserId)
+
+        val displayFav = overrideFav ?: serverFav ?: false
+
+        binding.starBtn.setImageResource(
+            if (displayFav) R.drawable.friend_profile_fill_star
+            else R.drawable.friend_profile_star
+        )
     }
 
     //  화면 내에 추가

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendProfileFollowingFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendProfileFollowingFragment.kt
@@ -56,7 +56,7 @@ class FriendProfileFollowingFragment : Fragment() {
             .into(binding.profileIv)
 
         if (targetUserId != -1) {
-            viewModel.getFriendProfile(targetUserId) { /* 필요 시 콜백 사용 */ } // <-- 추가
+            viewModel.getFriendProfile(targetUserId)
             viewModel.loadFriendTeumTime(targetUserId)
             viewModel.loadSharedTeumTime(targetUserId)
             viewModel.fetchRecentPublicTodos(targetUserId)

--- a/app/src/main/java/com/example/teumteum/ui/friend/viewModel/FriendViewModel.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/viewModel/FriendViewModel.kt
@@ -165,7 +165,10 @@ class FriendViewModel @Inject constructor(
     private val _friendProfile = MutableLiveData<FriendProfileResult>()
     val friendProfile: LiveData<FriendProfileResult> get() = _friendProfile
 
-    fun getFriendProfile(userId: Int, onResult: (FriendProfileResult) -> Unit) {
+    fun getFriendProfile(
+        userId: Int,
+        onResult: (FriendProfileResult) -> Unit = {}
+    ) {
         viewModelScope.launch {
             repository.getFriendProfile(userId)
                 .onSuccess { profile ->
@@ -178,6 +181,7 @@ class FriendViewModel @Inject constructor(
                 }
         }
     }
+
 
     private val _teumRequestTitle = MutableLiveData<String>("")
     val teumRequestTitle: LiveData<String> get() = _teumRequestTitle

--- a/app/src/main/java/com/example/teumteum/ui/friend/viewModel/FriendViewModel.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/viewModel/FriendViewModel.kt
@@ -495,59 +495,53 @@ class FriendViewModel @Inject constructor(
     val favoriteMessage: LiveData<String> get() = _favoriteMessage
 
     fun toggleFavorite(userId: Int) {
-        val before = _favoriteMap.value?.get(userId) ?: false
-        val after = !before
+        // 1) 지금 화면에 보이는 값을 기준으로 before 산정
+        val current = _followingUsers.value
+            ?.firstOrNull { it.userId == userId }
+            ?.isFavorite ?: false
+        val after = !current
 
-        // 즐겨찾기 맵 즉시 반영
+        // 2) 낙관적 UI 업데이트 (리스트 갱신 + 정렬)
+        val collator = Collator.getInstance(Locale.KOREAN).apply { strength = Collator.PRIMARY }
+        _followingUsers.value = _followingUsers.value
+            ?.map { if (it.userId == userId) it.copy(isFavorite = after) else it }
+            ?.sortedWith(Comparator { a, b ->
+                if (a.isFavorite != b.isFavorite) {
+                    if (a.isFavorite) -1 else 1
+                } else {
+                    collator.compare(a.nickname, b.nickname)
+                }
+            })
+
+        // 3) 오버라이드 맵 갱신: "사용자가 바꾼 값만" 저장
         _favoriteMap.value = _favoriteMap.value.orEmpty().toMutableMap().apply {
             put(userId, after)
         }
 
-        // 즐겨찾기 → 닉네임 가나다 정렬 (한글 Collator 사용)
-        val collator = Collator.getInstance(Locale.KOREAN).apply { strength = Collator.PRIMARY }
-        _followingUsers.value = _followingUsers.value
-            ?.map { item -> if (item.userId == userId) item.copy(isFavorite = after) else item }
-            ?.sortedWith(Comparator { a, b ->
-                if (a.isFavorite != b.isFavorite) {
-                    if (a.isFavorite) -1 else 1
-                } else {
-                    collator.compare(a.nickname, b.nickname)
-                }
-            })
-
+        // 4) 서버 반영
         viewModelScope.launch {
             repository.setFavorite(userId, after)
                 .onSuccess { resp ->
-                    if (resp.userId == userId && resp.isFavorite == after) {
-                        _favoriteMessage.value = if (after) {
-                            Log.d("FAVORITE_FRAGMENT", "즐겨찾기 성공 → userId=$userId")
-                            "즐겨찾기에 추가했습니다."
-                        } else {
-                            Log.d("FAVORITE_FRAGMENT", "즐겨찾기 해제 성공 → userId=$userId")
-                            "즐겨찾기를 해제했습니다."
-                        }
+                    val ok = resp.userId == userId && resp.isFavorite == after
+                    if (ok) {
+                        _favoriteMessage.value = if (after) "즐겨찾기에 추가했습니다." else "즐겨찾기를 해제했습니다."
                     } else {
-                        rollbackFavorite(userId, before)
+                        rollbackFavorite(userId, current)   // 실패 시 복구
                         _favoriteMessage.value = "즐겨찾기 변경 실패"
-                        Log.e("FAVORITE_FRAGMENT", "비정상 응답 → userId=$userId")
                     }
                 }
                 .onFailure { e ->
-                    rollbackFavorite(userId, before)
+                    rollbackFavorite(userId, current)
                     _favoriteMessage.value = "즐겨찾기 변경 실패 (${e.message})"
-                    Log.e("FAVORITE_FRAGMENT", "서버 요청 실패 → userId=$userId", e)
                 }
         }
     }
 
-    private fun rollbackFavorite(userId: Int, before: Boolean) {
-        _favoriteMap.value = _favoriteMap.value.orEmpty().toMutableMap().apply {
-            put(userId, before)
-        }
-
+    private fun rollbackFavorite(userId: Int, oldValue: Boolean) {
+        // 리스트 되돌리기
         val collator = Collator.getInstance(Locale.KOREAN).apply { strength = Collator.PRIMARY }
         _followingUsers.value = _followingUsers.value
-            ?.map { item -> if (item.userId == userId) item.copy(isFavorite = before) else item }
+            ?.map { if (it.userId == userId) it.copy(isFavorite = oldValue) else it }
             ?.sortedWith(Comparator { a, b ->
                 if (a.isFavorite != b.isFavorite) {
                     if (a.isFavorite) -1 else 1
@@ -555,7 +549,13 @@ class FriendViewModel @Inject constructor(
                     collator.compare(a.nickname, b.nickname)
                 }
             })
+
+        // 오버라이드 맵도 되돌리기
+        _favoriteMap.value = _favoriteMap.value.orEmpty().toMutableMap().apply {
+            put(userId, oldValue)
+        }
     }
+
 
     // 14. 팔로워 목록 조회
     private val _followerUsers = MutableLiveData<List<FollowerResult>>()


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #176 

## ✨ 작업 내용
- 친구 목록(`FollowingResult`) DTO에서 `@SerializedName`(`"isfavorite"`) → `@SerializedName`(`"isFavorite"`)로 수정
- 팔로잉 리스트 즐겨찾기 토글 시 현재 표시값 기준으로 반영하도록 로직 수정 (`_favoriteMap`만 보던 문제 해결)
- 친구 프로필 화면 진입 시 서버 favorite 값을 반영하도록 `getFriendProfile()` 호출 추가
- 별 아이콘 표시 로직 변경
→ 오버라이드 값이 있으면 우선, 없으면 서버 값 사용
→ 서버 값이 즉시 반영되지 않던 문제 해결

## ✅ 코드 리뷰어 체크리스트
- [x] 토글 로직이 현재 표시값 기준으로 동작하는지 검증
- [x] 프로필 화면에서 서버 값이 정상 반영되는지 확인

## 📸 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/f01944ef-26ef-4852-9530-3850df379397" width="300" />


## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항
