### PR TITLE
[Fix/#243] 현재 시각 이전의 시간도 표시하는 문제 해결

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendRoommateMatchingDetailFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendRoommateMatchingDetailFragment.kt
@@ -136,13 +136,13 @@ class FriendRoommateMatchingDetailFragment : Fragment() {
             showCustomTimePicker(initial = current) { picked ->
                 // 1) 카드의 허용 범위 [startBound, endBound] 검사
                 if (!isWithinRange(picked, startBound, endBound)) {
-                    Toast.makeText(requireContext(), "가능한 시간대에서 벗어났어요!", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(requireContext(), "가능한 시간대에서 벗어났어요.", Toast.LENGTH_SHORT).show()
                     return@showCustomTimePicker
                 }
 
                 // 2) 오늘 선택 시 현재 시각 이후인지 검사
                 if (!isAfterCurrentTime(picked)) {
-                    Toast.makeText(requireContext(), "현재 시각 이후의 시간을 선택해주세요!", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(requireContext(), "현재 시각 이후의 시간을 선택해주세요.", Toast.LENGTH_SHORT).show()
                     return@showCustomTimePicker
                 }
 
@@ -208,17 +208,10 @@ class FriendRoommateMatchingDetailFragment : Fragment() {
     private fun observeViewModel() {
         viewModel.possibleTimeList.observe(viewLifecycleOwner) { list ->
             val nonNullList = list.filterNotNull()
-            android.util.Log.d("TimeFiltering", "=== observeViewModel 시작 ===")
-            android.util.Log.d("TimeFiltering", "원본 카드 개수: ${nonNullList.size}")
 
             // 오늘인 경우, 현재 시각 기준으로 카드들 필터링/조정
             val dateFormatted = convertDateFormat(selectedDate)
             val today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
-
-            android.util.Log.d("TimeFiltering", "선택된 날짜: $selectedDate")
-            android.util.Log.d("TimeFiltering", "변환된 날짜: $dateFormatted")
-            android.util.Log.d("TimeFiltering", "오늘 날짜: $today")
-            android.util.Log.d("TimeFiltering", "오늘인가? ${dateFormatted == today}")
 
             val filteredList = if (dateFormatted == today) {
                 val now = LocalDateTime.now()
@@ -226,23 +219,13 @@ class FriendRoommateMatchingDetailFragment : Fragment() {
                 // 현재 시각을 10분 단위로 올림
                 val adjustedCurrentMinutes = ((currentMinutes + 9) / 10) * 10
 
-                android.util.Log.d("TimeFiltering", "현재 시각: ${now.hour}:${String.format("%02d", now.minute)}")
-                android.util.Log.d("TimeFiltering", "현재 시각(분): $currentMinutes")
-                android.util.Log.d("TimeFiltering", "조정된 시각(분): $adjustedCurrentMinutes")
-                android.util.Log.d("TimeFiltering", "조정된 시각: ${minutesToTime(adjustedCurrentMinutes)}")
-
                 nonNullList.mapNotNull { card ->
                     val startMinutes = timeToMinutes(card.startTime)
                     val endMinutes = timeToMinutes(card.endTime)
 
-                    android.util.Log.d("TimeFiltering", "--- 카드 처리 ---")
-                    android.util.Log.d("TimeFiltering", "원본: ${card.startTime} ~ ${card.endTime}")
-                    android.util.Log.d("TimeFiltering", "분 단위: $startMinutes ~ $endMinutes")
-
                     when {
                         // endTime이 현재 시각 이후가 아니면 (현재 시각 이하면) 제외
                         endMinutes <= currentMinutes -> {
-                            android.util.Log.d("TimeFiltering", "결과: 제외 (endTime이 현재 시각 이하)")
                             null
                         }
                         // startTime과 endTime 사이에 현재 시각이 있으면 조정된 현재 시각을 startTime으로 설정
@@ -250,27 +233,20 @@ class FriendRoommateMatchingDetailFragment : Fragment() {
                             val adjustedStartTime = minutesToTime(adjustedCurrentMinutes)
                             // 조정된 시작 시간이 종료 시간보다 크거나 같으면 제외
                             if (adjustedCurrentMinutes >= endMinutes) {
-                                android.util.Log.d("TimeFiltering", "결과: 제외 (조정된 시작시간이 종료시간보다 크거나 같음)")
                                 null
                             } else {
-                                android.util.Log.d("TimeFiltering", "결과: 조정 ($adjustedStartTime ~ ${card.endTime})")
                                 card.copy(startTime = adjustedStartTime)
                             }
                         }
                         // startTime이 현재 시각 이후면 그대로 사용
                         else -> {
-                            android.util.Log.d("TimeFiltering", "결과: 그대로 사용")
                             card
                         }
                     }
                 }
             } else {
-                android.util.Log.d("TimeFiltering", "오늘이 아니므로 필터링 없이 그대로 사용")
                 nonNullList
             }
-
-            android.util.Log.d("TimeFiltering", "필터링 후 카드 개수: ${filteredList.size}")
-            android.util.Log.d("TimeFiltering", "=== observeViewModel 끝 ===")
 
             timeCardAdapter.setData(filteredList)
             updateNextButtonState()

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendRoommateMatchingDetailFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendRoommateMatchingDetailFragment.kt
@@ -21,7 +21,11 @@ import com.example.teumteum.ui.main.MainActivity
 import com.example.teumteum.ui.signup.SignUpActivity
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import dagger.hilt.android.AndroidEntryPoint
+import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 import kotlin.getValue
 
 @AndroidEntryPoint
@@ -33,6 +37,9 @@ class FriendRoommateMatchingDetailFragment : Fragment() {
     private var selectedEndTime: String? = null
     private var lastSelectedCardView: View? = null
     private lateinit var timeCardAdapter: TimeCardAdapter
+
+    // 선택된 날짜 저장 (이전 Fragment에서 전달)
+    private var selectedDate: String = ""
 
     private val viewModel: FriendViewModel by activityViewModels()
 
@@ -49,6 +56,9 @@ class FriendRoommateMatchingDetailFragment : Fragment() {
         (activity as? SignUpActivity)?.setProgressBar(75)
         (activity as? MainActivity)?.hideBottomBar()
 
+        // 이전 Fragment에서 선택된 날짜 받기 (예: "25.08.21(목)" 또는 "2025-08-21")
+        selectedDate = arguments?.getString("selected_date") ?: ""
+
         val fullText = "틈 요청 제목을 작성해주세요*"
         val spannable = android.text.SpannableString(fullText)
         val starIndex = fullText.indexOf("*")
@@ -62,7 +72,6 @@ class FriendRoommateMatchingDetailFragment : Fragment() {
             )
             binding.teumRequestTitle.text = spannable
         }
-
 
         binding.clearTitleBtn.setOnClickListener {
             binding.editTextTitle.text.clear()
@@ -88,7 +97,6 @@ class FriendRoommateMatchingDetailFragment : Fragment() {
             dialog.show(parentFragmentManager, "PreviewDialog")
         }
 
-
         // 뒤로가기 버튼 처리
         binding.btnBack.setOnClickListener {
             parentFragmentManager.popBackStack()
@@ -107,11 +115,9 @@ class FriendRoommateMatchingDetailFragment : Fragment() {
         // 초기 버튼 상태 설정
         binding.sendBtn.isEnabled = false
         binding.sendBtn.setBackgroundColor(android.graphics.Color.parseColor("#F6F6F6"))
-
     }
 
     private fun updateNextButtonState() {
-
         val isTimeSelected = timeCardAdapter.getSelectedItem() != null
         val isTitleFilled = binding.editTextTitle.text.toString().isNotBlank()
         val isEnabled = isTimeSelected && isTitleFilled
@@ -128,25 +134,29 @@ class FriendRoommateMatchingDetailFragment : Fragment() {
     private fun setupTimeCardRecyclerView() {
         timeCardAdapter = TimeCardAdapter { position, isStart, startBound, endBound, current ->
             showCustomTimePicker(initial = current) { picked ->
-                // 카드의 허용 범위 [startBound, endBound] 검사
+                // 1) 카드의 허용 범위 [startBound, endBound] 검사
                 if (!isWithinRange(picked, startBound, endBound)) {
                     Toast.makeText(requireContext(), "가능한 시간대에서 벗어났어요!", Toast.LENGTH_SHORT).show()
+                    return@showCustomTimePicker
+                }
+
+                // 2) 오늘 선택 시 현재 시각 이후인지 검사
+                if (!isAfterCurrentTime(picked)) {
+                    Toast.makeText(requireContext(), "현재 시각 이후의 시간을 선택해주세요!", Toast.LENGTH_SHORT).show()
                     return@showCustomTimePicker
                 }
 
                 timeCardAdapter.updateTime(position, isStart, picked)
                 binding.possibleTimeRc.post { updateNextButtonState() }
             }
-
         }
         binding.possibleTimeRc.apply {
             layoutManager = LinearLayoutManager(requireContext())
             adapter = timeCardAdapter
         }
-
     }
 
-    //정해진 시간 범위의 시간으로 선택했는지 확인
+    // 정해진 시간 범위의 시간으로 선택했는지 확인
     private fun isWithinRange(picked: String, min: String, max: String): Boolean {
         val normMax = if (max == "24:00") "23:59" else max
         val t = LocalTime.parse(picked)
@@ -198,10 +208,111 @@ class FriendRoommateMatchingDetailFragment : Fragment() {
     private fun observeViewModel() {
         viewModel.possibleTimeList.observe(viewLifecycleOwner) { list ->
             val nonNullList = list.filterNotNull()
-            timeCardAdapter.setData(nonNullList)
+            android.util.Log.d("TimeFiltering", "=== observeViewModel 시작 ===")
+            android.util.Log.d("TimeFiltering", "원본 카드 개수: ${nonNullList.size}")
 
+            // 오늘인 경우, 현재 시각 기준으로 카드들 필터링/조정
+            val dateFormatted = convertDateFormat(selectedDate)
+            val today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+
+            android.util.Log.d("TimeFiltering", "선택된 날짜: $selectedDate")
+            android.util.Log.d("TimeFiltering", "변환된 날짜: $dateFormatted")
+            android.util.Log.d("TimeFiltering", "오늘 날짜: $today")
+            android.util.Log.d("TimeFiltering", "오늘인가? ${dateFormatted == today}")
+
+            val filteredList = if (dateFormatted == today) {
+                val now = LocalDateTime.now()
+                val currentMinutes = now.hour * 60 + now.minute
+                // 현재 시각을 10분 단위로 올림
+                val adjustedCurrentMinutes = ((currentMinutes + 9) / 10) * 10
+
+                android.util.Log.d("TimeFiltering", "현재 시각: ${now.hour}:${String.format("%02d", now.minute)}")
+                android.util.Log.d("TimeFiltering", "현재 시각(분): $currentMinutes")
+                android.util.Log.d("TimeFiltering", "조정된 시각(분): $adjustedCurrentMinutes")
+                android.util.Log.d("TimeFiltering", "조정된 시각: ${minutesToTime(adjustedCurrentMinutes)}")
+
+                nonNullList.mapNotNull { card ->
+                    val startMinutes = timeToMinutes(card.startTime)
+                    val endMinutes = timeToMinutes(card.endTime)
+
+                    android.util.Log.d("TimeFiltering", "--- 카드 처리 ---")
+                    android.util.Log.d("TimeFiltering", "원본: ${card.startTime} ~ ${card.endTime}")
+                    android.util.Log.d("TimeFiltering", "분 단위: $startMinutes ~ $endMinutes")
+
+                    when {
+                        // endTime이 현재 시각 이후가 아니면 (현재 시각 이하면) 제외
+                        endMinutes <= currentMinutes -> {
+                            android.util.Log.d("TimeFiltering", "결과: 제외 (endTime이 현재 시각 이하)")
+                            null
+                        }
+                        // startTime과 endTime 사이에 현재 시각이 있으면 조정된 현재 시각을 startTime으로 설정
+                        startMinutes <= currentMinutes && endMinutes > currentMinutes -> {
+                            val adjustedStartTime = minutesToTime(adjustedCurrentMinutes)
+                            // 조정된 시작 시간이 종료 시간보다 크거나 같으면 제외
+                            if (adjustedCurrentMinutes >= endMinutes) {
+                                android.util.Log.d("TimeFiltering", "결과: 제외 (조정된 시작시간이 종료시간보다 크거나 같음)")
+                                null
+                            } else {
+                                android.util.Log.d("TimeFiltering", "결과: 조정 ($adjustedStartTime ~ ${card.endTime})")
+                                card.copy(startTime = adjustedStartTime)
+                            }
+                        }
+                        // startTime이 현재 시각 이후면 그대로 사용
+                        else -> {
+                            android.util.Log.d("TimeFiltering", "결과: 그대로 사용")
+                            card
+                        }
+                    }
+                }
+            } else {
+                android.util.Log.d("TimeFiltering", "오늘이 아니므로 필터링 없이 그대로 사용")
+                nonNullList
+            }
+
+            android.util.Log.d("TimeFiltering", "필터링 후 카드 개수: ${filteredList.size}")
+            android.util.Log.d("TimeFiltering", "=== observeViewModel 끝 ===")
+
+            timeCardAdapter.setData(filteredList)
             updateNextButtonState()
         }
+    }
+
+    // 선택 시간이 (선택 날짜가 오늘인 경우) 현재 시각 이후인지 확인
+    private fun isAfterCurrentTime(selectedTime: String): Boolean {
+        val dateFormatted = convertDateFormat(selectedDate)
+        val today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+        if (dateFormatted != today) return true // 오늘이 아니면 통과
+
+        val now = LocalDateTime.now()
+        val currentMinutes = now.hour * 60 + now.minute
+        val selectedMinutes = timeToMinutes(selectedTime)
+        return selectedMinutes > currentMinutes
+    }
+
+    // 날짜 형식 변환 ("yy.MM.dd(E)" -> "yyyy-MM-dd"). 이미 yyyy-MM-dd면 그대로 반환
+    private fun convertDateFormat(dateStr: String): String {
+        if (dateStr.isBlank()) return dateStr
+        return try {
+            val formatterInput = DateTimeFormatter.ofPattern("yy.MM.dd(E)", Locale.KOREAN)
+            val formatterOutput = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.KOREAN)
+            LocalDate.parse(dateStr, formatterInput).format(formatterOutput)
+        } catch (e: Exception) {
+            // 파싱 실패 시, 원본을 반환 (이미 yyyy-MM-dd 형태일 수 있음)
+            dateStr
+        }
+    }
+
+    // 시간 문자열(HH:mm)을 분으로 변환
+    private fun timeToMinutes(timeStr: String): Int {
+        val parts = timeStr.split(":")
+        return parts[0].toInt() * 60 + parts[1].toInt()
+    }
+
+    // 분을 HH:mm 문자열로 변환
+    private fun minutesToTime(minutes: Int): String {
+        val hours = minutes / 60
+        val mins = minutes % 60
+        return String.format("%02d:%02d", hours, mins)
     }
 
     private fun setViewModelData() {
@@ -213,16 +324,15 @@ class FriendRoommateMatchingDetailFragment : Fragment() {
             )
         )
         viewModel.setTeumRequestTitle(binding.editTextTitle.text.toString())
-        if(binding.editTextDetail.text.isEmpty()){
-            //기본 멘트
+        if (binding.editTextDetail.text.isEmpty()) {
+            // 기본 멘트
             viewModel.setTeumRequestDescription("같이 빈틈을 채워봐요.")
-        }else{
+        } else {
             viewModel.setTeumRequestDescription(binding.editTextDetail.text.toString())
         }
-
     }
 
-    //24:00 -> 00:00 변환
+    // 24:00 -> 00:00 변환
     private fun convert24To00(timeStr: String): String {
         return if (timeStr == "24:00") "00:00" else timeStr
     }

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendRoommateTimeFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendRoommateTimeFragment.kt
@@ -30,6 +30,7 @@ import com.example.teumteum.ui.main.data.TimeBlock
 import com.example.teumteum.ui.main.data.TimeType
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import kotlin.collections.orEmpty
@@ -162,8 +163,14 @@ class FriendRoommateTimeFragment : Fragment() {
 
         // 다음 버튼
         binding.nextBtn.setOnClickListener {
+            val receivedDate = arguments?.getString("selected_date") ?: ""
+            val detail = FriendRoommateMatchingDetailFragment().apply {
+                arguments = Bundle().apply {
+                    putString("selected_date", receivedDate)
+                }
+            }
             parentFragmentManager.beginTransaction()
-                .replace(R.id.main_frm, FriendRoommateMatchingDetailFragment())
+                .replace(R.id.main_frm, detail)
                 .addToBackStack(null)
                 .commit()
         }
@@ -263,17 +270,76 @@ class FriendRoommateTimeFragment : Fragment() {
             val cards = list.filterNotNull()
             Log.d("DEBUG", "after filterNotNull: ${cards.size}개")
 
-            if (cards.isEmpty()) {
-                binding.possibleTime.text = "이때는 가능한 빈틈이 없어요"
+            // 현재 날짜와 선택된 날짜 비교
+            val selectedDate = convertDateFormat(arguments?.getString("selected_date") ?: "")
+            val today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+
+            val filteredCards = if (selectedDate == today) {
+                // 오늘인 경우 현재 시각 이후의 시간만 필터링
+                val currentMinutes = LocalDateTime.now().let { now ->
+                    now.hour * 60 + now.minute
+                }
+
+                cards.mapNotNull { card ->
+                    val startMinutes = timeToMinutes(card.startTime)
+                    val endMinutes = timeToMinutes(card.endTime)
+
+                    when {
+                        // 전체 시간이 현재 시각 이전인 경우 제외
+                        endMinutes <= currentMinutes -> null
+                        // 시작 시간이 현재 시각 이전인 경우 현재 시각부터 시작하도록 조정
+                        startMinutes < currentMinutes -> {
+                            val adjustedStartTime = minutesToTime(currentMinutes)
+                            card.copy(startTime = adjustedStartTime)
+                        }
+                        // 전체 시간이 현재 시각 이후인 경우 그대로 유지
+                        else -> card
+                    }
+                }
+            } else {
+                // 오늘이 아닌 경우 모든 시간 표시
+                cards
+            }
+
+            // 필터링 결과에 따른 텍스트 및 UI 업데이트
+            if (filteredCards.isEmpty()) {
+                // 가용 시간이 없는 경우의 텍스트 분기
+                binding.possibleTime.text = if (selectedDate == today) {
+                    if (cards.isEmpty()) {
+                        "이때는 가능한 빈틈이 없어요"  // 원래 서버에서 빈 시간이 없는 경우
+                    } else {
+                        "현재 시각 이후 가능한 빈틈이 없어요"  // 현재 시각 필터링으로 인해 없어진 경우
+                    }
+                } else {
+                    "이때는 가능한 빈틈이 없어요"  // 다른 날짜
+                }
                 currentFullDayBlocks = listOf(TimeBlock(0, 1440, TimeType.TODO))
                 updateNextButton(false)
             } else {
-                binding.possibleTime.text = "가능한 빈틈이 있어요"
-                currentFullDayBlocks = ChartUtils.buildBlocksFromTimeCardItems(cards)
+                // 가용 시간이 있는 경우의 텍스트 분기
+                binding.possibleTime.text = if (selectedDate == today && cards.size > filteredCards.size) {
+                    "현재 시각 이후 가능한 빈틈이 있어요"  // 일부 시간이 필터링된 경우
+                } else {
+                    "가능한 빈틈이 있어요"  // 일반적인 경우
+                }
+                currentFullDayBlocks = ChartUtils.buildBlocksFromTimeCardItems(filteredCards)
                 updateNextButton(true)
             }
             clockAdapter.refreshAll()
         }
+    }
+
+    // 시간 문자열을 분(minutes)으로 변환하는 헬퍼 함수
+    private fun timeToMinutes(timeStr: String): Int {
+        val parts = timeStr.split(":")
+        return parts[0].toInt() * 60 + parts[1].toInt()
+    }
+
+    // 분(minutes)을 시간 문자열로 변환하는 헬퍼 함수
+    private fun minutesToTime(minutes: Int): String {
+        val hours = minutes / 60
+        val mins = minutes % 60
+        return String.format("%02d:%02d", hours, mins)
     }
 
     private fun convertDateFormat(dateStr: String): String {


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #243

## ✨ 작업 내용
- 오늘 날자 선택 시 현재 시각 이후만 표시하도록 필터링 로직 추가
  - 시간표
    - 현재 시각 이전 구간은 제외
    - 현재 시각과 겹치는 구간은 시작 시간을 보정
  - 타임 피커
    - 시간표와 동일
    - 오늘일 경우 현재 시각 이전은 선택 불가 처리
  - 오늘이 아닌 날짜는 기존 동작 그대로 유지

## ✅ 코드 리뷰어 체크리스트
- [x] 오늘 날짜 필터링이 정상적으로 동작하는지
- [x] 타임 피커에서 현재 시각 이전 선택이 차단되는지
- [x] 기존(오늘이 아닌 날짜) 동작이 그대로 유지되는지

## 📸 스크린샷 (선택)
<img width="250" alt="image" src="https://github.com/user-attachments/assets/476dbc95-8389-4976-8b05-106eebea5b0c" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/622a2fa2-faa6-4444-b0cc-a36c528564ce" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/4dbacb9c-da33-4650-9a96-e2236450d111" />

> 표 만들기 귀찮아서....ㅜㅜ

## 💬 기타 참고 사항

