### PR TITLE
[FIX/#231] 자동 로그인 로직 개선

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/signin/LoginActivity.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signin/LoginActivity.kt
@@ -6,19 +6,24 @@ import android.util.Log
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import com.example.teumteum.ui.signup.SignUpActivity
 import com.example.teumteum.databinding.ActivityLoginBinding
+import com.example.teumteum.ui.main.MainActivity
 import com.example.teumteum.ui.signin.data.LoginResult
 import com.example.teumteum.ui.signin.viewModel.LoginViewModel
+import com.example.teumteum.ui.signup.SignUpActivity
+import com.example.teumteum.utils.FlowPrefs
 import com.example.teumteum.utils.NextStep
 import com.kakao.sdk.user.UserApiClient
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class LoginActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityLoginBinding
     private val viewModel: LoginViewModel by viewModels()
+
+    @Inject lateinit var flowPrefs: FlowPrefs
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -27,8 +32,7 @@ class LoginActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         binding.signupLayout.setOnClickListener {
-            val intent = Intent(this, SignUpActivity::class.java)
-            startActivity(intent)
+            startActivity(Intent(this, SignUpActivity::class.java))
         }
 
         binding.kakaoLoginBtn.setOnClickListener {
@@ -41,21 +45,23 @@ class LoginActivity : AppCompatActivity() {
     private fun observeViewModel() {
         viewModel.loginResult.observe(this) { result ->
             when (result) {
-                is LoginResult.Loading -> { /* 로딩 표시 */ }
+                is LoginResult.Loading -> { /* TODO: 로딩 표시 */ }
                 is LoginResult.Success -> {
+                    // 서버가 알려준 nextStep을 즉시 FlowPrefs에 동기화
                     when (result.nextStep) {
                         NextStep.AGREEMENT, NextStep.ONBOARDING -> {
+                            flowPrefs.setLastStep(result.nextStep)
                             startActivity(Intent(this, SignUpActivity::class.java))
                         }
                         NextStep.MAIN -> {
-                            startActivity(Intent(this, com.example.teumteum.ui.main.MainActivity::class.java))
+                            flowPrefs.setLastStep(NextStep.MAIN)
+                            startActivity(Intent(this, MainActivity::class.java))
                         }
                     }
                     finish()
                 }
                 is LoginResult.Error -> {
                     Log.d("KakaoLogin", "카카오 로그인 실패 ${result.message}")
-//                    Toast.makeText(this, result.message ?: "로그인 실패", Toast.LENGTH_SHORT).show()
                 }
             }
         }
@@ -82,5 +88,4 @@ class LoginActivity : AppCompatActivity() {
             UserApiClient.instance.loginWithKakaoAccount(this, callback = callback)
         }
     }
-
 }

--- a/app/src/main/java/com/example/teumteum/ui/signup/CompleteFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/CompleteFragment.kt
@@ -7,13 +7,19 @@ import android.view.View
 import android.view.ViewGroup
 import com.example.teumteum.R
 import com.example.teumteum.databinding.FragmentCompleteBinding
+import com.example.teumteum.utils.FlowPrefs
+import com.example.teumteum.utils.NextStep
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class CompleteFragment : Fragment() {
 
     private var _binding: FragmentCompleteBinding? = null
     private val binding get() = _binding!!
+
+    @Inject
+    lateinit var flowPrefs: FlowPrefs
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -28,6 +34,9 @@ class CompleteFragment : Fragment() {
 
         // 프로그래스바 설정
         (activity as? SignUpActivity)?.setProgressBar(100)
+
+        // step을 ONBORDING으로 설정
+        flowPrefs.setLastStep(NextStep.ONBOARDING)
 
         binding.completeBtn.setOnClickListener {
             parentFragmentManager.beginTransaction()

--- a/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingNicknameFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/OnBoardingNicknameFragment.kt
@@ -38,6 +38,9 @@ class OnBoardingNicknameFragment : Fragment() {
     }
 
     private fun setupUI() {
+        // 프로그래스바 설정
+        (activity as? SignUpActivity)?.setProgressBar(20)
+
         // 텍스트 입력 ViewModel 업데이트
         binding.nicknameEt.addTextChangedListener(object : TextWatcher {
             override fun afterTextChanged(s: Editable?) {

--- a/app/src/main/java/com/example/teumteum/ui/signup/SignUpActivity.kt
+++ b/app/src/main/java/com/example/teumteum/ui/signup/SignUpActivity.kt
@@ -17,6 +17,10 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class SignUpActivity : AppCompatActivity() {
 
+    companion object {
+        const val EXTRA_NEXT_STEP = "extra_next_step"
+    }
+
     private lateinit var binding: ActivitySignUpBinding
 
     @Inject
@@ -32,27 +36,20 @@ class SignUpActivity : AppCompatActivity() {
     }
 
     private fun initializeSignUpFlow() {
-        val currentStep = flowPrefs.getLastStep()
+        val stepFromIntent = intent.getStringExtra(EXTRA_NEXT_STEP)
+            ?.let { runCatching { NextStep.valueOf(it) }.getOrNull() }
+
+        // 1순위: 인텐트, 2순위: 로컬 캐시
+        val currentStep = stepFromIntent ?: flowPrefs.getLastStep()
 
         when (currentStep) {
-            NextStep.AGREEMENT -> {
-                // 약관 동의 화면부터 시작
-                setProgressBarVisible(true)
-                setProgressBar(0)
-                loadFragment(AgreementFragment())
-            }
             NextStep.ONBOARDING -> {
-                // 온보딩 첫 번째 단계부터 시작
                 setProgressBarVisible(true)
                 setProgressBar(20)
                 loadFragment(OnBoardingNicknameFragment())
             }
-            NextStep.MAIN -> {
-                // 이미 모든 과정이 완료된 경우 - 메인으로 이동
-                navigateToMain()
-            }
-            null -> {
-                // NextStep이 설정되지 않은 경우 - 약관 동의부터 시작
+            NextStep.MAIN -> navigateToMain()
+            NextStep.AGREEMENT, null -> {
                 setProgressBarVisible(false)
                 loadFragment(AgreementFragment())
             }
@@ -65,20 +62,21 @@ class SignUpActivity : AppCompatActivity() {
             .commit()
     }
 
-    //상단 프로그레스바 제어
+    // 상단 프로그레스바 제어
     fun setProgressBar(progress: Int) {
         binding.progressBar.progress = progress
     }
 
-    //프로그레스바 visible 설정
+    // 프로그레스바 visible 설정
     fun setProgressBarVisible(visible: Boolean) {
         binding.progressBar.visibility = if (visible) View.VISIBLE else View.GONE
     }
 
-    /**
-     * 온보딩 단계 진행
-     */
+    // 온보딩 단계
     fun proceedToNextOnboardingStep(currentFragment: Fragment) {
+        // 온보딩 도중에는 항상 ONBOARDING 유지
+        flowPrefs.setLastStep(NextStep.ONBOARDING)
+
         when (currentFragment) {
             is OnBoardingNicknameFragment -> {
                 setProgressBar(40)
@@ -102,21 +100,16 @@ class SignUpActivity : AppCompatActivity() {
         }
     }
 
-    /**
-     * 온보딩 완료 후 메인 화면으로 이동
-     */
+    // 온보딩 완료 후 메인 화면으로 이동
     fun completeOnboarding() {
         flowPrefs.setLastStep(NextStep.MAIN)
         navigateToMain()
     }
 
-    /**
-     * 메인 화면으로 이동
-     */
+    // 메인 화면으로 이동
     private fun navigateToMain() {
         val intent = Intent(this, MainActivity::class.java)
         startActivity(intent)
         finish()
     }
-
 }

--- a/app/src/main/java/com/example/teumteum/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/example/teumteum/ui/splash/SplashActivity.kt
@@ -4,13 +4,13 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Looper
 import android.os.Handler
+import android.util.Log
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import com.example.teumteum.R
 import com.example.teumteum.ui.main.MainActivity
 import com.example.teumteum.ui.signin.LoginActivity
+import com.example.teumteum.ui.signup.SignUpActivity
 import com.example.teumteum.utils.FlowPrefs
 import com.example.teumteum.utils.NextStep
 import com.example.teumteum.utils.TokenProvider
@@ -28,17 +28,34 @@ class SplashActivity : AppCompatActivity() {
         enableEdgeToEdge()
         setContentView(R.layout.activity_splash)
 
+        // 2초 딜레이 후 라우팅
         Handler(Looper.getMainLooper()).postDelayed({
-            val hasAccess = !tokenProvider.getAccessToken().isNullOrBlank()
-            val last = flowPrefs.getLastStep()
+            routeFromSplash()
+        }, 2000)
+    }
 
-            val target = if (hasAccess && last == NextStep.MAIN) {
-                Intent(this, MainActivity::class.java)
-            } else {
+    // 토큰 + 마지막 단계 기준으로 진입 경로 결정
+    private fun routeFromSplash() {
+        val raw = tokenProvider.getAccessToken()
+        val hasAccess = !raw.isNullOrBlank()
+        val last = flowPrefs.getLastStep()
+
+        val target = when {
+            !hasAccess -> {
                 Intent(this, LoginActivity::class.java)
             }
-            startActivity(target)
-            finish()
-        }, 2000)
+            last == NextStep.AGREEMENT || last == NextStep.ONBOARDING -> {
+                Intent(this, SignUpActivity::class.java)
+            }
+            last == NextStep.MAIN -> {
+                Intent(this, MainActivity::class.java)
+            }
+            else -> {
+                Intent(this, LoginActivity::class.java)
+            }
+        }
+
+        startActivity(target)
+        finish()
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #231 

- 기존 구조에서는 토큰만 확인했기 때문에 약관/온보딩 도중 앱을 종료하면 다시 로그인부터 시작해야 했음
- 재로그인 하는 과정에서 꼬임 발생

## ✨ 작업 내용
- `SplashActivity`: 토큰 + step 조합으로 분기
  - 토큰 없음 -> LoginActivity
  - 토큰 있음 + AGREEMENT -> 약관 화면
  - 토큰 있음 + ONBOARDING -> 온보딩
  - 토큰 있음 + MAIN -> MainActivity

## ✅ 코드 리뷰어 체크리스트
- [ ] 토큰 + step 조합의 분기가 적절한지

## 📸 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/d7db52d8-7620-4577-bedd-f1430bcc9650" width="300"/>


## 💬 기타 참고 사항
- 이미 계정이 생긴 상황에서 테스트를 해보실 수 없을테니... 제가 로컬 서버로 돌린 거 확인해주시면 좋을 것 같습니다
- 아니면 내일 로컬 서버로 돌려봐도 좋을 듯합니다!!
