### PR TITLE
[FIX/#260] 틈요청 사진 연결

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendMatchingPreviewDialog.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendMatchingPreviewDialog.kt
@@ -9,6 +9,7 @@ import android.view.*
 import android.widget.Toast
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
 import com.bumptech.glide.Glide
 import com.example.teumteum.R
 import com.example.teumteum.databinding.DialogFriendMatchingPreviewBinding
@@ -84,6 +85,9 @@ class FriendMatchingPreviewDialog : DialogFragment() {
         binding.btnSend.setOnClickListener {
 
             val request = viewModel.buildTeumRequest()
+
+            setLoading(true)
+
             Log.d("SEND_TEUM_REQUEST", request.toString())
             if (request == null) {
                 return@setOnClickListener
@@ -95,15 +99,20 @@ class FriendMatchingPreviewDialog : DialogFragment() {
                 onSuccess = {
                     viewModel.setTeumRequestReceiverUserIds(emptyList())
 
-                    parentFragmentManager.beginTransaction()
-                        .replace(R.id.main_frm, FriendSendFragment())
-                        .addToBackStack(null)
-                        .commit()
-
-                    dismiss()
+                    if (isAdded &&
+                        this@FriendMatchingPreviewDialog.view != null &&
+                        lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+                    ) {
+                        requireActivity().supportFragmentManager.beginTransaction()
+                            .replace(R.id.main_frm, FriendSendFragment())
+                            .addToBackStack(null)
+                            .commit()
+                    }
+                    dismissAllowingStateLoss()
                 },
                 onError = { msg ->
-//                    Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
+                    setLoading(false)
+                    Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
                     Log.d("FRIEND_MATCHING_PREVIEW_DIALOG", msg.toString())
                 })
         }
@@ -156,6 +165,18 @@ class FriendMatchingPreviewDialog : DialogFragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    private fun setLoading(loading: Boolean) {
+
+        // 버튼 막기
+        binding.btnSend.isEnabled = !loading
+        binding.btnPrev.isEnabled = !loading
+        binding.btnNext.isEnabled = !loading
+
+        // 다이얼로그 취소/바깥터치 방지
+        isCancelable = !loading
+        dialog?.setCanceledOnTouchOutside(!loading)
     }
 
     data class Suggestion(val title: String, val detail: String)

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendMatchingPreviewDialog.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendMatchingPreviewDialog.kt
@@ -31,6 +31,7 @@ class FriendMatchingPreviewDialog : DialogFragment() {
     private var currentIndex = 0
 
     private var imageList = listOf(
+        R.drawable.friend_teum_logo,
         R.drawable.teumi_teuma_eat,
         R.drawable.teumi_teuma_ball,
         R.drawable.teumi_teuma_down,

--- a/app/src/main/java/com/example/teumteum/ui/friend/adapter/FriendRequestCardAdapter.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/adapter/FriendRequestCardAdapter.kt
@@ -11,6 +11,14 @@ import com.example.teumteum.databinding.Friend02ItemTeumCardBinding
 class FriendRequestCardAdapter(private val teumList: List<TeumReceivedItem>) :
     RecyclerView.Adapter<FriendRequestCardAdapter.TeumViewHolder>() {
 
+    private var imageList = listOf(
+        R.drawable.friend_teum_logo,
+        R.drawable.teumi_teuma_eat,
+        R.drawable.teumi_teuma_ball,
+        R.drawable.teumi_teuma_down,
+        R.drawable.teumi_teuma_juice
+    )
+
     inner class TeumViewHolder(private val binding: Friend02ItemTeumCardBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
@@ -39,6 +47,8 @@ class FriendRequestCardAdapter(private val teumList: List<TeumReceivedItem>) :
                 .error(R.drawable.gray_teum)
                 .fallback(R.drawable.gray_teum)
                 .into(binding.imgProfile)
+
+            binding.imgTeum.setImageResource(imageList[item.graphicId])
         }
     }
 

--- a/app/src/main/java/com/example/teumteum/ui/friend/adapter/FriendResponseCardAdapter.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/adapter/FriendResponseCardAdapter.kt
@@ -12,6 +12,14 @@ class FriendResponseCardAdapter(
     private val responseList: List<TeumReceivedItem>
 ) : RecyclerView.Adapter<FriendResponseCardAdapter.ResponseViewHolder>() {
 
+    private var imageList = listOf(
+        R.drawable.friend_teum_logo,
+        R.drawable.teumi_teuma_eat,
+        R.drawable.teumi_teuma_ball,
+        R.drawable.teumi_teuma_down,
+        R.drawable.teumi_teuma_juice
+    )
+
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int
@@ -56,6 +64,8 @@ class FriendResponseCardAdapter(
                     .placeholder(R.drawable.gray_teum)
                     .circleCrop()
                     .into(imgProfile)
+
+                binding.imgTeum.setImageResource(imageList[item.graphicId])
             }
         }
 


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #260

## ✨ 작업 내용
> 틈 요청할 때 보낸 틈 사진을 틈 조회에서 반영
> + 틈 요청 보내기 후 완료 화면 넘어가기 전에 다이얼로그를 없애면 앱이 꺼지는 현상이 있어서 급하게 수정
> + 요청 보내기 버튼을 클릭하면 잠시 대기상태로 다이얼로그를 없애거나 버튼을 클릭하지 못하게 비활성화 해놓는 방식으로 수정했습니다.

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 상대방이 틈 요청 시에 보낸 사진이 틈 조회에서 반영되는지
- [x] 상대방이 보낸 재요청 확인하는 화면에서도 반영되는지

## 📸 스크린샷 (선택)
> 

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항
