### PR TITLE
[Refactor/#223] 원형시간표 스와이프 변경 적용

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting01Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting01Fragment.kt
@@ -7,14 +7,19 @@ import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.viewpager2.widget.ViewPager2
 import com.example.teumteum.R
 import com.example.teumteum.data.remote.todo.model.enums.ScheduleType
 import com.example.teumteum.databinding.FragmentFillingSetting01Binding
+import com.example.teumteum.databinding.ItemClockMiniPageBinding
 import com.example.teumteum.ui.clock.ChartUtils
+import com.example.teumteum.ui.clock.ClockHalf
+import com.example.teumteum.ui.clock.ClockVPAdapter
 import com.example.teumteum.ui.clock.IconPieChartRenderer
 import com.example.teumteum.ui.main.viewModel.HomeViewModel
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import dagger.hilt.android.AndroidEntryPoint
+import kotlin.collections.orEmpty
 
 @AndroidEntryPoint
 class FillingSetting01Fragment : Fragment() {
@@ -35,6 +40,8 @@ class FillingSetting01Fragment : Fragment() {
     private var wishId: Long? = null
 
     private var scheduleType: String? = null
+
+    private lateinit var clockAdapter: ClockVPAdapter<ItemClockMiniPageBinding>
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -191,25 +198,54 @@ class FillingSetting01Fragment : Fragment() {
             parentFragmentManager.popBackStack()
         }
 
-        ChartUtils.setupPieChart(binding.clockChart)
-
-        val sleepBitmap = ChartUtils.getBitmapFromVector(requireContext(), R.drawable.ic_sleep_sv)
-
-        binding.clockChart.renderer = IconPieChartRenderer(
-            binding.clockChart,
-            binding.clockChart.animator,
-            binding.clockChart.viewPortHandler,
-            sleepBitmap
-        )
-
-        updateTimeChart(isAM)
-        updateIndicator(isAM)
+        setupClockPager()
 
         binding.amPmTv.setOnClickListener {
-            isAM = !isAM
-            updateTimeChart(isAM)
-            updateIndicator(isAM)
+            val amPos = clockAdapter.positionOf(ClockHalf.AM)
+            val pmPos = clockAdapter.positionOf(ClockHalf.PM)
+            val next = if (binding.clockPager.currentItem == amPos) pmPos else amPos
+            binding.clockPager.setCurrentItem(next, true)
         }
+
+        updateIndicator(isAM)
+    }
+
+    private fun setupClockPager() {
+        clockAdapter = ClockVPAdapter(
+            inflate = ItemClockMiniPageBinding::inflate,
+            chartOf = { it.clockChart },
+            onBindPage = { chart, half ->
+                ChartUtils.setupPieChart(chart)
+                val sleepBitmap = ChartUtils.getBitmapFromVector(requireContext(), R.drawable.ic_sleep_sv)
+                chart.renderer = IconPieChartRenderer(chart, chart.animator, chart.viewPortHandler, sleepBitmap)
+
+                // AM/PM 데이터 바인딩
+                val blocks = homeViewModel.scheduleList.value.orEmpty()
+                val halfBlocks = ChartUtils.splitAndFillTimeBlocks(blocks, half == ClockHalf.AM)
+                ChartUtils.setTimePieChartData(requireContext(), chart, halfBlocks)
+
+            }
+        )
+
+        binding.clockPager.adapter = clockAdapter
+        binding.clockPager.offscreenPageLimit = 1
+
+        val amPos = clockAdapter.positionOf(ClockHalf.AM) // 0
+        val pmPos = clockAdapter.positionOf(ClockHalf.PM) // 1
+
+        binding.clockPager.setCurrentItem(amPos, false)
+
+        binding.clockPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                updateIndicator(position == amPos)
+            }
+        })
+
+        binding.amPmTv.setOnClickListener {
+            val next = if (binding.clockPager.currentItem == amPos) pmPos else amPos
+            binding.clockPager.setCurrentItem(next, true)
+        }
+
     }
 
     private fun enableNextButton() {
@@ -226,11 +262,6 @@ class FillingSetting01Fragment : Fragment() {
         binding.assignTimeTv.text = time
     }
 
-    private fun updateTimeChart(isAM: Boolean) {
-        val blocks = homeViewModel.scheduleList.value ?: return
-        val halfDayBlocks = ChartUtils.splitAndFillTimeBlocks(blocks, isAM)
-        ChartUtils.setTimePieChartData(requireContext(), binding.clockChart, halfDayBlocks)
-    }
 
     private fun updateIndicator(isAM: Boolean) {
         val leftView = binding.leftView

--- a/app/src/main/java/com/example/teumteum/ui/clock/ClockVPAdapter.kt
+++ b/app/src/main/java/com/example/teumteum/ui/clock/ClockVPAdapter.kt
@@ -4,28 +4,33 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import androidx.recyclerview.widget.RecyclerView
+import androidx.viewbinding.ViewBinding
 import com.example.teumteum.databinding.ItemClockPageBinding
 import com.github.mikephil.charting.charts.PieChart
 
-class ClockVPAdapter(
+class ClockVPAdapter<VB : ViewBinding>(
+    private val inflate: (LayoutInflater, ViewGroup, Boolean) -> VB,
+    private val chartOf: (VB) -> PieChart,
     private val onBindPage: (chart: PieChart, half: ClockHalf) -> Unit
-) : RecyclerView.Adapter<ClockVPAdapter.ViewHolder>() {
+) : RecyclerView.Adapter<ClockVPAdapter<VB>.ViewHolder>() {
 
     private val halves = listOf(ClockHalf.AM, ClockHalf.PM) // 0=AM, 1=PM
 
-    inner class ViewHolder(val binding: ItemClockPageBinding) : RecyclerView.ViewHolder(binding.root)
+    inner class ViewHolder(val binding: VB) : RecyclerView.ViewHolder(binding.root) {
+        val chart: PieChart = chartOf(binding)
+    }
 
-    override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): ViewHolder {
-        val binding: ItemClockPageBinding =
-            ItemClockPageBinding.inflate(LayoutInflater.from(viewGroup.context), viewGroup, false)
-
-        binding.root.layoutParams = RecyclerView.LayoutParams(MATCH_PARENT, MATCH_PARENT)
-
-        return ViewHolder(binding)
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val vb = inflate(LayoutInflater.from(parent.context), parent, false)
+        vb.root.layoutParams = RecyclerView.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT
+        )
+        return ViewHolder(vb)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        onBindPage(holder.binding.clockChart, halves[position])
+        onBindPage(holder.chart, halves[position])
     }
 
     override fun getItemCount(): Int = halves.size

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendRoommateTimeFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendRoommateTimeFragment.kt
@@ -12,12 +12,17 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.viewpager2.widget.ViewPager2
 import com.bumptech.glide.Glide
 import com.example.teumteum.R
 import com.example.teumteum.data.remote.friend.model.FriendProfileResult
 import com.example.teumteum.data.remote.friend.model.PossibleTimeRequest
 import com.example.teumteum.databinding.FragmentFriendRoommateTimeBinding
+import com.example.teumteum.databinding.ItemClockMiniPageBinding
 import com.example.teumteum.ui.clock.ChartUtils
+import com.example.teumteum.ui.clock.ClockHalf
+import com.example.teumteum.ui.clock.ClockVPAdapter
+import com.example.teumteum.ui.clock.IconPieChartRenderer
 import com.example.teumteum.ui.friend.adapter.FriendProfileAdapter
 import com.example.teumteum.ui.friend.viewModel.FriendViewModel
 import com.example.teumteum.ui.main.MainActivity
@@ -27,6 +32,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Locale
+import kotlin.collections.orEmpty
 import kotlin.getValue
 
 @AndroidEntryPoint
@@ -36,12 +42,13 @@ class FriendRoommateTimeFragment : Fragment() {
     private val binding get() = _binding!!
 
     private var isAM = true
-    private lateinit var sleepIconBitmap: Bitmap
 
     private val viewModel: FriendViewModel by activityViewModels()
 
     //차트에 들어갈 시간 데이터
     private var currentFullDayBlocks: List<TimeBlock> = emptyList()
+
+    private lateinit var clockAdapter: ClockVPAdapter<ItemClockMiniPageBinding>
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -135,16 +142,17 @@ class FriendRoommateTimeFragment : Fragment() {
         viewModel.setFixedDate(convertDateFormat(receivedDate))
 
         // PieChart 설정
-        ChartUtils.setupPieChart(binding.clockChart)
+        setupClockPager()
+        updateIndicator(isAM)
+
         observeViewModel()
-        updateTimeChart()
-        updateAMPMIndicator()
 
         // AM/PM 토글
         binding.amPmTv.setOnClickListener {
-            isAM = !isAM
-            updateTimeChart()
-            updateAMPMIndicator()
+            val amPos = clockAdapter.positionOf(ClockHalf.AM)
+            val pmPos = clockAdapter.positionOf(ClockHalf.PM)
+            val next = if (binding.clockPager.currentItem == amPos) pmPos else amPos
+            binding.clockPager.setCurrentItem(next, true)
         }
 
         // 뒤로가기
@@ -161,16 +169,42 @@ class FriendRoommateTimeFragment : Fragment() {
         }
     }
 
-    private fun updateTimeChart() {
-        // 데이터가 오기 전엔 예시(fullSchedule), 온 뒤엔 currentFullDayBlocks 사용
-        val baseBlocks = currentFullDayBlocks
-        val halfBlocks = ChartUtils.splitAndFillTimeBlocks(baseBlocks, isAM)
+    private fun setupClockPager() {
+        clockAdapter = ClockVPAdapter(
+            inflate = ItemClockMiniPageBinding::inflate,
+            chartOf = { it.clockChart },
+            onBindPage = { chart, half ->
+                ChartUtils.setupPieChart(chart)
+                val sleepBitmap = ChartUtils.getBitmapFromVector(requireContext(), R.drawable.ic_sleep_sv)
+                chart.renderer = IconPieChartRenderer(chart, chart.animator, chart.viewPortHandler, sleepBitmap)
 
-        val unifiedPurple = Color.parseColor("#847EFF")
-        ChartUtils.setTimePieChartData(requireContext(), binding.clockChart, halfBlocks, unifiedPurple)
+                // AM/PM 데이터 바인딩
+                val blocks = currentFullDayBlocks
+                val halfBlocks = ChartUtils.splitAndFillTimeBlocks(blocks, half == ClockHalf.AM)
+                ChartUtils.setTimePieChartData(requireContext(), chart, halfBlocks)
 
-        val hasEmptyTime = halfBlocks.any { it.type == TimeType.EMPTY }
-        updateNextButton(hasEmptyTime)
+            }
+        )
+
+        binding.clockPager.adapter = clockAdapter
+        binding.clockPager.offscreenPageLimit = 1
+
+        val amPos = clockAdapter.positionOf(ClockHalf.AM) // 0
+        val pmPos = clockAdapter.positionOf(ClockHalf.PM) // 1
+
+        binding.clockPager.setCurrentItem(amPos, false)
+
+        binding.clockPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                updateIndicator(position == amPos)
+            }
+        })
+
+        binding.amPmTv.setOnClickListener {
+            val next = if (binding.clockPager.currentItem == amPos) pmPos else amPos
+            binding.clockPager.setCurrentItem(next, true)
+        }
+
     }
 
     private fun updateNextButton(hasEmpty: Boolean) {
@@ -185,31 +219,38 @@ class FriendRoommateTimeFragment : Fragment() {
         }
     }
 
-    private fun updateAMPMIndicator() {
+    private fun updateIndicator(isAM: Boolean) {
         val leftView = binding.leftView
         val rightView = binding.rightView
 
         if (isAM) {
-            updateIndicatorView(leftView, 28, 4, R.drawable.clock_indicator_bar_purple)
-            updateIndicatorView(rightView, 4, 4, R.drawable.clock_indicator_dot)
-            binding.amPmTv.text = "AM"
+            //왼쪽이 막대, 오른쪽이 점
+            leftView.layoutParams.width = dpToPx(28)
+            leftView.layoutParams.height = dpToPx(4)
+            leftView.background = ContextCompat.getDrawable(requireContext(), R.drawable.clock_indicator_bar_purple)
+
+            rightView.layoutParams.width = dpToPx(4)
+            rightView.layoutParams.height = dpToPx(4)
+            rightView.background = ContextCompat.getDrawable(requireContext(), R.drawable.clock_indicator_dot)
+
+            binding.amPmTv.text="AM"
         } else {
-            updateIndicatorView(leftView, 4, 4, R.drawable.clock_indicator_dot)
-            updateIndicatorView(rightView, 28, 4, R.drawable.clock_indicator_bar_purple)
-            binding.amPmTv.text = "PM"
+            //왼쪽이 점, 오른쪽이 막대
+            leftView.layoutParams.width = dpToPx(4)
+            leftView.layoutParams.height = dpToPx(4)
+            leftView.background = ContextCompat.getDrawable(requireContext(), R.drawable.clock_indicator_dot)
+
+            rightView.layoutParams.width = dpToPx(28)
+            rightView.layoutParams.height = dpToPx(4)
+            rightView.background = ContextCompat.getDrawable(requireContext(), R.drawable.clock_indicator_bar_purple)
+
+            binding.amPmTv.text="PM"
         }
 
         leftView.requestLayout()
         rightView.requestLayout()
     }
 
-    private fun updateIndicatorView(view: View, widthDp: Int, heightDp: Int, drawableRes: Int) {
-        val layoutParams = view.layoutParams
-        layoutParams.width = dpToPx(widthDp)
-        layoutParams.height = dpToPx(heightDp)
-        view.layoutParams = layoutParams
-        view.background = ContextCompat.getDrawable(requireContext(), drawableRes)
-    }
 
     private fun dpToPx(dp: Int): Int {
         return (dp * resources.displayMetrics.density).toInt()
@@ -225,12 +266,13 @@ class FriendRoommateTimeFragment : Fragment() {
             if (cards.isEmpty()) {
                 binding.possibleTime.text = "이때는 가능한 빈틈이 없어요"
                 currentFullDayBlocks = listOf(TimeBlock(0, 1440, TimeType.TODO))
+                updateNextButton(false)
             } else {
                 binding.possibleTime.text = "가능한 빈틈이 있어요"
                 currentFullDayBlocks = ChartUtils.buildBlocksFromTimeCardItems(cards)
+                updateNextButton(true)
             }
-
-            updateTimeChart()
+            clockAdapter.refreshAll()
         }
     }
 

--- a/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
@@ -31,6 +31,7 @@ import java.time.format.DateTimeFormatter
 import com.example.teumteum.data.remote.todo.model.TodoListResult
 import com.example.teumteum.data.remote.todo.model.enums.AlarmStatus
 import com.example.teumteum.data.remote.todo.model.enums.ScheduleType
+import com.example.teumteum.databinding.ItemClockPageBinding
 import com.example.teumteum.ui.todo.viewModel.TodoViewModel
 import com.example.teumteum.ui.clock.ChartUtils
 import com.example.teumteum.ui.clock.ClockHalf
@@ -40,6 +41,7 @@ import com.example.teumteum.ui.main.data.TimeType
 import com.example.teumteum.ui.main.viewModel.HomeViewModel
 import com.example.teumteum.ui.myhome.viewModel.MyHomeViewModel
 import com.example.teumteum.utils.applyBlurShadow
+import com.example.teumteum.utils.saveSelectedDate
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -62,7 +64,7 @@ class HomeFragment : Fragment(), IDateClickListener {
 
     private val TODO_SHEET_TAG = "TodoRegisterSheet"
 
-    private lateinit var clockAdapter: ClockVPAdapter
+    private lateinit var clockAdapter: ClockVPAdapter<ItemClockPageBinding>
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -231,16 +233,20 @@ class HomeFragment : Fragment(), IDateClickListener {
     }
 
     private fun setupClockPager() {
-        clockAdapter = ClockVPAdapter { chart, half ->
-            ChartUtils.setupPieChart(chart)
-            val sleepBitmap = ChartUtils.getBitmapFromVector(requireContext(), R.drawable.ic_sleep_sv)
-            chart.renderer = IconPieChartRenderer(chart, chart.animator, chart.viewPortHandler, sleepBitmap)
+        clockAdapter = ClockVPAdapter(
+            inflate = ItemClockPageBinding::inflate,
+            chartOf = { it.clockChart },
+            onBindPage = { chart, half ->
+                ChartUtils.setupPieChart(chart)
+                val sleepBitmap = ChartUtils.getBitmapFromVector(requireContext(), R.drawable.ic_sleep_sv)
+                chart.renderer = IconPieChartRenderer(chart, chart.animator, chart.viewPortHandler, sleepBitmap)
 
-            // AM/PM 데이터 바인딩
-            val blocks = viewModel.scheduleList.value.orEmpty()
-            val halfBlocks = ChartUtils.splitAndFillTimeBlocks(blocks, half == ClockHalf.AM)
-            ChartUtils.setTimePieChartData(requireContext(), chart, halfBlocks)
-        }
+                // AM/PM 데이터 바인딩
+                val blocks = viewModel.scheduleList.value.orEmpty()
+                val halfBlocks = ChartUtils.splitAndFillTimeBlocks(blocks, half == ClockHalf.AM)
+                ChartUtils.setTimePieChartData(requireContext(), chart, halfBlocks)
+            }
+        )
 
         binding.clockPager.adapter = clockAdapter
         binding.clockPager.offscreenPageLimit = 1

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishSetting01Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishSetting01Fragment.kt
@@ -7,9 +7,13 @@ import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.viewpager2.widget.ViewPager2
 import com.example.teumteum.R
 import com.example.teumteum.databinding.FragmentWishSetting01Binding
+import com.example.teumteum.databinding.ItemClockMiniPageBinding
 import com.example.teumteum.ui.clock.ChartUtils
+import com.example.teumteum.ui.clock.ClockHalf
+import com.example.teumteum.ui.clock.ClockVPAdapter
 import com.example.teumteum.ui.clock.IconPieChartRenderer
 import com.example.teumteum.ui.main.viewModel.HomeViewModel
 import com.google.android.material.bottomnavigation.BottomNavigationView
@@ -30,6 +34,8 @@ class WishSetting01Fragment : Fragment() {
 
     private var isAM: Boolean = true
     private var wishId: Long? = null
+
+    private lateinit var clockAdapter: ClockVPAdapter<ItemClockMiniPageBinding>
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -182,24 +188,14 @@ class WishSetting01Fragment : Fragment() {
             parentFragmentManager.popBackStack()
         }
 
-        ChartUtils.setupPieChart(binding.clockChart)
-
-        val sleepBitmap = ChartUtils.getBitmapFromVector(requireContext(), R.drawable.ic_sleep_sv)
-
-        binding.clockChart.renderer = IconPieChartRenderer(
-            binding.clockChart,
-            binding.clockChart.animator,
-            binding.clockChart.viewPortHandler,
-            sleepBitmap
-        )
-
-        updateTimeChart(isAM)
+        setupClockPager()
         updateIndicator(isAM)
 
         binding.amPmTv.setOnClickListener {
-            isAM = !isAM
-            updateTimeChart(isAM)
-            updateIndicator(isAM)
+            val amPos = clockAdapter.positionOf(ClockHalf.AM)
+            val pmPos = clockAdapter.positionOf(ClockHalf.PM)
+            val next = if (binding.clockPager.currentItem == amPos) pmPos else amPos
+            binding.clockPager.setCurrentItem(next, true)
         }
     }
 
@@ -217,10 +213,42 @@ class WishSetting01Fragment : Fragment() {
         binding.wishTimeTv.text = time
     }
 
-    private fun updateTimeChart(isAM: Boolean) {
-        val blocks = homeViewModel.scheduleList.value ?: return
-        val halfDayBlocks = ChartUtils.splitAndFillTimeBlocks(blocks, isAM)
-        ChartUtils.setTimePieChartData(requireContext(), binding.clockChart, halfDayBlocks)
+    private fun setupClockPager() {
+        clockAdapter = ClockVPAdapter(
+            inflate = ItemClockMiniPageBinding::inflate,
+            chartOf = { it.clockChart },
+            onBindPage = { chart, half ->
+                ChartUtils.setupPieChart(chart)
+                val sleepBitmap = ChartUtils.getBitmapFromVector(requireContext(), R.drawable.ic_sleep_sv)
+                chart.renderer = IconPieChartRenderer(chart, chart.animator, chart.viewPortHandler, sleepBitmap)
+
+                // AM/PM 데이터 바인딩
+                val blocks = homeViewModel.scheduleList.value.orEmpty()
+                val halfBlocks = ChartUtils.splitAndFillTimeBlocks(blocks, half == ClockHalf.AM)
+                ChartUtils.setTimePieChartData(requireContext(), chart, halfBlocks)
+
+            }
+        )
+
+        binding.clockPager.adapter = clockAdapter
+        binding.clockPager.offscreenPageLimit = 1
+
+        val amPos = clockAdapter.positionOf(ClockHalf.AM) // 0
+        val pmPos = clockAdapter.positionOf(ClockHalf.PM) // 1
+
+        binding.clockPager.setCurrentItem(amPos, false)
+
+        binding.clockPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                updateIndicator(position == amPos)
+            }
+        })
+
+        binding.amPmTv.setOnClickListener {
+            val next = if (binding.clockPager.currentItem == amPos) pmPos else amPos
+            binding.clockPager.setCurrentItem(next, true)
+        }
+
     }
 
     private fun updateIndicator(isAM: Boolean) {

--- a/app/src/main/res/layout/fragment_filling_setting_01.xml
+++ b/app/src/main/res/layout/fragment_filling_setting_01.xml
@@ -109,42 +109,6 @@
         android:layout_marginTop="12dp"
         />
 
-<!--    <ImageView-->
-<!--        android:id="@+id/clock_background_iv"-->
-<!--        android:layout_width="match_parent"-->
-<!--        android:layout_height="wrap_content"-->
-<!--        android:src="@drawable/clock_mini_sv"-->
-<!--        app:layout_constraintTop_toBottomOf="@id/assign_cv"-->
-<!--        app:layout_constraintStart_toStartOf="parent"-->
-<!--        app:layout_constraintEnd_toEndOf="parent"-->
-<!--        android:layout_marginTop="12dp"-->
-<!--        android:layout_marginStart="55dp"-->
-<!--        android:layout_marginEnd="55dp"-->
-<!--        />-->
-
-<!--    <com.github.mikephil.charting.charts.PieChart-->
-<!--        android:id="@+id/clock_chart"-->
-<!--        android:layout_width="179.49dp"-->
-<!--        android:layout_height="179.49dp"-->
-<!--        app:layout_constraintTop_toTopOf="@id/clock_background_iv"-->
-<!--        app:layout_constraintStart_toStartOf="@id/clock_background_iv"-->
-<!--        app:layout_constraintEnd_toEndOf="@id/clock_background_iv"-->
-<!--        app:layout_constraintBottom_toBottomOf="@id/clock_background_iv"-->
-<!--        android:background="@color/transparent"-->
-<!--        />-->
-
-<!--    <ImageView-->
-<!--        android:id="@+id/clock_center_iv"-->
-<!--        android:layout_width="wrap_content"-->
-<!--        android:layout_height="wrap_content"-->
-<!--        app:layout_constraintTop_toTopOf="@id/clock_background_iv"-->
-<!--        app:layout_constraintStart_toStartOf="@id/clock_background_iv"-->
-<!--        app:layout_constraintEnd_toEndOf="@id/clock_background_iv"-->
-<!--        app:layout_constraintBottom_toBottomOf="@id/clock_background_iv"-->
-<!--        android:src="@drawable/clock_mini_center_sv"-->
-<!--        android:background="@color/transparent"-->
-<!--        />-->
-
     <LinearLayout
         android:id="@+id/clock_indicator_ll"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_filling_setting_01.xml
+++ b/app/src/main/res/layout/fragment_filling_setting_01.xml
@@ -99,41 +99,51 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.cardview.widget.CardView>
 
-    <ImageView
-        android:id="@+id/clock_background_iv"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/clock_mini_sv"
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/clock_pager"
+        android:layout_width="match_parent"
+        android:layout_height="250dp"
         app:layout_constraintTop_toBottomOf="@id/assign_cv"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         android:layout_marginTop="12dp"
-        android:layout_marginStart="55dp"
-        android:layout_marginEnd="55dp"
         />
 
-    <com.github.mikephil.charting.charts.PieChart
-        android:id="@+id/clock_chart"
-        android:layout_width="179.49dp"
-        android:layout_height="179.49dp"
-        app:layout_constraintTop_toTopOf="@id/clock_background_iv"
-        app:layout_constraintStart_toStartOf="@id/clock_background_iv"
-        app:layout_constraintEnd_toEndOf="@id/clock_background_iv"
-        app:layout_constraintBottom_toBottomOf="@id/clock_background_iv"
-        android:background="@color/transparent"
-        />
+<!--    <ImageView-->
+<!--        android:id="@+id/clock_background_iv"-->
+<!--        android:layout_width="match_parent"-->
+<!--        android:layout_height="wrap_content"-->
+<!--        android:src="@drawable/clock_mini_sv"-->
+<!--        app:layout_constraintTop_toBottomOf="@id/assign_cv"-->
+<!--        app:layout_constraintStart_toStartOf="parent"-->
+<!--        app:layout_constraintEnd_toEndOf="parent"-->
+<!--        android:layout_marginTop="12dp"-->
+<!--        android:layout_marginStart="55dp"-->
+<!--        android:layout_marginEnd="55dp"-->
+<!--        />-->
 
-    <ImageView
-        android:id="@+id/clock_center_iv"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="@id/clock_background_iv"
-        app:layout_constraintStart_toStartOf="@id/clock_background_iv"
-        app:layout_constraintEnd_toEndOf="@id/clock_background_iv"
-        app:layout_constraintBottom_toBottomOf="@id/clock_background_iv"
-        android:src="@drawable/clock_mini_center_sv"
-        android:background="@color/transparent"
-        />
+<!--    <com.github.mikephil.charting.charts.PieChart-->
+<!--        android:id="@+id/clock_chart"-->
+<!--        android:layout_width="179.49dp"-->
+<!--        android:layout_height="179.49dp"-->
+<!--        app:layout_constraintTop_toTopOf="@id/clock_background_iv"-->
+<!--        app:layout_constraintStart_toStartOf="@id/clock_background_iv"-->
+<!--        app:layout_constraintEnd_toEndOf="@id/clock_background_iv"-->
+<!--        app:layout_constraintBottom_toBottomOf="@id/clock_background_iv"-->
+<!--        android:background="@color/transparent"-->
+<!--        />-->
+
+<!--    <ImageView-->
+<!--        android:id="@+id/clock_center_iv"-->
+<!--        android:layout_width="wrap_content"-->
+<!--        android:layout_height="wrap_content"-->
+<!--        app:layout_constraintTop_toTopOf="@id/clock_background_iv"-->
+<!--        app:layout_constraintStart_toStartOf="@id/clock_background_iv"-->
+<!--        app:layout_constraintEnd_toEndOf="@id/clock_background_iv"-->
+<!--        app:layout_constraintBottom_toBottomOf="@id/clock_background_iv"-->
+<!--        android:src="@drawable/clock_mini_center_sv"-->
+<!--        android:background="@color/transparent"-->
+<!--        />-->
 
     <LinearLayout
         android:id="@+id/clock_indicator_ll"
@@ -142,9 +152,9 @@
         android:orientation="horizontal"
         android:gravity="center_vertical"
         android:background="@android:color/transparent"
-        app:layout_constraintTop_toBottomOf="@id/clock_background_iv"
-        app:layout_constraintStart_toStartOf="@id/clock_background_iv"
-        app:layout_constraintEnd_toEndOf="@id/clock_background_iv"
+        app:layout_constraintTop_toBottomOf="@id/clock_pager"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         android:layout_marginTop="13dp"
         >
 
@@ -177,7 +187,8 @@
         android:textSize="15sp"
         android:textColor="@color/main_2"
         android:includeFontPadding="false"
-        app:layout_constraintStart_toEndOf="@id/clock_background_iv"
+        android:layout_marginEnd="22.5dp"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBottom_toBottomOf="@id/clock_indicator_ll"
         android:layout_marginStart="16dp"
         />

--- a/app/src/main/res/layout/fragment_friend_roommate_time.xml
+++ b/app/src/main/res/layout/fragment_friend_roommate_time.xml
@@ -43,42 +43,6 @@
         android:layout_marginTop="12dp"
         />
 
-<!--    &lt;!&ndash; 원형 시간표 &ndash;&gt;-->
-<!--    <ImageView-->
-<!--        android:id="@+id/clock_background_iv"-->
-<!--        android:layout_width="wrap_content"-->
-<!--        android:layout_height="wrap_content"-->
-<!--        android:layout_marginStart="68dp"-->
-<!--        android:layout_marginEnd="68dp"-->
-<!--        android:layout_marginTop="1dp"-->
-<!--        android:src="@drawable/clock_mini_sv"-->
-<!--        app:layout_constraintEnd_toEndOf="parent"-->
-<!--        app:layout_constraintStart_toStartOf="parent"-->
-<!--        app:layout_constraintTop_toBottomOf="@+id/date" />-->
-
-<!--    <com.github.mikephil.charting.charts.PieChart-->
-<!--        android:id="@+id/clock_chart"-->
-<!--        android:layout_width="179.49dp"-->
-<!--        android:layout_height="179.49dp"-->
-<!--        app:layout_constraintTop_toTopOf="@id/clock_background_iv"-->
-<!--        app:layout_constraintStart_toStartOf="@id/clock_background_iv"-->
-<!--        app:layout_constraintEnd_toEndOf="@id/clock_background_iv"-->
-<!--        app:layout_constraintBottom_toBottomOf="@id/clock_background_iv"-->
-<!--        android:background="@color/transparent"-->
-<!--        />-->
-
-<!--    <ImageView-->
-<!--        android:id="@+id/clock_center_iv"-->
-<!--        android:layout_width="wrap_content"-->
-<!--        android:layout_height="wrap_content"-->
-<!--        app:layout_constraintTop_toTopOf="@id/clock_background_iv"-->
-<!--        app:layout_constraintStart_toStartOf="@id/clock_background_iv"-->
-<!--        app:layout_constraintEnd_toEndOf="@id/clock_background_iv"-->
-<!--        app:layout_constraintBottom_toBottomOf="@id/clock_background_iv"-->
-<!--        android:src="@drawable/clock_mini_center_sv"-->
-<!--        android:background="@color/transparent"-->
-<!--        />-->
-
     <LinearLayout
         android:id="@+id/clock_indicator_ll"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_friend_roommate_time.xml
+++ b/app/src/main/res/layout/fragment_friend_roommate_time.xml
@@ -33,41 +33,51 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/btnBack" />
 
-    <!-- 원형 시간표 -->
-    <ImageView
-        android:id="@+id/clock_background_iv"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="68dp"
-        android:layout_marginEnd="68dp"
-        android:layout_marginTop="1dp"
-        android:src="@drawable/clock_mini_sv"
-        app:layout_constraintEnd_toEndOf="parent"
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/clock_pager"
+        android:layout_width="match_parent"
+        android:layout_height="254dp"
+        app:layout_constraintTop_toBottomOf="@id/date"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/date" />
-
-    <com.github.mikephil.charting.charts.PieChart
-        android:id="@+id/clock_chart"
-        android:layout_width="179.49dp"
-        android:layout_height="179.49dp"
-        app:layout_constraintTop_toTopOf="@id/clock_background_iv"
-        app:layout_constraintStart_toStartOf="@id/clock_background_iv"
-        app:layout_constraintEnd_toEndOf="@id/clock_background_iv"
-        app:layout_constraintBottom_toBottomOf="@id/clock_background_iv"
-        android:background="@color/transparent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="12dp"
         />
 
-    <ImageView
-        android:id="@+id/clock_center_iv"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="@id/clock_background_iv"
-        app:layout_constraintStart_toStartOf="@id/clock_background_iv"
-        app:layout_constraintEnd_toEndOf="@id/clock_background_iv"
-        app:layout_constraintBottom_toBottomOf="@id/clock_background_iv"
-        android:src="@drawable/clock_mini_center_sv"
-        android:background="@color/transparent"
-        />
+<!--    &lt;!&ndash; 원형 시간표 &ndash;&gt;-->
+<!--    <ImageView-->
+<!--        android:id="@+id/clock_background_iv"-->
+<!--        android:layout_width="wrap_content"-->
+<!--        android:layout_height="wrap_content"-->
+<!--        android:layout_marginStart="68dp"-->
+<!--        android:layout_marginEnd="68dp"-->
+<!--        android:layout_marginTop="1dp"-->
+<!--        android:src="@drawable/clock_mini_sv"-->
+<!--        app:layout_constraintEnd_toEndOf="parent"-->
+<!--        app:layout_constraintStart_toStartOf="parent"-->
+<!--        app:layout_constraintTop_toBottomOf="@+id/date" />-->
+
+<!--    <com.github.mikephil.charting.charts.PieChart-->
+<!--        android:id="@+id/clock_chart"-->
+<!--        android:layout_width="179.49dp"-->
+<!--        android:layout_height="179.49dp"-->
+<!--        app:layout_constraintTop_toTopOf="@id/clock_background_iv"-->
+<!--        app:layout_constraintStart_toStartOf="@id/clock_background_iv"-->
+<!--        app:layout_constraintEnd_toEndOf="@id/clock_background_iv"-->
+<!--        app:layout_constraintBottom_toBottomOf="@id/clock_background_iv"-->
+<!--        android:background="@color/transparent"-->
+<!--        />-->
+
+<!--    <ImageView-->
+<!--        android:id="@+id/clock_center_iv"-->
+<!--        android:layout_width="wrap_content"-->
+<!--        android:layout_height="wrap_content"-->
+<!--        app:layout_constraintTop_toTopOf="@id/clock_background_iv"-->
+<!--        app:layout_constraintStart_toStartOf="@id/clock_background_iv"-->
+<!--        app:layout_constraintEnd_toEndOf="@id/clock_background_iv"-->
+<!--        app:layout_constraintBottom_toBottomOf="@id/clock_background_iv"-->
+<!--        android:src="@drawable/clock_mini_center_sv"-->
+<!--        android:background="@color/transparent"-->
+<!--        />-->
 
     <LinearLayout
         android:id="@+id/clock_indicator_ll"
@@ -76,9 +86,9 @@
         android:orientation="horizontal"
         android:gravity="center_vertical"
         android:background="@android:color/transparent"
-        app:layout_constraintTop_toBottomOf="@id/clock_background_iv"
-        app:layout_constraintStart_toStartOf="@id/clock_background_iv"
-        app:layout_constraintEnd_toEndOf="@id/clock_background_iv"
+        app:layout_constraintTop_toBottomOf="@id/clock_pager"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         android:layout_marginTop="13dp"
         >
 

--- a/app/src/main/res/layout/fragment_wish_setting_01.xml
+++ b/app/src/main/res/layout/fragment_wish_setting_01.xml
@@ -99,41 +99,51 @@
 
     </androidx.cardview.widget.CardView>
 
-    <ImageView
-        android:id="@+id/clock_background_iv"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/clock_mini_sv"
-        app:layout_constraintTop_toBottomOf="@+id/wish_cv"
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/clock_pager"
+        android:layout_width="match_parent"
+        android:layout_height="250dp"
+        app:layout_constraintTop_toBottomOf="@id/wish_cv"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         android:layout_marginTop="12dp"
-        android:layout_marginStart="55dp"
-        android:layout_marginEnd="55dp"
         />
 
-    <com.github.mikephil.charting.charts.PieChart
-        android:id="@+id/clock_chart"
-        android:layout_width="179.49dp"
-        android:layout_height="179.49dp"
-        app:layout_constraintTop_toTopOf="@+id/clock_background_iv"
-        app:layout_constraintStart_toStartOf="@+id/clock_background_iv"
-        app:layout_constraintEnd_toEndOf="@+id/clock_background_iv"
-        app:layout_constraintBottom_toBottomOf="@+id/clock_background_iv"
-        android:background="@android:color/transparent"
-        />
+<!--    <ImageView-->
+<!--        android:id="@+id/clock_background_iv"-->
+<!--        android:layout_width="wrap_content"-->
+<!--        android:layout_height="wrap_content"-->
+<!--        android:src="@drawable/clock_mini_sv"-->
+<!--        app:layout_constraintTop_toBottomOf="@+id/wish_cv"-->
+<!--        app:layout_constraintStart_toStartOf="parent"-->
+<!--        app:layout_constraintEnd_toEndOf="parent"-->
+<!--        android:layout_marginTop="12dp"-->
+<!--        android:layout_marginStart="55dp"-->
+<!--        android:layout_marginEnd="55dp"-->
+<!--        />-->
 
-    <ImageView
-        android:id="@+id/clock_center_iv"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="@id/clock_background_iv"
-        app:layout_constraintStart_toStartOf="@+id/clock_background_iv"
-        app:layout_constraintEnd_toEndOf="@+id/clock_background_iv"
-        app:layout_constraintBottom_toBottomOf="@+id/clock_background_iv"
-        android:src="@drawable/clock_mini_center_sv"
-        android:background="@android:color/transparent"
-        />
+<!--    <com.github.mikephil.charting.charts.PieChart-->
+<!--        android:id="@+id/clock_chart"-->
+<!--        android:layout_width="179.49dp"-->
+<!--        android:layout_height="179.49dp"-->
+<!--        app:layout_constraintTop_toTopOf="@+id/clock_background_iv"-->
+<!--        app:layout_constraintStart_toStartOf="@+id/clock_background_iv"-->
+<!--        app:layout_constraintEnd_toEndOf="@+id/clock_background_iv"-->
+<!--        app:layout_constraintBottom_toBottomOf="@+id/clock_background_iv"-->
+<!--        android:background="@android:color/transparent"-->
+<!--        />-->
+
+<!--    <ImageView-->
+<!--        android:id="@+id/clock_center_iv"-->
+<!--        android:layout_width="wrap_content"-->
+<!--        android:layout_height="wrap_content"-->
+<!--        app:layout_constraintTop_toTopOf="@id/clock_background_iv"-->
+<!--        app:layout_constraintStart_toStartOf="@+id/clock_background_iv"-->
+<!--        app:layout_constraintEnd_toEndOf="@+id/clock_background_iv"-->
+<!--        app:layout_constraintBottom_toBottomOf="@+id/clock_background_iv"-->
+<!--        android:src="@drawable/clock_mini_center_sv"-->
+<!--        android:background="@android:color/transparent"-->
+<!--        />-->
 
     <LinearLayout
         android:id="@+id/clock_indicator_ll"
@@ -142,9 +152,9 @@
         android:orientation="horizontal"
         android:gravity="center_vertical"
         android:background="@android:color/transparent"
-        app:layout_constraintTop_toBottomOf="@+id/clock_background_iv"
-        app:layout_constraintStart_toStartOf="@+id/clock_background_iv"
-        app:layout_constraintEnd_toEndOf="@+id/clock_background_iv"
+        app:layout_constraintTop_toBottomOf="@+id/clock_pager"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         android:layout_marginTop="13dp"
         >
 
@@ -177,7 +187,8 @@
         android:textSize="15sp"
         android:textColor="@color/main_2"
         android:includeFontPadding="false"
-        app:layout_constraintStart_toEndOf="@id/clock_background_iv"
+        android:layout_marginEnd="22.5dp"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBottom_toBottomOf="@id/clock_indicator_ll"
         android:layout_marginStart="16dp"
         />

--- a/app/src/main/res/layout/fragment_wish_setting_01.xml
+++ b/app/src/main/res/layout/fragment_wish_setting_01.xml
@@ -109,42 +109,6 @@
         android:layout_marginTop="12dp"
         />
 
-<!--    <ImageView-->
-<!--        android:id="@+id/clock_background_iv"-->
-<!--        android:layout_width="wrap_content"-->
-<!--        android:layout_height="wrap_content"-->
-<!--        android:src="@drawable/clock_mini_sv"-->
-<!--        app:layout_constraintTop_toBottomOf="@+id/wish_cv"-->
-<!--        app:layout_constraintStart_toStartOf="parent"-->
-<!--        app:layout_constraintEnd_toEndOf="parent"-->
-<!--        android:layout_marginTop="12dp"-->
-<!--        android:layout_marginStart="55dp"-->
-<!--        android:layout_marginEnd="55dp"-->
-<!--        />-->
-
-<!--    <com.github.mikephil.charting.charts.PieChart-->
-<!--        android:id="@+id/clock_chart"-->
-<!--        android:layout_width="179.49dp"-->
-<!--        android:layout_height="179.49dp"-->
-<!--        app:layout_constraintTop_toTopOf="@+id/clock_background_iv"-->
-<!--        app:layout_constraintStart_toStartOf="@+id/clock_background_iv"-->
-<!--        app:layout_constraintEnd_toEndOf="@+id/clock_background_iv"-->
-<!--        app:layout_constraintBottom_toBottomOf="@+id/clock_background_iv"-->
-<!--        android:background="@android:color/transparent"-->
-<!--        />-->
-
-<!--    <ImageView-->
-<!--        android:id="@+id/clock_center_iv"-->
-<!--        android:layout_width="wrap_content"-->
-<!--        android:layout_height="wrap_content"-->
-<!--        app:layout_constraintTop_toTopOf="@id/clock_background_iv"-->
-<!--        app:layout_constraintStart_toStartOf="@+id/clock_background_iv"-->
-<!--        app:layout_constraintEnd_toEndOf="@+id/clock_background_iv"-->
-<!--        app:layout_constraintBottom_toBottomOf="@+id/clock_background_iv"-->
-<!--        android:src="@drawable/clock_mini_center_sv"-->
-<!--        android:background="@android:color/transparent"-->
-<!--        />-->
-
     <LinearLayout
         android:id="@+id/clock_indicator_ll"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_clock_mini_page.xml
+++ b/app/src/main/res/layout/item_clock_mini_page.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:foregroundGravity="center"
+    android:clipToPadding="false"
+    android:paddingBottom="0dp">
+
+    <ImageView
+        android:id="@+id/clock_background_iv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:src="@drawable/clock_mini_sv" />
+
+    <com.github.mikephil.charting.charts.PieChart
+        android:id="@+id/clock_chart"
+        android:layout_width="179.49dp"
+        android:layout_height="179.49dp"
+        android:layout_gravity="center"
+        android:background="@android:color/transparent" />
+
+    <ImageView
+        android:id="@+id/clock_center_iv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:src="@drawable/clock_mini_center_sv"
+        android:background="@android:color/transparent" />
+
+</FrameLayout>


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #223

## ✨ 작업 내용
> 친구매칭, 위시 등록 화면에서 사용하는 원형 시간표 AM, PM 변경을 스와이프 동작을 통해서도 변경할 수 있도록 수정하였습니다.
> 홈 화면의 시간표와는 크기가 다르고 배경이 다르기 때문에 아이템 xml을 하나 더 만들었고, 기존에 승현님이 작성해주신 어댑터를 제네릭 ViewBinding 어댑터로  변경하였습니다. 
> 홈화면에서 ItemClockPageBinding, 나머지 화면에서 ItemClockMiniPageBinding 사용

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 홈 화면 시간표 스와이프
- [x] 친구 매칭 화면 시간표 스와이프(틈 요청 플로우)
- [x] 위시 등록 화면 시간표(나의 위시리스트-> 빈틈 채우기, 채움활동찾기 -> AI 콘텐츠 빈틈 채우기)

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항
