### PR TITLE
[BUG/#217] 틈 거절 시 화면 이동 없이 그대로 있는 문제

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/friend/Friend02RejectBottomSheetFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/Friend02RejectBottomSheetFragment.kt
@@ -11,6 +11,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.activityViewModels
 import com.example.teumteum.R
 import com.example.teumteum.databinding.BottomSheetFriend02RejectBinding
@@ -90,8 +91,16 @@ class Friend02RejectBottomSheetFragment : BottomSheetDialogFragment() {
                 Log.d("REJECT_BOTTOM_SHEET", "responseId: $responseId, status: $status")
 //                Toast.makeText(requireContext(), "응답: 시간이 안돼요 (id: $responseId)", Toast.LENGTH_SHORT).show()
 
+                Toast.makeText(requireContext(), "삭제되었습니다", Toast.LENGTH_SHORT).show()
+
                 //  응답 처리
                 viewModel.respondToTeum(responseId, status)
+
+                //  응답 완료 후 reject 전송 완료 화면으로 이동
+                parentFragmentManager.beginTransaction()
+                    .replace(R.id.main_frm, FriendRejectSendFragment())
+                    .addToBackStack(null)
+                    .commit()
 
                 //  바텀시트 닫기
                 dismiss()

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendRejectSendFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendRejectSendFragment.kt
@@ -1,0 +1,60 @@
+package com.example.teumteum.ui.friend
+
+import android.graphics.Color
+import android.os.Bundle
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.ForegroundColorSpan
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.example.teumteum.R
+import com.example.teumteum.databinding.FragmentFriendRejectSendBinding
+
+class FriendRejectSendFragment : Fragment() {
+
+    private var _binding: FragmentFriendRejectSendBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentFriendRejectSendBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // "전송" 글자만 색상 변경
+        val text = "친구에게 전송했어요!"
+        val spannable = SpannableString(text)
+        val start = text.indexOf("전송")
+        val end = start + 2
+        spannable.setSpan(
+            ForegroundColorSpan(Color.parseColor("#7770FE")),
+            start, end,
+            Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+        binding.textTitle.text = spannable
+
+        binding.btnGoHome.setOnClickListener {
+            parentFragmentManager.beginTransaction()
+                .replace(R.id.main_frm, FriendFragment()) // 메인에 FriendFragment 로드
+                .addToBackStack(null) // 뒤로 가기 가능하게 할지 여부
+                .commit()
+        }
+
+        // 뒤로가기 버튼 동작
+        binding.backButton.setOnClickListener {
+            parentFragmentManager.popBackStack()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/res/layout/fragment_friend_reject_send.xml
+++ b/app/src/main/res/layout/fragment_friend_reject_send.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#FFFFFF">
+
+    <!-- 뒤로가기 버튼 -->
+    <ImageButton
+        android:id="@+id/backButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="70dp"
+        android:layout_marginStart="16dp"
+        android:background="@android:color/transparent"
+        android:src="@drawable/ic_arrow_back"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <!-- 캐릭터 이미지 -->
+    <ImageView
+        android:id="@+id/imageCharacter"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="309dp"
+        android:src="@drawable/friend_temi"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <!-- 큰 텍스트 -->
+    <TextView
+        android:id="@+id/textTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="친구에게 전송했어요!"
+        android:lineSpacingExtra="0dp"
+        android:includeFontPadding="false"
+        android:textSize="18sp"
+        android:textColor="#0F0F0F"
+        android:fontFamily="@font/noto_sans_kr_medium"
+        android:layout_marginTop="16dp"
+        app:layout_constraintTop_toBottomOf="@id/imageCharacter"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <!-- 설명 텍스트 -->
+    <TextView
+        android:id="@+id/textDesc"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:fontFamily="@font/noto_sans_kr_regular"
+        android:includeFontPadding="false"
+        android:lineSpacingExtra="0dp"
+        android:text="틈 요청 기록에서 확인할 수 있어요"
+        android:textColor="#5C6569"
+        android:textSize="15sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/textTitle" />
+
+
+    <!-- 하단 버튼 -->
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnGoHome"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="19dp"
+        android:layout_marginEnd="19dp"
+        android:layout_marginBottom="19dp"
+        android:fontFamily="@font/noto_sans_kr_medium"
+        android:text="친구 화면으로 돌아가기"
+        android:textColor="#FFFFFF"
+        android:textSize="16sp"
+        app:backgroundTint="#0F0F0F"
+        app:cornerRadius="12dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #217

## ✨ 작업 내용
> 틈 거절 시 화면 이동 없이 그대로 있었는데 거절 시 -> 화면 이동될 수 있게 수정  

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 틈 요청 이때는 시간 안돼요 버튼 선택 시 취소되었습니다 토스트가 뜨는지
- [x] 버튼 선택 시 친구에게 전송했어요 화면이 보이는지 
- [x] 친구 화면으로 돌아가기 버튼 선택 시 친구 메인 화면으로 넘어가는지 

## 📸 스크린샷 (선택)
> 삭제되었습니다 토스트 추가
<img width="411" height="815" alt="image" src="https://github.com/user-attachments/assets/1fc05526-c0b2-4eb2-9ad7-542eee8905af" />

> 거절 버튼 선택 시 이동하는 화면 
<img width="403" height="820" alt="image" src="https://github.com/user-attachments/assets/6b9e8a1b-576b-40df-a0be-c432ca972daf" />


## 💬 기타 참고 사항
> x
