### PR TITLE
[Fix/#229] 토큰 재발급/로그아웃 처리의 안정화

### DIFF
--- a/app/src/main/java/com/example/teumteum/utils/AuthIntercepter.kt
+++ b/app/src/main/java/com/example/teumteum/utils/AuthIntercepter.kt
@@ -19,6 +19,9 @@ data class ErrorResponse(
     val message: String
 )
 
+// 요청 단위 1회 재시도 가드용 마커
+private object RetryOnceTag
+
 class AuthInterceptor @Inject constructor(
     private val tokenProvider: TokenProvider,
     private val logoutManager: LogoutManager
@@ -52,6 +55,8 @@ class AuthInterceptor @Inject constructor(
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
 
+        // 이미 재발급 재시도를 했는지(tag) 확인
+        val hasRetried = originalRequest.tag(RetryOnceTag::class.java) != null
         if (isNoAuthRequired(originalRequest.url.encodedPath)) {
             return chain.proceed(originalRequest)
         }
@@ -61,31 +66,34 @@ class AuthInterceptor @Inject constructor(
 
         val requestWithToken = originalRequest.newBuilder().apply {
             if (!accessToken.isNullOrEmpty()) {
+                // 8번 이슈는 범위 밖: 최초 주입은 addHeader 유지
                 addHeader(AUTH_HEADER, "$BEARER_PREFIX$accessToken")
             }
         }.build()
 
         val response = chain.proceed(requestWithToken)
 
-        // 만료(AUTH4113)면 재발급 시도
-        if (isTokenExpired(response) && !refreshToken.isNullOrEmpty()) {
-            response.close()
+        // 이미 재시도한 요청은 더 이상 재발급을 시도하지 않음 (가드)
+        if (!hasRetried && isTokenExpired(response) && !refreshToken.isNullOrEmpty()) {
+            response.close() // (1번 이슈는 이번 범위 밖)
+
             val newAccessToken = refreshAccessToken(refreshToken)
             if (!newAccessToken.isNullOrEmpty()) {
                 val newRequest = originalRequest.newBuilder()
                     .header(AUTH_HEADER, "$BEARER_PREFIX$newAccessToken")
+                    .tag(RetryOnceTag::class.java, RetryOnceTag)
                     .build()
                 return chain.proceed(newRequest)
             } else {
+                // 재발급 실패 시에는 현재 응답을 그대로 반환 (기존 동작 유지)
                 return response
             }
         }
 
-        // 401 이면서 '만료'가 아닌 특정 코드면 즉시 로그아웃
+        // 401이면서 '만료'가 아닌 특정 코드면 즉시 로그아웃
         if (response.code == HTTP_UNAUTHORIZED) {
             val code = extractErrorCode(response)
             if (code != null && code != JWT_EXPIRED_CODE && FORCE_LOGOUT_CODES.contains(code)) {
-                // 응답은 소비/유지 여부 상관없이 사용자 플로우는 로그아웃으로 전환
                 logoutManager.forceLogout()
             }
         }
@@ -130,39 +138,60 @@ class AuthInterceptor @Inject constructor(
         Log.e("AuthInterceptor", "Error parsing code", e); null
     }
 
-    // 재발급 로직
     private fun refreshAccessToken(refreshToken: String): String? {
-        return runBlocking {
-            try {
-                val retrofit = Retrofit.Builder()
-                    .baseUrl(BuildConfig.BASE_URL)
-                    .addConverterFactory(GsonConverterFactory.create())
-                    .build()
+        // 동시 재발급을 1회로 합쳐줌
+        return RefreshSingleFlight.refreshBlocking {
+            reissueOnce(refreshToken)
+        }
+    }
 
-                val tempAuthService = retrofit.create(AuthService::class.java)
-                val reissueResponse = tempAuthService.reissue(ReissueRequest(refreshToken))
+    // 네트워크 호출만 담당 (싱글플라이트 블록 안에서 호출)
+    private suspend fun reissueOnce(refreshToken: String): String? {
+        return try {
+            val retrofit = Retrofit.Builder()
+                .baseUrl(BuildConfig.BASE_URL)
+                .addConverterFactory(GsonConverterFactory.create())
+                .build()
 
-                if (reissueResponse.isSuccessful) {
-                    val newToken = reissueResponse.body()?.result
-                    fun String.mask() = if (length > 10) take(4) + "..." + takeLast(6) else "***"
+            val tempAuthService = retrofit.create(AuthService::class.java)
+            val reissueResponse = tempAuthService.reissue(ReissueRequest(refreshToken))
 
-                    Log.d("AuthInterceptor", "Token refreshed successfully")
-                    Log.d("AuthInterceptor", "NewAccessToken: ${newToken?.accessToken?.mask()}")
-                    Log.d("AuthInterceptor", "NewRefreshToken: ${newToken?.refreshToken?.mask()}")
+            if (reissueResponse.isSuccessful) {
+                val newToken = reissueResponse.body()?.result
+                fun String.mask() = if (length > 10) take(4) + "..." + takeLast(6) else "***"
 
-                    tokenProvider.saveTokens(
-                        accessToken = newToken?.accessToken ?: "",
-                        refreshToken = newToken?.refreshToken ?: refreshToken
+                Log.d("AuthInterceptor", "Token refreshed successfully")
+                Log.d("AuthInterceptor", "NewAccessToken: ${newToken?.accessToken?.mask()}")
+                Log.d("AuthInterceptor", "NewRefreshToken: ${newToken?.refreshToken?.mask()}")
+
+                tokenProvider.saveTokens(
+                    accessToken = newToken?.accessToken ?: "",
+                    refreshToken = newToken?.refreshToken ?: refreshToken
+                )
+                newToken?.accessToken
+            } else {
+                // 401이면 RT 만료/무효로 간주하고 즉시 로그아웃
+                if (reissueResponse.code() == HTTP_UNAUTHORIZED) {
+                    val errBody = reissueResponse.errorBody()?.string()
+                    val errCode = try {
+                        if (!errBody.isNullOrEmpty())
+                            Gson().fromJson(errBody, ErrorResponse::class.java)?.code
+                        else null
+                    } catch (_: Exception) { null }
+
+                    Log.e(
+                        "AuthInterceptor",
+                        "Token refresh failed: 401${if (errCode != null) " (code=$errCode)" else ""}. Forcing logout."
                     )
-                    newToken?.accessToken
+                    logoutManager.forceLogout()
                 } else {
                     Log.e("AuthInterceptor", "Token refresh failed: ${reissueResponse.code()}")
-                    null
                 }
-            } catch (e: Exception) {
-                Log.e("AuthInterceptor", "Token refresh error", e)
                 null
             }
+        } catch (e: Exception) {
+            Log.e("AuthInterceptor", "Token refresh error", e)
+            null
         }
     }
 }

--- a/app/src/main/java/com/example/teumteum/utils/AuthIntercepter.kt
+++ b/app/src/main/java/com/example/teumteum/utils/AuthIntercepter.kt
@@ -66,16 +66,16 @@ class AuthInterceptor @Inject constructor(
 
         val requestWithToken = originalRequest.newBuilder().apply {
             if (!accessToken.isNullOrEmpty()) {
-                // 8번 이슈는 범위 밖: 최초 주입은 addHeader 유지
                 addHeader(AUTH_HEADER, "$BEARER_PREFIX$accessToken")
             }
         }.build()
 
         val response = chain.proceed(requestWithToken)
 
-        // 이미 재시도한 요청은 더 이상 재발급을 시도하지 않음 (가드)
+        // 이미 재시도한 요청은 더 이상 재발급을 시도하지 않음
+        // RetryOnceTag를 붙여 무한 루프 및 중복 재발급 방지
         if (!hasRetried && isTokenExpired(response) && !refreshToken.isNullOrEmpty()) {
-            response.close() // (1번 이슈는 이번 범위 밖)
+            response.close()
 
             val newAccessToken = refreshAccessToken(refreshToken)
             if (!newAccessToken.isNullOrEmpty()) {
@@ -85,12 +85,13 @@ class AuthInterceptor @Inject constructor(
                     .build()
                 return chain.proceed(newRequest)
             } else {
-                // 재발급 실패 시에는 현재 응답을 그대로 반환 (기존 동작 유지)
+                // 재발급 실패 시에는 현재 응답을 그대로 반환
                 return response
             }
         }
 
-        // 401이면서 '만료'가 아닌 특정 코드면 즉시 로그아웃
+        // 401이면 RT 만료/무효로 간주하고 즉시 로그아웃
+        // 재발급 API에서 401이 떨어지는 경우는 RT 만료 외에는 거의 없으므로 세션을 종료
         if (response.code == HTTP_UNAUTHORIZED) {
             val code = extractErrorCode(response)
             if (code != null && code != JWT_EXPIRED_CODE && FORCE_LOGOUT_CODES.contains(code)) {

--- a/app/src/main/java/com/example/teumteum/utils/AuthIntercepter.kt
+++ b/app/src/main/java/com/example/teumteum/utils/AuthIntercepter.kt
@@ -6,18 +6,12 @@ import com.example.teumteum.data.remote.login.LogoutManager
 import com.example.teumteum.data.remote.login.model.ReissueRequest
 import com.example.teumteum.data.remote.login.service.AuthService
 import com.google.gson.Gson
-import kotlinx.coroutines.runBlocking
+import com.google.gson.reflect.TypeToken
 import okhttp3.Interceptor
 import okhttp3.Response
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Inject
-
-data class ErrorResponse(
-    val isSuccess: Boolean,
-    val code: String,
-    val message: String
-)
 
 // 요청 단위 1회 재시도 가드용 마커
 private object RetryOnceTag
@@ -73,7 +67,6 @@ class AuthInterceptor @Inject constructor(
         val response = chain.proceed(requestWithToken)
 
         // 이미 재시도한 요청은 더 이상 재발급을 시도하지 않음
-        // RetryOnceTag를 붙여 무한 루프 및 중복 재발급 방지
         if (!hasRetried && isTokenExpired(response) && !refreshToken.isNullOrEmpty()) {
             response.close()
 
@@ -85,13 +78,12 @@ class AuthInterceptor @Inject constructor(
                     .build()
                 return chain.proceed(newRequest)
             } else {
-                // 재발급 실패 시에는 현재 응답을 그대로 반환
+                // 재발급 실패 시에는 기존 응답을 그대로 반환
                 return response
             }
         }
 
-        // 401이면 RT 만료/무효로 간주하고 즉시 로그아웃
-        // 재발급 API에서 401이 떨어지는 경우는 RT 만료 외에는 거의 없으므로 세션을 종료
+        // 401이면 RT 만료/무효로 간주하고 즉시 로그아웃 (만료 코드 제외 + 강제 로그아웃 코드만)
         if (response.code == HTTP_UNAUTHORIZED) {
             val code = extractErrorCode(response)
             if (code != null && code != JWT_EXPIRED_CODE && FORCE_LOGOUT_CODES.contains(code)) {
@@ -110,13 +102,10 @@ class AuthInterceptor @Inject constructor(
     private fun isTokenExpired(response: Response): Boolean {
         if (response.code != HTTP_UNAUTHORIZED) return false
         return try {
-            val source = response.body?.source()
-            source?.request(Long.MAX_VALUE)
-            val buffer = source?.buffer?.clone()
-            val responseBodyString = buffer?.readUtf8() ?: ""
-            if (responseBodyString.isNotEmpty()) {
-                val errorResponse = Gson().fromJson(responseBodyString, ErrorResponse::class.java)
-                errorResponse.code == JWT_EXPIRED_CODE
+            val bodyString = readBodyString(response)
+            if (bodyString.isNotEmpty()) {
+                val api = parseApiErrorBody(bodyString)
+                api?.code == JWT_EXPIRED_CODE
             } else {
                 true
             }
@@ -126,17 +115,31 @@ class AuthInterceptor @Inject constructor(
         }
     }
 
-    // 에러코드만 뽑아보기 (재발급 로직과 분리)
+    // 에러코드만 추출 (재발급 로직과 분리)
     private fun extractErrorCode(response: Response): String? = try {
-        val source = response.body?.source()
-        source?.request(Long.MAX_VALUE)
-        val buffer = source?.buffer?.clone()
-        val bodyString = buffer?.readUtf8() ?: ""
-        if (bodyString.isNotEmpty()) {
-            Gson().fromJson(bodyString, ErrorResponse::class.java)?.code
-        } else null
+        val bodyString = readBodyString(response)
+        if (bodyString.isNotEmpty()) parseApiErrorBody(bodyString)?.code else null
     } catch (e: Exception) {
-        Log.e("AuthInterceptor", "Error parsing code", e); null
+        Log.e("AuthInterceptor", "Error parsing code", e)
+        null
+    }
+
+    // peekBody로 본문을 소비하지 않고 미리보기 문자열 획득
+    private fun readBodyString(response: Response): String {
+        return try {
+            response.peekBody(1024 * 1024).string() // 1MB
+        } catch (e: Exception) {
+            Log.e("AuthInterceptor", "Error peeking body", e)
+            ""
+        }
+    }
+
+    // ApiResponse<Any?>로 에러 바디 파싱
+    private fun parseApiErrorBody(bodyString: String): ApiResponse<Any?>? = try {
+        val type = object : TypeToken<ApiResponse<Any?>>() {}.type
+        Gson().fromJson<ApiResponse<Any?>>(bodyString, type)
+    } catch (_: Exception) {
+        null
     }
 
     private fun refreshAccessToken(refreshToken: String): String? {
@@ -174,15 +177,11 @@ class AuthInterceptor @Inject constructor(
                 // 401이면 RT 만료/무효로 간주하고 즉시 로그아웃
                 if (reissueResponse.code() == HTTP_UNAUTHORIZED) {
                     val errBody = reissueResponse.errorBody()?.string()
-                    val errCode = try {
-                        if (!errBody.isNullOrEmpty())
-                            Gson().fromJson(errBody, ErrorResponse::class.java)?.code
-                        else null
-                    } catch (_: Exception) { null }
+                    val errCode = errBody?.let { parseApiErrorBody(it)?.code }
 
                     Log.e(
                         "AuthInterceptor",
-                        "Token refresh failed: 401${if (errCode != null) " (code=$errCode)" else ""}. Forcing logout."
+                        "Token refresh failed: 401${if (errCode != null) " (code=$errCode)" else ""} Forcing logout"
                     )
                     logoutManager.forceLogout()
                 } else {

--- a/app/src/main/java/com/example/teumteum/utils/RefreshSingleFlight.kt
+++ b/app/src/main/java/com/example/teumteum/utils/RefreshSingleFlight.kt
@@ -1,0 +1,39 @@
+package com.example.teumteum.utils
+
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.async
+
+object RefreshSingleFlight {
+    private val mutex = kotlinx.coroutines.sync.Mutex()
+    private var inFlight: kotlinx.coroutines.Deferred<String?>? = null
+
+    // runBlocking 환경에서도 쓸 수 있게 blocking 버전 제공
+    @OptIn(DelicateCoroutinesApi::class)
+    fun refreshBlocking(block: suspend () -> String?): String? = kotlinx.coroutines.runBlocking {
+        mutex.lock()
+        try {
+            // 누군가 이미 재발급 중이면 그 결과를 기다림
+            inFlight?.let { existing ->
+                mutex.unlock() // 대기 중에는 잠금 풀어줌
+                return@runBlocking existing.await()
+            }
+            // 새 재발급 시작
+            val job = kotlinx.coroutines.GlobalScope.async(kotlinx.coroutines.Dispatchers.IO) {
+                try { block() } finally { /* no-op */ }
+            }
+            inFlight = job
+            mutex.unlock()
+            try { job.await() } finally {
+                // 완료되면 inFlight 해제
+                mutex.lock()
+                if (inFlight == job) inFlight = null
+                mutex.unlock()
+            }
+        } catch (t: Throwable) {
+            // 예외 시 안전하게 inFlight 초기화
+            if (mutex.isLocked) mutex.unlock()
+            inFlight = null
+            throw t
+        }
+    }
+}

--- a/app/src/main/java/com/example/teumteum/utils/RefreshSingleFlight.kt
+++ b/app/src/main/java/com/example/teumteum/utils/RefreshSingleFlight.kt
@@ -7,30 +7,38 @@ object RefreshSingleFlight {
     private val mutex = kotlinx.coroutines.sync.Mutex()
     private var inFlight: kotlinx.coroutines.Deferred<String?>? = null
 
-    // runBlocking 환경에서도 쓸 수 있게 blocking 버전 제공
+    /**
+     * 동시 재발급 요청을 단 1회로 합쳐주는 유틸
+     * - 이미 재발급이 진행 중이면 그 결과를 기다렸다가 그대로 반환
+     * - 새로운 재발급이 필요하면 직접 실행
+     * - runBlocking 환경에서도 호출 가능
+     */
     @OptIn(DelicateCoroutinesApi::class)
     fun refreshBlocking(block: suspend () -> String?): String? = kotlinx.coroutines.runBlocking {
         mutex.lock()
         try {
-            // 누군가 이미 재발급 중이면 그 결과를 기다림
+            // 이미 재발급 진행 중이라면 → 그 Job 결과를 기다리고 반환
             inFlight?.let { existing ->
-                mutex.unlock() // 대기 중에는 잠금 풀어줌
+                mutex.unlock() // 다른 호출자들이 대기하지 않도록 잠금 해제
                 return@runBlocking existing.await()
             }
-            // 새 재발급 시작
+            // 아직 재발급이 없으면 → 새로운 Job 실행
             val job = kotlinx.coroutines.GlobalScope.async(kotlinx.coroutines.Dispatchers.IO) {
                 try { block() } finally { /* no-op */ }
             }
             inFlight = job
             mutex.unlock()
-            try { job.await() } finally {
-                // 완료되면 inFlight 해제
+            try {
+                // 실행한 Job 결과 반환
+                job.await()
+            } finally {
+                // 완료된 Job이면 inFlight 초기화
                 mutex.lock()
                 if (inFlight == job) inFlight = null
                 mutex.unlock()
             }
         } catch (t: Throwable) {
-            // 예외 시 안전하게 inFlight 초기화
+            // 예외 발생 시에도 inFlight 초기화 보장
             if (mutex.isLocked) mutex.unlock()
             inFlight = null
             throw t


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #229 

## ✨ 작업 내용
이번 PR은 **토큰 재발급/로그아웃 처리의 안정화**를 목표로 아래 사항을 반영했습니다.

#### 중복 재발급 방지 (동시성 제어)
- **싱글플라이트 유틸 추가**: `RefreshSingleFlight.refreshBlocking { ... }`
  - `Mutex + Deferred` 기반으로 **동시에 여러 요청이 AT 만료를 맞아도 재발급 호출은 딱 1회만** 발생하도록 직렬화
  - 다른 동시 호출자들은 해당 Job의 결과를 `await()`하여 **결과 공유**
- 성능/부하 개선 포인트
  - 기존: 동시 n개의 요청 → 재발급 n회
  - 변경: 동시 n개의 요청 → 재발급 1회, 나머지 n-1개의 요청은 결과 대기/공유

#### 요청 단위 재시도 1회 가드
- **`RetryOnceTag` 마커 태그** 도입 (OkHttp `tag` 멀티-키 API)
  - 같은 요청 체인에서 401 만료 발생 시 **최대 1회만** 재발급 후 재시도
  - 두 번째 401에서도 재발급을 **더 이상 시도하지 않음** → 무한 루프/폭주 방지
- 기존 Boolean 태그 사용 시 발생하던 **`ClassCastException(Boolean↔boolean)`** 문제를 제거

#### 재발급 실패(401) 시 즉시 로그아웃
- `reissueOnce(...)`에서 **재발급 API 응답 코드가 401**인 경우:
  - 에러 바디 파싱(`ErrorResponse.code`)을 시도해 로그에 남김
  - **`logoutManager.forceLogout()` 호출**로 세션 즉시 종료
- 의미
  - RT 만료/무효, 블랙리스트 등으로 **재발급 자체가 불가능**해진 경우를 클라이언트에서 신속히 감지하고 사용자 흐름을 정상화

#### 응답 파싱 로직 개선  
- **에러/성공 응답 모두 `ApiResponse`로 통일**  
  - 중복되던 `ErrorResponse` 제거  
  - 에러 응답도 `ApiResponse<Any?>`로 안전하게 파싱 → 모델 관리 일원화  
- **`peekBody` 기반 응답 본문 읽기 도입**  
  - 기존 `source().request()` + `buffer.clone()` 방식 제거  
  - `response.peekBody(…)` 사용으로 **본문 소비 없이 미리보기 가능**  
  - 파싱 실패 시에도 NPE/EOF 방지  


## ✅ 코드 리뷰어 체크리스트
- [ ] 동시성 제어(`RefreshSingleFlight`) 동작이 올바른지  
- [ ] `RetryOnceTag`를 통한 1회 재시도 가드가 잘 적용되었는지  
- [ ] `ApiResponse` 일원화 및 `peekBody` 도입이 안전하게 반영되었는지 

## 📸 스크린샷 (선택)
<img width="790" height="135" alt="image" src="https://github.com/user-attachments/assets/39d5af60-64aa-4bb2-9d89-628cc4d2e7fd" />
- AT 만료 후 토큰 재발급 성공
- RT 만료 후 재발급 실패 -> 즉시 로그아웃 처리

## 💬 기타 참고 사항
- 저도 처음 적용해보는 것들이 대부분이라 PR이 좀 길어졌습니다...ㅜㅜ
- 주석을 작성해두긴 했으나 PR이랑 코드랑 비교해서 보시면 이해하기가 쉬울 듯 합니다......