### PR TITLE
[FIX/#248] LinearProgressIndicator 끝점 점 현상 제거

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/activity/LoadingPageFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/LoadingPageFragment.kt
@@ -5,10 +5,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ProgressBar
 import androidx.core.animation.doOnEnd
 import androidx.fragment.app.Fragment
 import com.example.teumteum.databinding.FragmentLoadingPageBinding
-import com.google.android.material.progressindicator.LinearProgressIndicator
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -22,8 +22,9 @@ class LoadingPageFragment : Fragment() {
     private var _binding: FragmentLoadingPageBinding? = null
     private val binding get() = _binding!!
 
-    private val progress: LinearProgressIndicator get() = binding.linearProgress
+    private val progress: ProgressBar get() = binding.linearProgress
     private var animator: ValueAnimator? = null
+    private var current = 0 // 진행률 캐시(선택)
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -33,6 +34,13 @@ class LoadingPageFragment : Fragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // 초기화
+        progress.isIndeterminate = false
+        progress.progress = 0
+        current = 0
+
         animateProgress(to = 90)
     }
 
@@ -40,16 +48,17 @@ class LoadingPageFragment : Fragment() {
         val start = progress.progress
         val end = to.coerceIn(0, 100)
 
-        // 중복 애니메이터 정리 (겹침 방지)
         animator?.cancel()
         animator = null
         progress.clearAnimation()
         progress.jumpDrawablesToCurrentState()
 
-        ValueAnimator.ofInt(start, end).apply {
+        animator = ValueAnimator.ofInt(start, end).apply {
             duration = 1500L
-            addUpdateListener { animator ->
-                progress.setProgressCompat(animator.animatedValue as Int, true)
+            addUpdateListener { a ->
+                val v = a.animatedValue as Int
+                progress.progress = v
+                current = v
             }
             doOnEnd { onEnd?.invoke() }
             start()

--- a/app/src/main/res/drawable/progress_square.xml
+++ b/app/src/main/res/drawable/progress_square.xml
@@ -1,0 +1,16 @@
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@android:id/background">
+        <shape android:shape="rectangle">
+            <corners android:radius="0dp"/>
+            <solid android:color="@color/teumteum_bg"/>
+        </shape>
+    </item>
+    <item android:id="@android:id/progress">
+        <clip android:clipOrientation="horizontal" android:gravity="left">
+            <shape android:shape="rectangle">
+                <corners android:radius="0dp"/>
+                <solid android:color="@color/main_1"/>
+            </shape>
+        </clip>
+    </item>
+</layer-list>

--- a/app/src/main/res/layout/fragment_loading_page.xml
+++ b/app/src/main/res/layout/fragment_loading_page.xml
@@ -44,16 +44,17 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
 
-    <com.google.android.material.progressindicator.LinearProgressIndicator
+    <ProgressBar
         android:id="@+id/linear_progress"
+        style="?android:attr/progressBarStyleHorizontal"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="6dp"
         android:layout_marginStart="46dp"
         android:layout_marginEnd="46dp"
         android:max="100"
-        app:trackCornerRadius="0dp"
-        app:indicatorColor="@color/main_1"
-        app:trackColor="@color/teumteum_bg"
+        android:progress="0"
+        android:progressDrawable="@drawable/progress_square"
+        android:indeterminate="false"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #248 

## ✨ 작업 내용
- `LinearProgressIndicator` → `ProgressBar` 교체
- `progress_square.xml` 추가
- Fragment 코드 수정: `setProgressCompat` 제거, `progress` 직접 업데이트

## ✅ 코드 리뷰어 체크리스트
- [x] 애니메이션이 자연스럽고 성능 저하가 없는지

## 📸 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/0008e935-cf9d-48bd-a2b3-c2f8c7123481" width="300" />

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항
