### PR TITLE
[Feat/#233] 친구 목록 무한스크롤 및 공통 PagingResponse 적용

### DIFF
--- a/app/src/main/java/com/example/teumteum/data/remote/friend/model/FollowerResult.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/friend/model/FollowerResult.kt
@@ -8,8 +8,3 @@ data class FollowerResult(
     @SerializedName("job") val job: String,
     @SerializedName("profileImageUrl") val profileImageUrl: String
 )
-
-data class FollowerPageResult(
-    @SerializedName("content") val content: List<FollowerResult>,
-    @SerializedName("hasNext") val hasNext: Boolean
-)

--- a/app/src/main/java/com/example/teumteum/data/remote/friend/model/FollowingPageResult.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/friend/model/FollowingPageResult.kt
@@ -1,9 +1,0 @@
-package com.example.teumteum.data.remote.friend.model
-
-import com.google.gson.annotations.SerializedName
-
-data class FollowingPageResult(
-    @SerializedName("content") val content: List<FollowingResult>,
-    @SerializedName("hasNext") val hasNext: Boolean
-)
-

--- a/app/src/main/java/com/example/teumteum/data/remote/friend/model/PagingResponse.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/friend/model/PagingResponse.kt
@@ -1,0 +1,6 @@
+package com.example.teumteum.data.remote.friend.model
+
+data class PagingResponse<T>(
+    val content: List<T>,
+    val hasNext: Boolean
+)

--- a/app/src/main/java/com/example/teumteum/data/remote/friend/repository/FriendRepository.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/friend/repository/FriendRepository.kt
@@ -83,11 +83,14 @@ class FriendRepository @Inject constructor(
     }
 
     // 7) 팔로잉 목록
-    suspend fun getFollowings(page: Int, size: Int): Result<List<FollowingResult>> = runCatching {
+    suspend fun getFollowingsPage(
+        page: Int,
+        size: Int
+    ): Result<PagingResponse<FollowingResult>> = runCatching {
         val response = api.getFollowings(page, size)
         val body = response.body()
         if (response.isSuccessful && body?.isSuccess == true) {
-            body.result?.content ?: emptyList()
+            body.result ?: PagingResponse(emptyList(), false)
         } else {
             throw Exception("${body?.code ?: "HTTP ${response.code()}"} - ${body?.message ?: response.message()}")
         }
@@ -162,24 +165,14 @@ class FriendRepository @Inject constructor(
     }
 
     // 14) 팔로워 목록
-    suspend fun getFollowers(page: Int, size: Int): Result<List<FollowerResult>> = runCatching {
+    suspend fun getFollowersPage(
+        page: Int,
+        size: Int
+    ): Result<PagingResponse<FollowerResult>> = runCatching {
         val response = api.getFollowers(page, size)
         val body = response.body()
         if (response.isSuccessful && body?.isSuccess == true) {
-            Log.d("FOLLOWER_FRAGMENT", "친구 목록 조회에 성공하였습니다. message=${body.message}")
-            body.result?.content ?: emptyList()
-        } else {
-            throw Exception("${body?.code ?: "HTTP ${response.code()}"} - ${body?.message ?: response.message()}")
-        }
-    }
-
-    // 14-1) 팔로워 목록
-    suspend fun getFollowersPage(page: Int, size: Int): Result<FollowerPageResult> = runCatching {
-        val response = api.getFollowers(page, size)
-        val body = response.body()
-        if (response.isSuccessful && body?.isSuccess == true && body.result != null) {
-            Log.d("FOLLOWER_FRAGMENT", "친구 목록 조회에 성공하였습니다. message=${body.message}")
-            body.result
+            body.result ?: PagingResponse(emptyList(), false)
         } else {
             throw Exception("${body?.code ?: "HTTP ${response.code()}"} - ${body?.message ?: response.message()}")
         }

--- a/app/src/main/java/com/example/teumteum/data/remote/friend/service/FriendService.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/friend/service/FriendService.kt
@@ -42,12 +42,6 @@ interface FriendService {
         @Path("userId") userId: Int
     ): Response<ApiResponse<Unit>>
 
-    @GET("/api/friends/followings")
-    suspend fun getFollowings(
-        @Query("page") page: Int,
-        @Query("size") size: Int
-    ): Response<ApiResponse<FollowingPageResult>>
-
     @GET("/api/teums/scheduled/calendar")
     suspend fun getScheduledTeumCalendar(
         @Query("month") month: String
@@ -80,12 +74,19 @@ interface FriendService {
         @Body body: FavoriteRequest
     ): Response<ApiResponse<FavoriteResult>>
 
+    // 팔로잉 목록
+    @GET("/api/friends/followings")
+    suspend fun getFollowings(
+        @Query("page") page: Int,
+        @Query("size") size: Int
+    ): Response<ApiResponse<PagingResponse<FollowingResult>>>
+
     // 팔로워 목록 (페이지)
     @GET("/api/friends/followers")
     suspend fun getFollowers(
         @Query("page") page: Int,
         @Query("size") size: Int
-    ): Response<ApiResponse<FollowerPageResult>>
+    ): Response<ApiResponse<PagingResponse<FollowerResult>>>
 
     // 틈 요청 읽음 처리
     @PATCH("/api/teums/request/{responseId}/read")

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendFragment.kt
@@ -215,6 +215,26 @@ class FriendFragment : Fragment() {
             adapter = recommendAdapter
         }
 
+        // 무한스크롤 (following)
+        val flm = binding.followingRecyclerView.layoutManager as LinearLayoutManager
+        binding.followingRecyclerView.addOnScrollListener(object: RecyclerView.OnScrollListener() {
+            override fun onScrolled(rv: RecyclerView, dx: Int, dy: Int) {
+                if (dy <= 0) return
+                val last = flm.findLastVisibleItemPosition()
+                if (last >= flm.itemCount - 3) viewModel.loadNextFollowings()
+            }
+        })
+
+        // 무한스크롤 (follower)
+        val flm2 = binding.followerRecyclerView.layoutManager as LinearLayoutManager
+        binding.followerRecyclerView.addOnScrollListener(object: RecyclerView.OnScrollListener() {
+            override fun onScrolled(rv: RecyclerView, dx: Int, dy: Int) {
+                if (dy <= 0) return
+                val last = flm2.findLastVisibleItemPosition()
+                if (last >= flm2.itemCount - 3) viewModel.loadNextFollowers()
+            }
+        })
+
         // 탭 클릭 리스너
         binding.tabFollowing.setOnClickListener {
             binding.tabFollowing.setTextColor(Color.parseColor("#0F0F0F"))
@@ -223,7 +243,8 @@ class FriendFragment : Fragment() {
             binding.followerRecyclerView.visibility = View.GONE
 
             // 팔로잉 목록 조회
-            viewModel.getFollowingUsers()
+            viewModel.resetFollowingPaging()
+            viewModel.loadNextFollowings()
         }
 
         binding.tabFollower.setOnClickListener {
@@ -233,7 +254,8 @@ class FriendFragment : Fragment() {
             binding.followerRecyclerView.visibility = View.VISIBLE
 
             // 팔로워 목록 조회
-            viewModel.getFollowerUsers()
+            viewModel.resetFollowerPaging()
+            viewModel.loadNextFollowers()
         }
 
         binding.btnAlarm.setOnClickListener {

--- a/app/src/main/java/com/example/teumteum/ui/friend/viewModel/FriendViewModel.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/viewModel/FriendViewModel.kt
@@ -44,6 +44,20 @@ class FriendViewModel @Inject constructor(
     private val _errorMessage = MutableLiveData<Event<String>>()
     val errorMessage: LiveData<Event<String>> get() = _errorMessage
 
+    // 페이징 상태 관련 필드
+    private var followingPage = 1
+    private var followerPage = 1
+    private val pageSize = 10
+
+    private var isLoadingFollowing = false
+    private var isLoadingFollower = false
+
+    private val _followingHasNext = MutableLiveData(true)
+    val followingHasNext: LiveData<Boolean> = _followingHasNext
+
+    private val _followersHasNext = MutableLiveData(true)
+    val followersHasNext: LiveData<Boolean> = _followersHasNext
+
 
     //    상단 프로필의 star_btn 과 리스트 아이템의 starIv 가 함께 관찰하는 공통 상태
     private val _favoriteMap = MutableLiveData<Map<Int, Boolean>>(emptyMap())
@@ -428,34 +442,28 @@ class FriendViewModel @Inject constructor(
     private val _followingUsers = MutableLiveData<List<FollowingResult>>()
     val followingUsers: LiveData<List<FollowingResult>> get() = _followingUsers
 
-    fun getFollowingUsers(page: Int = 1, size: Int = 10) {
+    fun resetFollowingPaging() {
+        followingPage = 1
+        _followingHasNext.value = true
+        _followingUsers.value = emptyList()
+    }
+
+    fun loadNextFollowings() {
+        if (isLoadingFollowing || _followingHasNext.value == false) return
+        isLoadingFollowing = true
         viewModelScope.launch {
-            repository.getFollowings(page, size)
-                .onSuccess { list ->
-                    // 기존 토글 상태 우선 반영
-                    val favMap = _favoriteMap.value.orEmpty()
-                    val merged = list.map { item ->
-                        val fav = favMap[item.userId] ?: item.isFavorite
-                        item.copy(isFavorite = fav)
-                    }
+            repository.getFollowingsPage(followingPage, pageSize)
+                .onSuccess { page ->
+                    // 서버 정렬 그대로 + 사용자가 토글한 즐겨찾기는 오버라이드만 반영
+                    val favMap = favoriteMap.value.orEmpty()
+                    val merged = page.content.map { it.copy(isFavorite = favMap[it.userId] ?: it.isFavorite) }
+                    _followingUsers.value = _followingUsers.value.orEmpty() + merged
 
-                    val collator =
-                        Collator.getInstance(Locale.KOREAN).apply { strength = Collator.PRIMARY }
-                    val sorted = merged.sortedWith(Comparator { a, b ->
-                        if (a.isFavorite != b.isFavorite) {
-                            if (a.isFavorite) -1 else 1
-                        } else {
-                            collator.compare(a.nickname, b.nickname)
-                        }
-                    })
-
-                    _followingUsers.value = sorted
-                    Log.d("FOLLOWING_LIST", "FRIEND2002 친구 목록 조회 성공")
+                    _followingHasNext.value = page.hasNext
+                    if (page.hasNext) followingPage += 1
                 }
-                .onFailure { e ->
-                    _errorMessage.value = Event("팔로잉 목록 조회 실패 (${e.message})")
-                    Log.e("FOLLOWING_LIST", "팔로잉 목록 조회 실패: ${e.message}")
-                }
+                .onFailure { e -> _errorMessage.value = Event("팔로잉 목록 조회 실패 (${e.message})") }
+            isLoadingFollowing = false
         }
     }
 
@@ -569,40 +577,27 @@ class FriendViewModel @Inject constructor(
         }
     }
 
-
-    // 14. 팔로워 목록 조회
     private val _followerUsers = MutableLiveData<List<FollowerResult>>()
     val followerUsers: LiveData<List<FollowerResult>> get() = _followerUsers
 
-    // 다음 페이지 여부
-    private val _followersHasNext = MutableLiveData<Boolean>()
-    val followersHasNext: LiveData<Boolean> get() = _followersHasNext
+    fun resetFollowerPaging() {
+        followerPage = 1
+        _followersHasNext.value = true
+        _followerUsers.value = emptyList()
+    }
 
-    /** 팔로워 목록 조회 (가나다 정렬 + 성공 로그/토스트) */
-    fun getFollowerUsers(page: Int = 1, size: Int = 10) {
+    fun loadNextFollowers() {
+        if (isLoadingFollower || _followersHasNext.value == false) return
+        isLoadingFollower = true
         viewModelScope.launch {
-            // repository에 getFollowersPage(...) 추가해둔 버전 사용
-            repository.getFollowersPage(page, size)
-                .onSuccess { pageResult ->
-                    Log.d("FOLLOWER_FRAGMENT", "친구 목록 조회에 성공하였습니다.")
-
-                    // 가나다 정렬
-                    val collator =
-                        Collator.getInstance(Locale.KOREAN).apply { strength = Collator.PRIMARY }
-                    val sorted = pageResult.content.sortedWith { a, b ->
-                        collator.compare(a.nickname, b.nickname)
-                    }
-
-                    _followerUsers.value = sorted
-                    _followersHasNext.value = pageResult.hasNext
-
-//                    _successMessage.value = Event("친구 목록 조회에 성공하였습니다.")
+            repository.getFollowersPage(followerPage, pageSize)
+                .onSuccess { page ->
+                    _followerUsers.value = _followerUsers.value.orEmpty() + page.content
+                    _followersHasNext.value = page.hasNext
+                    if (page.hasNext) followerPage += 1
                 }
-                .onFailure { e ->
-                    val msg = "팔로워 목록 조회 실패 (${e.message ?: "알 수 없는 오류"})"
-                    _errorMessage.value = Event(msg)
-                    Log.e("FOLLOWER_FRAGMENT", msg, e)
-                }
+                .onFailure { e -> _errorMessage.value = Event("팔로워 목록 조회 실패 (${e.message ?: "알 수 없는 오류"})") }
+            isLoadingFollower = false
         }
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #233 

## ✨ 작업 내용
> 팔로잉/팔로워 조회에 무한스크롤을 적용하고 API 응답을 공통 PagingResponse<T> 구조로 통일했습니다.
- FriendService 반환 타입을 PagingResponse<T>로 변경
- Repository에 getFollowingsPage / getFollowersPage 구현
- ViewModel에 page/hasNext/isLoading 상태 관리 및 loadNext* 함수 추가
- Fragment에 RecyclerView 무한스크롤 리스너 추가
- 탭 전환 시 reset + 첫 페이지 로드 처리
- 기존 단발 조회(getFollowingUsers / getFollowerUsers) 코드 제거

## ✅ 코드 리뷰어 체크리스트
- [x] 공통 PagingResponse<T> 적용이 정상적으로 동작하는지
- [x] 무한스크롤 로직에서 중복 호출/누락 없이 페이지가 이어지는지
- [x] 탭 전환 시 reset + 첫 페이지 로드가 올바르게 수행되는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
- 초기 size는 10으로 설정했습니다.
