### PR TITLE
[Feat/#235] 위시리스트 스크롤 적용 및 페이징

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/wish/WishlistEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishlistEditFragment.kt
@@ -94,7 +94,7 @@ class WishlistEditFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.deleteSuccess.collect {
-                    Toast.makeText(requireContext(), "삭제가 완료되었어요.", Toast.LENGTH_SHORT).show()
+                    Log.d("WISH_EDIT_FRAGMENT", "위시가 성공적으로 삭제되었습니다.")
                     pendingDeleteIds.clear()
                     viewModel.refreshWishlist("all") // 요구사항: 삭제는 항상 ALL
                     parentFragmentManager.popBackStack()

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishlistEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishlistEditFragment.kt
@@ -11,6 +11,8 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.example.teumteum.R
 import com.example.teumteum.data.remote.wish.model.DeleteWishesRequest
 import com.example.teumteum.data.remote.wish.model.WishlistItem
@@ -22,110 +24,127 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
-class WishlistEditFragment() : Fragment() {
+class WishlistEditFragment : Fragment() {
 
     private var _binding: FragmentWishlistEditBinding? = null
     private val binding get() = _binding!!
 
     private lateinit var adapter: WishlistEditRVAdapter
-    private lateinit var editedWishlist: MutableList<WishlistItem>
+    private val edited: MutableList<WishlistItem> = mutableListOf()
+
+    // 페이지 append 시에 선택(삭제 체크) 유지용
+    private val selectedIds = mutableSetOf<Long>()
 
     private val viewModel: WishViewModel by activityViewModels()
 
     override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View {
         _binding = FragmentWishlistEditBinding.inflate(inflater, container, false)
-
-        // ViewModel에서 데이터 복사
-        editedWishlist = viewModel.wishlistItems.value?.map { it.copy() }?.toMutableList() ?: mutableListOf()
-
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        // 바텀 내비게이션 숨기기
-        val bottomNav = activity?.findViewById<BottomNavigationView>(R.id.main_bnv)
-        bottomNav?.visibility = View.GONE
+        activity?.findViewById<BottomNavigationView>(R.id.main_bnv)?.visibility = View.GONE
 
-        if (editedWishlist.isEmpty()) {
-            // 위시가 없을 경우
-            binding.wishlistRv.visibility = View.GONE
-            binding.wishNotExistsCv.visibility = View.VISIBLE
-        } else {
-            // 위시가 있을 경우
-            binding.wishlistRv.visibility = View.VISIBLE
-            binding.wishNotExistsCv.visibility = View.GONE
+        // 리사이클러/어댑터
+        adapter = WishlistEditRVAdapter(edited)
+        val lm = LinearLayoutManager(requireContext())
+        binding.wishlistRv.layoutManager = lm
+        binding.wishlistRv.adapter = adapter
 
-            adapter = WishlistEditRVAdapter(editedWishlist)
-            binding.wishlistRv.adapter = adapter
+        setupButtons()
+        observeViewModel()
 
-            setupButtons()
+        // 무한 스크롤: 끝 근처에서 다음 페이지 로드
+        binding.wishlistRv.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(rv: RecyclerView, dx: Int, dy: Int) {
+                if (dy <= 0) return
+                val last = lm.findLastVisibleItemPosition()
+                val total = adapter.itemCount
+                if (last >= total - 3) {
+                    viewModel.loadNextPage()
+                }
+            }
+        })
+
+        // 진입 시 무조건 ALL 1페이지부터
+        viewModel.refreshWishlist("all")
+    }
+
+    private fun observeViewModel() {
+        viewModel.wishlistItems.observe(viewLifecycleOwner) { serverList ->
+            // 가시성
+            if (serverList.isNullOrEmpty()) {
+                binding.wishlistRv.visibility = View.GONE
+                binding.wishNotExistsCv.visibility = View.VISIBLE
+            } else {
+                binding.wishlistRv.visibility = View.VISIBLE
+                binding.wishNotExistsCv.visibility = View.GONE
+            }
+
+            // 선택(삭제 체크) 보존
+            val prevSelected = selectedIds.toSet()
+
+            edited.clear()
+            edited.addAll(
+                serverList.map { item ->
+                    item.copy(isDeleted = item.id in prevSelected)
+                }
+            )
+
+            // (선택) 동기화: 내부 selectedIds를 현재 edited 상태로 갱신
+            selectedIds.clear()
+            selectedIds.addAll(edited.filter { it.isDeleted }.map { it.id })
+
+            adapter.notifyDataSetChanged()
         }
 
-        binding.backArrowIv.setOnClickListener {
-            parentFragmentManager.popBackStack()
+        // 삭제 성공 → 다시 ALL로 최신화 후 화면 닫기
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.deleteSuccess.collect {
+                    Toast.makeText(requireContext(), "삭제가 완료되었어요.", Toast.LENGTH_SHORT).show()
+                    viewModel.refreshWishlist("all") // 요구사항: 삭제는 항상 ALL
+                    parentFragmentManager.popBackStack()
+                }
+            }
         }
 
-        setupObservers()
+        viewModel.errorMessage.observe(viewLifecycleOwner) { err ->
+            Log.e("WISHLIST_EDIT", "오류: $err")
+        }
     }
 
     private fun setupButtons() {
         binding.btnWishDelete.setOnClickListener {
-            val deletedCount = adapter.markCheckedItemsAsDeleted()
-            if (deletedCount > 0) {
-                Log.d("WISH_LIST_EDIT_FRAGMENT", "${deletedCount}개 위시가 삭제되었어요.")
-            } else {
+            // 어댑터에서 체크 표시 반영
+            val cnt = adapter.markCheckedItemsAsDeleted()
+
+            // 현재 편집 리스트에서 선택 집합 갱신(보존의 핵심)
+            selectedIds.clear()
+            selectedIds.addAll(edited.filter { it.isDeleted }.map { it.id })
+
+            if (cnt <= 0) {
                 Toast.makeText(requireContext(), "삭제할 위시를 선택해주세요.", Toast.LENGTH_SHORT).show()
             }
         }
 
         binding.btnWishCancel.setOnClickListener {
             adapter.cancelAllCheckedItems()
+            // 선택 취소 시에도 선택 집합 초기화
+            selectedIds.clear()
         }
 
         binding.completeTv.setOnClickListener {
-            val deletedIds = editedWishlist.filter { it.isDeleted }.map { it.id }
-
-            if (deletedIds.isNotEmpty()) {
-                val request = DeleteWishesRequest(deletedIds)
-                viewModel.deleteWishes(request)
-            }
-
-            parentFragmentManager.setFragmentResult("wish_delete", Bundle())
-            parentFragmentManager.popBackStack()
-        }
-
-        binding.backArrowIv.setOnClickListener {
-            parentFragmentManager.popBackStack()
-        }
-    }
-
-    private fun setupObservers() {
-
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.deleteSuccess.collect {
-                    Toast.makeText(requireContext(), "삭제가 완료되었어요.", Toast.LENGTH_SHORT).show()
-
-                    // ViewModel 내 리스트 갱신
-                    val deletedIds = editedWishlist.filter { it.isDeleted }.map { it.id }
-                    val updatedList =
-                        viewModel.wishlistItems.value?.filterNot { it.id in deletedIds }
-                            ?: emptyList()
-                    viewModel.updateWishlistItems(updatedList)
-
-                    parentFragmentManager.setFragmentResult("wish_delete", Bundle())
-                    parentFragmentManager.popBackStack()
-                }
+            val ids = edited.filter { it.isDeleted }.map { it.id }
+            if (ids.isNotEmpty()) {
+                viewModel.deleteWishes(DeleteWishesRequest(ids))
+            } else {
+                parentFragmentManager.popBackStack()
             }
         }
 
-        viewModel.errorMessage.observe(viewLifecycleOwner) { error ->
-//            Toast.makeText(requireContext(), "삭제 실패: $error", Toast.LENGTH_SHORT).show()
-            Log.e("WISH_LIST_EDIT_FRAGMENT", "삭제 실패: $error")
-        }
+        binding.backArrowIv.setOnClickListener { parentFragmentManager.popBackStack() }
     }
 }

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishlistEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishlistEditFragment.kt
@@ -32,8 +32,8 @@ class WishlistEditFragment : Fragment() {
     private lateinit var adapter: WishlistEditRVAdapter
     private val edited: MutableList<WishlistItem> = mutableListOf()
 
-    // 페이지 append 시에 선택(삭제 체크) 유지용
-    private val selectedIds = mutableSetOf<Long>()
+    // 어댑터에서 실제 제거한 항목들을 서버에 일괄 반영하기 위한 보류 목록
+    private val pendingDeleteIds = mutableSetOf<Long>()
 
     private val viewModel: WishViewModel by activityViewModels()
 
@@ -83,19 +83,9 @@ class WishlistEditFragment : Fragment() {
                 binding.wishNotExistsCv.visibility = View.GONE
             }
 
-            // 선택(삭제 체크) 보존
-            val prevSelected = selectedIds.toSet()
-
+            // 서버 리스트를 그대로 반영 (선택/체크 보존은 어댑터에서 id 기반으로 처리)
             edited.clear()
-            edited.addAll(
-                serverList.map { item ->
-                    item.copy(isDeleted = item.id in prevSelected)
-                }
-            )
-
-            // (선택) 동기화: 내부 selectedIds를 현재 edited 상태로 갱신
-            selectedIds.clear()
-            selectedIds.addAll(edited.filter { it.isDeleted }.map { it.id })
+            edited.addAll(serverList)
 
             adapter.notifyDataSetChanged()
         }
@@ -105,6 +95,7 @@ class WishlistEditFragment : Fragment() {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.deleteSuccess.collect {
                     Toast.makeText(requireContext(), "삭제가 완료되었어요.", Toast.LENGTH_SHORT).show()
+                    pendingDeleteIds.clear()
                     viewModel.refreshWishlist("all") // 요구사항: 삭제는 항상 ALL
                     parentFragmentManager.popBackStack()
                 }
@@ -118,28 +109,23 @@ class WishlistEditFragment : Fragment() {
 
     private fun setupButtons() {
         binding.btnWishDelete.setOnClickListener {
-            // 어댑터에서 체크 표시 반영
-            val cnt = adapter.markCheckedItemsAsDeleted()
+            // 어댑터에서 실제 제거하고 제거된 id들을 돌려받아 보류 목록에 누적
+            val removedIds: List<Long> = adapter.markCheckedItemsAsDeletedAndReturnIds()
+            pendingDeleteIds.addAll(removedIds)
 
-            // 현재 편집 리스트에서 선택 집합 갱신(보존의 핵심)
-            selectedIds.clear()
-            selectedIds.addAll(edited.filter { it.isDeleted }.map { it.id })
-
-            if (cnt <= 0) {
+            if (removedIds.isEmpty()) {
                 Toast.makeText(requireContext(), "삭제할 위시를 선택해주세요.", Toast.LENGTH_SHORT).show()
             }
         }
 
         binding.btnWishCancel.setOnClickListener {
             adapter.cancelAllCheckedItems()
-            // 선택 취소 시에도 선택 집합 초기화
-            selectedIds.clear()
         }
 
         binding.completeTv.setOnClickListener {
-            val ids = edited.filter { it.isDeleted }.map { it.id }
-            if (ids.isNotEmpty()) {
-                viewModel.deleteWishes(DeleteWishesRequest(ids))
+            // 현재 화면에서는 이미 리스트에서 제거되었으므로 보류 목록으로 서버 삭제
+            if (pendingDeleteIds.isNotEmpty()) {
+                viewModel.deleteWishes(DeleteWishesRequest(pendingDeleteIds.toList()))
             } else {
                 parentFragmentManager.popBackStack()
             }

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishlistFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishlistFragment.kt
@@ -8,6 +8,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.example.teumteum.R
 import com.example.teumteum.data.remote.wish.model.WishlistItem
 import com.example.teumteum.databinding.FragmentWishlistBinding
@@ -19,16 +21,20 @@ import com.google.android.material.button.MaterialButton
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class WishlistFragment() : Fragment() {
+class WishlistFragment : Fragment() {
 
     private var _binding: FragmentWishlistBinding? = null
     private val binding get() = _binding!!
 
     private lateinit var adapter: WishlistRVAdapter
 
+    // 로컬 필터링에 의존하지 않으므로 내부 보관만 유지
     private var wishlistItems: List<WishlistItem> = emptyList()
 
     private val viewModel: WishViewModel by activityViewModels()
+
+    // 스크롤에서 중복 호출 방지용
+    private var loadingScrollGuard = false
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -49,12 +55,9 @@ class WishlistFragment() : Fragment() {
 
         binding.fabAddIv.setOnClickListener {
             val bottomSheet = WishRegisterFragment().apply {
-                arguments = Bundle().apply {
-                    putBoolean("isFromWish", true)  // 위시에서 열렸음을 전달
-                }
+                arguments = Bundle().apply { putBoolean("isFromWish", true) }
             }
             bottomSheet.show(parentFragmentManager, bottomSheet.tag)
-
         }
 
         return binding.root
@@ -65,41 +68,37 @@ class WishlistFragment() : Fragment() {
 
         adapter = WishlistRVAdapter(wishlistItems, parentFragmentManager)
         binding.wishlistRv.adapter = adapter
+        val lm = LinearLayoutManager(requireContext())
+        binding.wishlistRv.layoutManager = lm
 
         // 바텀 내비게이션 숨기기
-        val bottomNav = activity?.findViewById<BottomNavigationView>(R.id.main_bnv)
-        bottomNav?.visibility = View.GONE
+        activity?.findViewById<BottomNavigationView>(R.id.main_bnv)?.visibility = View.GONE
 
-        binding.backArrowIv.setOnClickListener {
-            parentFragmentManager.popBackStack()
-        }
+        binding.backArrowIv.setOnClickListener { parentFragmentManager.popBackStack() }
 
         binding.fabAddIv.post {
-            applyBlurShadow(
-                sourceView = binding.fabAddIv,
-                targetImageView = binding.fabShadowIv
-            )
+            applyBlurShadow(sourceView = binding.fabAddIv, targetImageView = binding.fabShadowIv)
         }
 
         setupTimeFilterButtons()
         setupObservers()
 
-        // 위시 등록 성공 이벤트 수신
-        parentFragmentManager.setFragmentResultListener("wish_register", viewLifecycleOwner) { _, _ ->
-            refreshWishlist()
-        }
+        // 페이징: 리스트 끝 근처에서 다음 페이지 로드
+        binding.wishlistRv.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(rv: RecyclerView, dx: Int, dy: Int) {
+                if (dy <= 0) return
+                val last = lm.findLastVisibleItemPosition()
+                val total = adapter.itemCount
+                if (!loadingScrollGuard && last >= total - 3) {
+                    loadingScrollGuard = true
+                    viewModel.loadNextPage()
+                }
+            }
+        })
 
-        // 위시 수정 성공 이벤트 수신
-        parentFragmentManager.setFragmentResultListener("wish_edit", viewLifecycleOwner) { _, _ ->
-            refreshWishlist()
-        }
+        // 최초 로드: 서버에서 all 기준 1페이지
+        viewModel.refreshWishlist(duration = "all")
 
-        // 위시 삭제 성공 이벤트 수신
-        parentFragmentManager.setFragmentResultListener("wish_delete", viewLifecycleOwner) { _, _ ->
-            refreshWishlist()
-        }
-
-        viewModel.getWishlist(duration = "all", page = 1)
     }
 
     private fun setupTimeFilterButtons() {
@@ -109,43 +108,19 @@ class WishlistFragment() : Fragment() {
         val button30m = binding.btnWishlistTime04
         val button1h = binding.btnWishlistTime05
 
-        allButton.setOnClickListener {
-            filterAndUpdate(duration = "all", button = allButton)
-        }
-
-        button10m.setOnClickListener {
-            filterAndUpdate(duration = "10m", button = button10m)
-        }
-
-        button20m.setOnClickListener {
-            filterAndUpdate(duration = "20m", button = button20m)
-        }
-
-        button30m.setOnClickListener {
-            filterAndUpdate(duration = "30m", button = button30m)
-        }
-
-        button1h.setOnClickListener {
-            filterAndUpdate(duration = "1h", button = button1h)
-        }
+        allButton.setOnClickListener { onDurationSelected("all", allButton) }
+        button10m.setOnClickListener { onDurationSelected("10m", button10m) }
+        button20m.setOnClickListener { onDurationSelected("20m", button20m) }
+        button30m.setOnClickListener { onDurationSelected("30m", button30m) }
+        button1h.setOnClickListener { onDurationSelected("1h", button1h) }
     }
 
-    private fun filterAndUpdate(duration: String, button: MaterialButton) {
-        val filteredList = when (duration) {
-            "all" -> wishlistItems
-            else -> wishlistItems.filter { it.estimatedDuration == duration }
-        }
-
-        if (filteredList.isEmpty()) {
-            binding.wishlistRv.visibility = View.GONE
-            binding.wishNotExistsCv.visibility = View.VISIBLE
-        } else {
-            binding.wishlistRv.visibility = View.VISIBLE
-            binding.wishNotExistsCv.visibility = View.GONE
-            adapter.updateList(filteredList)
-        }
-
+    private fun onDurationSelected(duration: String, button: MaterialButton) {
+        // 로컬 필터링 제거 → 서버 재조회
+        viewModel.refreshWishlist(duration)
         updateTimeButtonUI(button)
+        // 새 필터 적용 직후 스크롤 가드 초기화
+        loadingScrollGuard = false
     }
 
     private fun updateTimeButtonUI(selectedButton: MaterialButton) {
@@ -159,10 +134,12 @@ class WishlistFragment() : Fragment() {
 
         for (button in buttons) {
             if (button == selectedButton) {
-                button.backgroundTintList = ColorStateList.valueOf(resources.getColor(R.color.text_primary, null))
+                button.backgroundTintList =
+                    ColorStateList.valueOf(resources.getColor(R.color.text_primary, null))
                 button.setTextColor(resources.getColor(R.color.white, null))
             } else {
-                button.backgroundTintList = ColorStateList.valueOf(resources.getColor(R.color.teumteum_line, null))
+                button.backgroundTintList =
+                    ColorStateList.valueOf(resources.getColor(R.color.teumteum_line, null))
                 button.setTextColor(resources.getColor(R.color.text_primary, null))
             }
         }
@@ -171,6 +148,7 @@ class WishlistFragment() : Fragment() {
     private fun setupObservers() {
         viewModel.wishlistItems.observe(viewLifecycleOwner) { itemList ->
             wishlistItems = itemList
+            loadingScrollGuard = false // 새 데이터가 들어오면 스크롤 가드를 풀어 다음 페이지를 받을 수 있게 함
 
             if (itemList.isEmpty()) {
                 binding.wishlistRv.visibility = View.GONE
@@ -178,17 +156,12 @@ class WishlistFragment() : Fragment() {
             } else {
                 binding.wishlistRv.visibility = View.VISIBLE
                 binding.wishNotExistsCv.visibility = View.GONE
-                adapter.updateList(itemList)
+                adapter.updateList(itemList) // ViewModel이 append한 전체 리스트를 그대로 교체 반영
             }
         }
 
         viewModel.errorMessage.observe(viewLifecycleOwner) { error ->
-//            Toast.makeText(requireContext(), "위시리스트 조회 실패: $error", Toast.LENGTH_SHORT).show()
-            Log.e("WISH_LIST_FRAGMENT","위시리스트 조회 실패: $error")
+            Log.e("WISH_LIST_FRAGMENT", "위시리스트 조회 실패: $error")
         }
-    }
-
-    private fun refreshWishlist() {
-        viewModel.getWishlist(duration = "all", page = 1)
     }
 }

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishlistFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishlistFragment.kt
@@ -44,9 +44,6 @@ class WishlistFragment : Fragment() {
         _binding = FragmentWishlistBinding.inflate(inflater, container, false)
 
         binding.editTv.setOnClickListener {
-            val currentList = viewModel.wishlistItems.value ?: emptyList()
-            viewModel.updateWishlistItems(currentList.toMutableList())
-
             parentFragmentManager.beginTransaction()
                 .replace(R.id.main_frm, WishlistEditFragment())
                 .addToBackStack(null)

--- a/app/src/main/java/com/example/teumteum/ui/wish/adapter/WishlistEditRVAdapter.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/adapter/WishlistEditRVAdapter.kt
@@ -13,7 +13,18 @@ import com.example.teumteum.databinding.ItemWishlistEditBinding
 
 class WishlistEditRVAdapter(private val wishlist: MutableList<WishlistItem>) : RecyclerView.Adapter<WishlistEditRVAdapter.ViewHolder>() {
 
+    // 페이징/갱신 사이클 동안 선택 상태 유지용
+    private val selectedIds = mutableSetOf<Long>()
+
+    init {
+        // 초기 데이터에 체크된 항목이 있으면 동기화
+        selectedIds.addAll(wishlist.filter { it.isChecked }.map { it.id })
+        setHasStableIds(true)
+    }
+
     inner class ViewHolder(val binding: ItemWishlistEditBinding) : RecyclerView.ViewHolder(binding.root)
+
+    override fun getItemId(position: Int): Long = wishlist[position].id
 
     override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): ViewHolder {
         val binding : ItemWishlistEditBinding = ItemWishlistEditBinding.inflate(LayoutInflater.from(viewGroup.context), viewGroup, false)
@@ -33,10 +44,21 @@ class WishlistEditRVAdapter(private val wishlist: MutableList<WishlistItem>) : R
         binding.tvWishTitle.text = item.title
         binding.wishTimeTv.text = item.estimatedDuration
 
-        binding.wishCheckbox.isChecked = item.isChecked
-        setCheckBoxTint(binding.wishCheckbox, item.isChecked)
+        // 리스너 중복 호출 방지
+        binding.wishCheckbox.setOnCheckedChangeListener(null)
+
+        // 선택 집합 기준으로 체크 상태 복원
+        val checked = selectedIds.contains(item.id)
+        binding.wishCheckbox.isChecked = checked
+        item.isChecked = checked
+        setCheckBoxTint(binding.wishCheckbox, checked)
 
         binding.wishCheckbox.setOnCheckedChangeListener { button, isChecked ->
+            if (isChecked) {
+                selectedIds.add(item.id)
+            } else {
+                selectedIds.remove(item.id)
+            }
             item.isChecked = isChecked
             setCheckBoxTint(button, isChecked)
         }
@@ -45,6 +67,7 @@ class WishlistEditRVAdapter(private val wishlist: MutableList<WishlistItem>) : R
     override fun getItemCount(): Int = wishlist.size
 
     fun cancelAllCheckedItems() {
+        selectedIds.clear()
         wishlist.forEach { it.isChecked = false }
         notifyDataSetChanged()
     }
@@ -56,13 +79,13 @@ class WishlistEditRVAdapter(private val wishlist: MutableList<WishlistItem>) : R
     }
 
     fun markCheckedItemsAsDeleted(): Int {
-        val deletedItems = wishlist.filter { it.isChecked && !it.isDeleted }
+        val deletedItems = wishlist.filter { selectedIds.contains(it.id) && !it.isDeleted }
         deletedItems.forEach {
             it.isDeleted = true
             it.isChecked = false
+            selectedIds.remove(it.id)
         }
         notifyDataSetChanged()
         return deletedItems.size
     }
-
 }

--- a/app/src/main/java/com/example/teumteum/ui/wish/adapter/WishlistEditRVAdapter.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/adapter/WishlistEditRVAdapter.kt
@@ -2,7 +2,6 @@ package com.example.teumteum.ui.wish.adapter
 
 import android.content.res.ColorStateList
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import android.widget.CompoundButton
 import androidx.core.content.ContextCompat
@@ -13,11 +12,11 @@ import com.example.teumteum.databinding.ItemWishlistEditBinding
 
 class WishlistEditRVAdapter(private val wishlist: MutableList<WishlistItem>) : RecyclerView.Adapter<WishlistEditRVAdapter.ViewHolder>() {
 
-    // 페이징/갱신 사이클 동안 선택 상태 유지용
+    // 페이징/갱신 사이클 동안 선택 상태 유지용 id 집합
     private val selectedIds = mutableSetOf<Long>()
 
     init {
-        // 초기 데이터에 체크된 항목이 있으면 동기화
+        // 초기 데이터에 체크된 항목 반영
         selectedIds.addAll(wishlist.filter { it.isChecked }.map { it.id })
         setHasStableIds(true)
     }
@@ -34,12 +33,6 @@ class WishlistEditRVAdapter(private val wishlist: MutableList<WishlistItem>) : R
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val item = wishlist[position]
         val binding = holder.binding
-
-        if (item.isDeleted) {
-            holder.itemView.visibility = View.GONE
-            holder.itemView.layoutParams = RecyclerView.LayoutParams(0, 0)
-            return
-        }
 
         binding.tvWishTitle.text = item.title
         binding.wishTimeTv.text = item.estimatedDuration
@@ -78,14 +71,26 @@ class WishlistEditRVAdapter(private val wishlist: MutableList<WishlistItem>) : R
         checkBox.buttonTintList = ColorStateList.valueOf(ContextCompat.getColor(context, colorRes))
     }
 
-    fun markCheckedItemsAsDeleted(): Int {
-        val deletedItems = wishlist.filter { selectedIds.contains(it.id) && !it.isDeleted }
-        deletedItems.forEach {
-            it.isDeleted = true
-            it.isChecked = false
-            selectedIds.remove(it.id)
+
+    // 체크된 항목을 제거하고, 제거된 항목들의 id를 반환 (Fragment에서 서버로 삭제 요청 보낼 때 사용)
+    fun markCheckedItemsAsDeletedAndReturnIds(): List<Long> {
+        val toRemoveIdx = mutableListOf<Int>()
+        val removedIds = mutableListOf<Long>()
+        wishlist.forEachIndexed { index, it ->
+            if (selectedIds.contains(it.id) && !it.isDeleted) {
+                it.isDeleted = true
+                toRemoveIdx.add(index)
+                removedIds.add(it.id)
+            }
         }
-        notifyDataSetChanged()
-        return deletedItems.size
+        if (toRemoveIdx.isEmpty()) return emptyList()
+
+        for (i in toRemoveIdx.asReversed()) {
+            val removed = wishlist.removeAt(i)
+            selectedIds.remove(removed.id)
+            notifyItemRemoved(i)
+        }
+        return removedIds
     }
+
 }

--- a/app/src/main/java/com/example/teumteum/ui/wish/viewModel/WishViewModel.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/viewModel/WishViewModel.kt
@@ -161,8 +161,8 @@ class WishViewModel @Inject constructor(
             val result = wishRepository.deleteWish(request)
             result.onSuccess {
                 _deleteSuccess.tryEmit(Unit)
-                // 등록 성공 직후 현재 duration 기준으로 즉시 새로고침
-                refreshCurrent()
+                // 등록 성공 직후 즉시 새로고침
+                refreshWishlist("all")
             }
             result.onFailure { e ->
                 _errorMessage.value = e.localizedMessage ?: "위시 삭제에 실패했습니다."

--- a/app/src/main/java/com/example/teumteum/ui/wish/viewModel/WishViewModel.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/viewModel/WishViewModel.kt
@@ -58,6 +58,12 @@ class WishViewModel @Inject constructor(
     private val _assignError = MutableSharedFlow<ApiException>(replay = 0, extraBufferCapacity = 1)
     val assignError: SharedFlow<ApiException> = _assignError.asSharedFlow()
 
+    // 페이징 상태
+    private var currentPage = 1
+    private var currentDuration: String = "all"
+    private var hasNext: Boolean = true
+    private var loadingInProgress = false
+
     // 위시 등록
     fun registerWish(request: RegisterWishRequest) {
         viewModelScope.launch {
@@ -71,14 +77,47 @@ class WishViewModel @Inject constructor(
         }
     }
 
-    // 위시리스트 조회
-    fun getWishlist(duration: String, page: Int) {
+    // 위시리스트 조회 (refresh)
+    fun refreshWishlist(duration: String) {
+        currentDuration = duration
+        currentPage = 1
+        hasNext = true
+        loadWishlist(reset = true)
+    }
+
+    // 현재 duration으로 1페이지부터 다시 불러오기
+    fun refreshCurrent() {
+        refreshWishlist(currentDuration)
+    }
+
+    // 다음 페이지 조회
+    fun loadNextPage() {
+        if (!hasNext || loadingInProgress) return
+        currentPage += 1
+        loadWishlist(reset = false, onFail = {
+            currentPage = maxOf(1, currentPage - 1)
+        })
+    }
+
+
+    private fun loadWishlist(reset: Boolean, onFail: (() -> Unit)? = null) {
         viewModelScope.launch {
-            val result = wishRepository.getWishlist(duration, page)
-            result.onSuccess { response ->
-                _wishlistItems.value = response.wishlist
-            }.onFailure { e ->
-                _errorMessage.value = e.localizedMessage ?: "위시리스트 조회에 실패했습니다."
+            try {
+                loadingInProgress = true
+                val result = wishRepository.getWishlist(currentDuration, currentPage)
+                result.onSuccess { response ->
+                    hasNext = response.hasNext == true
+                    val incoming = response.wishlist.orEmpty()
+                    _wishlistItems.value = if (reset) incoming else _wishlistItems.value.orEmpty() + incoming
+                }.onFailure { e ->
+                    onFail?.invoke()
+                    _errorMessage.value = e.localizedMessage ?: "위시리스트 조회에 실패했습니다."
+                }
+            } catch (t: Throwable) {
+                onFail?.invoke()
+                _errorMessage.value = t.localizedMessage ?: "위시리스트 조회 중 오류가 발생했습니다."
+            } finally {
+                loadingInProgress = false
             }
         }
     }

--- a/app/src/main/java/com/example/teumteum/ui/wish/viewModel/WishViewModel.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/viewModel/WishViewModel.kt
@@ -70,6 +70,8 @@ class WishViewModel @Inject constructor(
             val result = wishRepository.registerWish(request)
             result.onSuccess {
                 _registerSuccess.tryEmit(Unit)
+                // 등록 성공 직후 현재 duration 기준으로 즉시 새로고침
+                refreshCurrent()
             }
             result.onFailure { e ->
                 _errorMessage.value = e.localizedMessage ?: "위시 등록에 실패했습니다."
@@ -140,6 +142,8 @@ class WishViewModel @Inject constructor(
             val result = wishRepository.editWish(wishId, request)
             result.onSuccess {
                 _editSuccess.tryEmit(Unit)
+                // 등록 성공 직후 현재 duration 기준으로 즉시 새로고침
+                refreshCurrent()
             }
             result.onFailure { e ->
                 _errorMessage.value = e.localizedMessage ?: "위시 수정에 실패했습니다."
@@ -157,6 +161,8 @@ class WishViewModel @Inject constructor(
             val result = wishRepository.deleteWish(request)
             result.onSuccess {
                 _deleteSuccess.tryEmit(Unit)
+                // 등록 성공 직후 현재 duration 기준으로 즉시 새로고침
+                refreshCurrent()
             }
             result.onFailure { e ->
                 _errorMessage.value = e.localizedMessage ?: "위시 삭제에 실패했습니다."

--- a/app/src/main/res/layout/fragment_wishlist.xml
+++ b/app/src/main/res/layout/fragment_wishlist.xml
@@ -140,7 +140,7 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/wishlist_rv"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="0dp"
             android:layout_marginTop="18dp"
             android:clipToPadding="false"
             android:nestedScrollingEnabled="true"
@@ -148,8 +148,10 @@
             android:paddingBottom="120dp"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="1.0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/wishlist_time_container"
+            app:layout_constraintBottom_toBottomOf="parent"
             tools:listitem="@layout/item_wishlist" />
 
         <com.google.android.material.card.MaterialCardView

--- a/app/src/main/res/layout/fragment_wishlist_edit.xml
+++ b/app/src/main/res/layout/fragment_wishlist_edit.xml
@@ -1,161 +1,155 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".ui.wish.WishlistEditFragment">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+    <ImageView
+        android:id="@+id/back_arrow_iv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="70dp"
+        android:src="@drawable/ic_arrow_back"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
 
-        <ImageView
-            android:id="@+id/back_arrow_iv"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="70dp"
-            android:layout_marginStart="16dp"
-            android:src="@drawable/ic_arrow_back"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+    <TextView
+        android:id="@+id/edit_tv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="66dp"
+        android:includeFontPadding="false"
+        android:fontFamily="@font/noto_sans_kr_medium"
+        android:text="편집"
+        android:textColor="@color/text_primary"
+        android:textSize="20sp"
+        app:layout_constraintStart_toEndOf="@id/back_arrow_iv"
+        app:layout_constraintTop_toTopOf="parent"/>
 
-        <TextView
-            android:id="@+id/edit_tv"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="66dp"
-            android:layout_marginStart="12dp"
-            android:includeFontPadding="false"
-            android:fontFamily="@font/noto_sans_kr_medium"
-            android:text="편집"
-            android:textColor="@color/text_primary"
-            android:textSize="20sp"
-            app:layout_constraintStart_toEndOf="@id/back_arrow_iv"
-            app:layout_constraintTop_toTopOf="parent" />
+    <TextView
+        android:id="@+id/complete_tv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="20dp"
+        android:layout_marginTop="70dp"
+        android:fontFamily="@font/pretendard_medium"
+        android:text="완료"
+        android:textColor="@color/text_primary"
+        android:textSize="16sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
 
-        <TextView
-            android:id="@+id/complete_tv"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="70dp"
-            android:layout_marginEnd="20dp"
-            android:fontFamily="@font/pretendard_medium"
-            android:text="완료"
-            android:textColor="@color/text_primary"
-            android:textSize="16sp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+    <TextView
+        android:id="@+id/select_wish_to_delete_tv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="38dp"
+        android:fontFamily="@font/pretendard_medium"
+        android:text="삭제할 위시를 선택해주세요"
+        android:textColor="@color/text_primary"
+        android:textSize="18sp"
+        app:layout_constraintStart_toStartOf="@id/back_arrow_iv"
+        app:layout_constraintTop_toBottomOf="@id/edit_tv"/>
 
-        <TextView
-            android:id="@+id/select_wish_to_delete_tv"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="38dp"
-            android:fontFamily="@font/pretendard_medium"
-            android:text="삭제할 위시를 선택해주세요"
-            android:textColor="@color/text_primary"
-            android:textSize="18sp"
-            app:layout_constraintBottom_toTopOf="@id/wishlist_rv"
-            app:layout_constraintStart_toStartOf="@id/back_arrow_iv"
-            app:layout_constraintTop_toBottomOf="@id/edit_tv" />
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/wishlist_rv"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="22dp"
+        android:clipToPadding="false"
+        android:nestedScrollingEnabled="true"
+        android:overScrollMode="never"
+        android:paddingBottom="20dp"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintTop_toBottomOf="@id/select_wish_to_delete_tv"
+        app:layout_constraintBottom_toTopOf="@+id/wishlist_bottom_bar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:listitem="@layout/item_wishlist_edit"/>
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/wishlist_rv"
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/wish_not_exists_cv"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="10dp"
+        android:backgroundTint="@color/white"
+        android:visibility="gone"
+        app:cardCornerRadius="10dp"
+        app:cardElevation="0dp"
+        app:layout_constraintTop_toBottomOf="@id/select_wish_to_delete_tv"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="24.5dp"
-            android:paddingBottom="120dp"
-            android:clipToPadding="false"
-            android:nestedScrollingEnabled="true"
-            android:overScrollMode="never"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/select_wish_to_delete_tv"
-            tools:listitem="@layout/item_wishlist_edit" />
+            android:layout_height="wrap_content">
 
-        <com.google.android.material.card.MaterialCardView
-            android:id="@+id/wish_not_exists_cv"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="10dp"
-            android:layout_marginTop="237dp"
-            android:backgroundTint="@color/white"
-            android:visibility="gone"
-            app:cardCornerRadius="10dp"
-            app:cardElevation="0dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/select_wish_to_delete_tv"
-            app:strokeWidth="0dp">
+            <ImageView
+                android:id="@+id/wish_not_exists_iv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:src="@drawable/ic_teum_char_sleep_sv"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toTopOf="@id/wish_not_exists_tv"/>
 
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+            <TextView
+                android:id="@+id/wish_not_exists_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/noto_sans_kr_medium"
+                android:includeFontPadding="false"
+                android:text="등록해 놓은 위시가 없어요"
+                android:textColor="@color/teumteum_gray"
+                android:textSize="15sp"
+                app:layout_constraintTop_toBottomOf="@id/wish_not_exists_iv"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"/>
 
-                <ImageView
-                    android:id="@+id/wish_not_exists_iv"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"
-                    android:src="@drawable/ic_teum_char_sleep_sv"
-                    app:layout_constraintBottom_toTopOf="@id/wish_not_exists_tv"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <TextView
-                    android:id="@+id/wish_not_exists_tv"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:fontFamily="@font/noto_sans_kr_medium"
-                    android:includeFontPadding="false"
-                    android:text="등록해 놓은 위시가 없어요"
-                    android:textColor="@color/teumteum_gray"
-                    android:textSize="15sp"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/wish_not_exists_iv" />
-
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
-        </com.google.android.material.card.MaterialCardView>
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
 
     <LinearLayout
         android:id="@+id/wishlist_bottom_bar"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="94dp"
-        android:layout_alignParentBottom="true"
-        android:layout_gravity="bottom"
-        android:background="@color/white"
         android:orientation="horizontal"
         android:padding="14dp"
-        android:weightSum="2">
+        android:weightSum="2"
+        android:background="@color/white"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent">
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_wish_cancel"
             android:layout_width="0dp"
             android:layout_height="65dp"
-            android:layout_marginEnd="8dp"
             android:layout_weight="1"
+            android:layout_marginEnd="8dp"
             android:text="선택 취소"
             android:textColor="@color/text_primary"
             app:backgroundTint="@color/teumteum_bg"
-            app:cornerRadius="12dp" />
+            app:cornerRadius="12dp"/>
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_wish_delete"
             android:layout_width="0dp"
             android:layout_height="65dp"
-            android:layout_marginStart="8dp"
             android:layout_weight="1"
+            android:layout_marginStart="8dp"
             android:text="삭제"
             android:textColor="@color/white"
             app:backgroundTint="@color/text_primary"
-            app:cornerRadius="12dp" />
+            app:cornerRadius="12dp"/>
     </LinearLayout>
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #235 

## ✨ 작업 내용
- **위시리스트 스크롤 가능 처리**  
  - ConstraintLayout 높이 제약을 조정하여 RecyclerView가 전체 화면에서 스크롤되도록 개선  
<br>

- **페이징 처리 적용 및 안정화**  
  - ViewModel: `loadNextPage()` 로 다음 페이지 요청  
  - Fragment: 스크롤 리스너 등록하여 끝에 도달 시 `loadNextPage()` 호출  
  - Adapter: `setHasStableIds(true)` + `getItemId()` 기반으로 포지션 안정성 확보  
  - `refreshWishlist("all")`로 ALL 기준 초기 로딩  
<br>

- **위시리스트 CRUD 즉시 반영**  
  - 등록 / 수정 / 삭제 시 ViewModel → UI까지 바로 반영되도록 처리  
<br>

- **선택 상태 보존 기능 추가**  
  - 스크롤/페이징 시에도 체크 상태 유지  
  - `selectedIds` 집합 관리 + 안정 ID(`getItemId`)로 체크박스 상태 복원  
<br>

- **삭제 플로우 개선**  
  - “삭제” 클릭 시 → 어댑터에서 체크된 아이템을 `removeAt + notifyItemRemoved`로 실제 제거 (UI 즉시 반영)  
  - 제거된 id는 Fragment의 `pendingDeleteIds`에 모아둠  
  - “완료” 클릭 시 → `deleteWishes()` 서버 요청  
  - 삭제 성공 시 → `refreshWishlist("all")` 재호출 및 화면 종료  

## ✅ 코드 리뷰어 체크리스트
- [x] 위시리스트가 정상적으로 스크롤 가능한지  
- [x] CRUD 즉시 반영이 정상 동작하는지  
- [x] 페이징 처리(스크롤 로드 + 어댑터 안정화)가 정상 동작하는지  
- [x] 선택 상태(체크박스)가 스크롤/재바인딩 후에도 정상 보존되는지  
- [x] 삭제 플로우가 `UI 즉시 반영 → 완료 시 서버 반영`으로 자연스러운지  

## 📸 스크린샷 (선택)
[![영상 미리보기](https://img.youtube.com/vi/agb3wFhPJU0/0.jpg)](https://youtu.be/agb3wFhPJU0)

## 💬 기타 참고 사항
- 삭제 후 동기화는 `all` 기준으로 동작  
- Adapter는 `getItemId()` + `setHasStableIds(true)` 기반으로 안정화  
- Fragment는 선택 집합을 직접 관리하지 않고 Adapter에 위임 → 역할 단순화  
