### PR TITLE
[FEAT/#203] 로그아웃 API 연동

### DIFF
--- a/app/src/main/java/com/example/teumteum/data/remote/login/service/AuthService.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/login/service/AuthService.kt
@@ -19,4 +19,7 @@ interface AuthService {
     @POST("/api/auth/reissue")
     suspend fun reissue( @Body request: ReissueRequest ): Response<ApiResponse<JwtTokenResponse>>
 
+    @POST("/api/auth/logout")
+    suspend fun logout(): Response<ApiResponse<Unit>>
+
 }

--- a/app/src/main/java/com/example/teumteum/ui/myhome/MyAccountSettingFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/myhome/MyAccountSettingFragment.kt
@@ -5,14 +5,18 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import com.example.teumteum.R
 import com.example.teumteum.databinding.FragmentMyAccountSettingBinding
 import com.example.teumteum.ui.main.MainActivity
 import com.example.teumteum.ui.signin.LoginActivity
 import com.example.teumteum.utils.FlowPrefs
+import com.example.teumteum.utils.LogoutManager
 import com.example.teumteum.utils.TokenProvider
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -21,8 +25,9 @@ class MyAccountSettingFragment : Fragment() {
     private var _binding: FragmentMyAccountSettingBinding? = null
     private val binding get() = _binding!!
 
-    @Inject lateinit var tokenProvider: TokenProvider
-    @Inject lateinit var flowPrefs: FlowPrefs
+    @Inject lateinit var logoutManager: LogoutManager
+
+    private var loggingOut = false
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -44,21 +49,23 @@ class MyAccountSettingFragment : Fragment() {
         }
 
         binding.logoutLl.setOnClickListener {
-            performLogout()
-        }
-    }
+            if (loggingOut) return@setOnClickListener
+            loggingOut = true
+            binding.logoutLl.isEnabled = false
 
-    private fun performLogout() {
-        // 토큰과 플로우 상태 초기화
-        tokenProvider.clearTokens()
-        flowPrefs.clear()
-
-        // 로그인 화면으로 이동 (백스택 클리어)
-        val intent = Intent(requireContext(), LoginActivity::class.java).apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            viewLifecycleOwner.lifecycleScope.launch {
+                try {
+                    // 서버 로그아웃 → 로컬 정리 → 로그인 화면 전환
+                    logoutManager.logout()
+                } catch (_: Exception) {
+                    Toast.makeText(requireContext(), "로그아웃 중 문제가 발생했어요.", Toast.LENGTH_SHORT).show()
+                } finally {
+                    loggingOut = false
+                    if (isAdded) binding.logoutLl.isEnabled = true
+                }
+            }
         }
-        startActivity(intent)
-        requireActivity().finish()
+
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/teumteum/utils/LogoutManager.kt
+++ b/app/src/main/java/com/example/teumteum/utils/LogoutManager.kt
@@ -1,35 +1,74 @@
+// utils/LogoutManager.kt
 package com.example.teumteum.utils
 
 import android.content.Context
 import android.content.Intent
-import java.util.concurrent.atomic.AtomicBoolean
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
-import dagger.hilt.android.qualifiers.ApplicationContext
 import com.example.teumteum.ui.signin.LoginActivity
+import com.example.teumteum.data.remote.login.service.AuthService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.util.concurrent.atomic.AtomicBoolean
+import retrofit2.Retrofit
+import retrofit2.Response
+import javax.inject.Provider
 
 @Singleton
 class LogoutManager @Inject constructor(
     @ApplicationContext private val context: Context,
     private val tokenProvider: TokenProvider,
-    private val flowPrefs: FlowPrefs
+    private val flowPrefs: FlowPrefs,
+    @AuthRetrofit private val retrofitProvider: Provider<Retrofit>,
 ) {
     private val loggingOut = AtomicBoolean(false)
 
+    // 앱 전역 스코프
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    // AuthService를 지연 생성
+    private val authService: AuthService by lazy {
+        retrofitProvider.get().create(AuthService::class.java)
+    }
+
+    // Interceptor 등 비코루틴 컨텍스트에서 호출 가능
     fun forceLogout() {
-        // 중복 호출 방지
-        if (!loggingOut.compareAndSet(false, true)) return
-
-        // 로컬 상태 초기화 -> 추후에 로그아웃 API 호출로 변경 예정
-        tokenProvider.clearTokens()
-        flowPrefs.clear()
-
-        // 로그인 화면으로 전환
-        val intent = Intent(context, LoginActivity::class.java).apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        scope.launch {
+            logout()
         }
-        context.startActivity(intent)
+    }
 
-        loggingOut.set(false)
+    // 전체 로그아웃 플로우
+    suspend fun logout() {
+        if (!loggingOut.compareAndSet(false, true)) return
+        try {
+            // 1) 서버 로그아웃
+            runCatching {
+                val resp = withContext(Dispatchers.IO) { authService.logout() }
+                val body = resp.body()
+                val ok = resp.isSuccessful && (body?.isSuccess == true || body?.code == "AUTH2004")
+                if (!ok) error(body?.message ?: "Logout failed (${resp.code()})")
+            }
+
+            // 2) 로컬 정리
+            withContext(Dispatchers.IO) {
+                tokenProvider.clearTokens()
+                flowPrefs.clear()
+            }
+
+            // 3) 화면 전환
+            withContext(Dispatchers.Main) {
+                val intent = Intent(context, LoginActivity::class.java).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                }
+                context.startActivity(intent)
+            }
+        } finally {
+            loggingOut.set(false)
+        }
     }
 }

--- a/app/src/main/java/com/example/teumteum/utils/NetworkModule.kt
+++ b/app/src/main/java/com/example/teumteum/utils/NetworkModule.kt
@@ -70,7 +70,7 @@ class NetworkModule {
             .build()
     }
 
-    // 토큰 없이 사용할 Retrofit 인스턴스 (필요한 경우)
+    // 토큰 없이 사용할 Retrofit 인스턴스
     @Provides
     @Singleton
     @NoAuthRetrofit
@@ -82,31 +82,5 @@ class NetworkModule {
             .addConverterFactory(GsonConverterFactory.create())
             .build()
     }
-}
 
-// 기존 함수들 (호환성을 위해 유지)
-const val BASE_URL = BuildConfig.BASE_URL
-
-fun getRetrofit(): Retrofit {
-    return Retrofit.Builder()
-        .baseUrl(BASE_URL)
-        .addConverterFactory(GsonConverterFactory.create())
-        .build()
-}
-
-fun getRetrofitWithToken(): Retrofit {
-    val client = OkHttpClient.Builder()
-        .addInterceptor { chain ->
-            val request = chain.request().newBuilder()
-                .addHeader("Authorization", "Bearer ${BuildConfig.TEMP_ACCESS_TOKEN}")
-                .build()
-            chain.proceed(request)
-        }
-        .build()
-
-    return Retrofit.Builder()
-        .baseUrl(BASE_URL)
-        .client(client)
-        .addConverterFactory(GsonConverterFactory.create())
-        .build()
 }


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #203 

## ✨ 작업 내용
- 로그아웃 API 연동: POST `/api/auth/logout` 호출 후 로컬 세션/토큰 정리
- `LogoutManager` 리팩토링: API 호출 -> 로컬 정리 -> 화면 전환
- UI에서 `logoutManager.logout()` 호출

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 순환 의존성 문제가 잘 해결되었는지
- [ ] 로그아웃 API 실패 시에도 안전 로그아웃이 보장되는지 (로컬 정리 + 로그인 화면 전환)
- [x] Intercepter에서 강제 로그아웃 호출 시 중복 처리 문제가 없는지

## 📸 스크린샷 (선택)
<img width="945" height="153" alt="image" src="https://github.com/user-attachments/assets/f9bd1671-e1f2-4746-acb9-08a34f9fddd3" />

## 💬 기타 참고 사항

#### Provider<Retrofit> 사용
- 순환 의존성 방지
  - 기존 구조에서 `LogoutManager` → `AuthService`→ `OkHttpClient` → `AuthInterceptor` → `LogoutManager` 순환이 발생
  - `Provider<Retrofit>`로 변경하면, `LogoutManager` 생성 시점에는 Retrofit 인스턴스를 만들지 않음 -> DI 그래프 구성 시 순환이 발동하지 않음
- 실제 사용 시점에 생성
  - `retrofitProvider.get()` 호출은 로그아웃 시점에만 이루어짐
  - 평상시 앱 실행/의존성 주입 단계에서는 Retrofit 생성이 지연되어 불필요한 초기화가 줄어듦
- `LogoutService`를 따로 두는 것도 고려해보면 좋을 듯함..

#### Repository/ViewModel 없이 구현한 이유
- 오케스트레이션이 LogoutManager에 응집
  - 로그아웃은 API 호출 -> 로컬 정리 -> 화면전환.. 의 플로우를 가지고 있다보니 UI 상태를 별도로 보관할 필요가 적다고 생각
  - Intercepter에서도 같은 로직을 호출해야 함 -> `LogoutManager`가 적합하지 않을까
- 중복 제거
  - Repository를 추가하면 실질 로직이 분리되어 UI/VM/Intercepter 세 곳에서 조합해야 함
  - 현재는 성공/실패 분기만 필요하니 ViewModel도 생략
- 확장하게 된다면...?
  - 로그아웃 UX나 상태 추척이 필요해진다면 `LogoutManager`는 그대로 두고 ViewModel에서 감싸는 형태가 어떨까

#### 참고
- 성공 → 토큰 & prefs 삭제, 로그인 화면 이동
- 실패 → 토큰 & prefs 삭제, 로그인 화면 이동(안전 로그아웃)
- Interceptor 강제 로그아웃 트리거와 버튼 로그아웃 동시 발생 -> 중복 방지 플래그로 단일 처리 보장
