### PR TITLE
[REFACTOR/#257] 채움활동 탐색 화면 토스트 개선

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/activity/FillingActivity01Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/FillingActivity01Fragment.kt
@@ -99,6 +99,12 @@ class FillingActivity01Fragment : Fragment() {
         locationButtons.forEachIndexed { index, locationBtn ->
             locationBtn.tag = locationIds[index]
             locationBtn.setOnClickListener {
+                // 위치 버튼 선택 시 직접 입력 선택 해제
+                if (!binding.fillingActivityLocationEt.text.isNullOrBlank()) {
+                    binding.fillingActivityLocationEt.setText("")
+                    selectedLocationText = null
+                }
+
                 // 이미 선택된 같은 버튼이면 해제
                 if (selectedLocationButton === locationBtn) {
                     locationBtn.setBackgroundColor(defaultBg)
@@ -126,6 +132,15 @@ class FillingActivity01Fragment : Fragment() {
             // 직접 입력이 있으면 selectedCategoryText에 반영
             selectedLocationText = if (!categoryText.isNullOrEmpty()) categoryText else null
 
+            // 직접 입력 선택 시 위치 버튼 해제
+            if (!categoryText.isNullOrEmpty() && selectedLocationButton != null) {
+                (selectedLocationButton as? android.widget.TextView)?.apply {
+                    setBackgroundColor(defaultBg)
+                    setTextColor(defaultText)
+                }
+                selectedLocationButton = null
+            }
+
             // 버튼 상태 갱신
             updateNextButtonState()
         }
@@ -144,6 +159,12 @@ class FillingActivity01Fragment : Fragment() {
         categoryButtons.forEachIndexed { index, categoryBtn ->
             categoryBtn.tag = categoryIds[index]
             categoryBtn.setOnClickListener {
+                // 카테고리 버튼 선택 시 직접 입력 선택 해제
+                if (!binding.fillingActivityCategoryEt.text.isNullOrBlank()) {
+                    binding.fillingActivityCategoryEt.setText("")
+                    selectedCategoryText = null
+                }
+
                 // 이미 선택된 같은 버튼이면 해제
                 if (selectedCategoryButton === categoryBtn) {
                     categoryBtn.setBackgroundColor(defaultBg)
@@ -170,6 +191,15 @@ class FillingActivity01Fragment : Fragment() {
 
             // 직접 입력이 있으면 selectedCategoryText에 반영
             selectedCategoryText = if (!categoryText.isNullOrEmpty()) categoryText else null
+
+            // 직접 입력 선택 시 카테고리 버튼 해제
+            if (!categoryText.isNullOrEmpty() && selectedCategoryButton != null) {
+                (selectedCategoryButton as? android.widget.TextView)?.apply {
+                    setBackgroundColor(defaultBg)
+                    setTextColor(defaultText)
+                }
+                selectedCategoryButton = null
+            }
 
             // 버튼 상태 갱신
             updateNextButtonState()


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #257 

## ✨ 작업 내용
채움활동 탐색 화면에서 시간(선택), 위치(선택or작성), 카테고리(선택or작성)
(기존) 위치 버튼 선택 + 위치 직접 작성 시 "위치와 직접 입력은 둘 중 하나만 선택해야 합니다." 토스트 메시지로 예외 처리, 카테고리 버튼 선택 + 카테고리 직접 작성 시 "카테고리와 직접 입력은 둘 중 하나만 선택해야 합니다." 토스트 메시지로 예외 처리

사용자가 오류를 적게 경험하도록 하기 위해 아래와 같이 코드를 개선합니다.

(변경) ex) 사용자가 학교 칩을 선택했더라도 직접 입력 텍스트 필드를 선택할 시 학교 선택이 취소되는 식으로.
-> 사용자가 직접 텍스트 필드에 텍스트를 작성하고 칩 버튼을 선택하면 작성했던 텍스트도 삭제되도록.

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] check
- [ ] check
- [ ] check

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항
