### PR TITLE
[REFACTOR/#284] 카카오 로그인 dto 변경

### DIFF
--- a/app/src/main/java/com/example/teumteum/data/remote/auth/model/KakaoLoginRequest.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/auth/model/KakaoLoginRequest.kt
@@ -3,5 +3,5 @@ package com.example.teumteum.data.remote.auth.model
 import com.google.gson.annotations.SerializedName
 
 data class KakaoLoginRequest(
-    @SerializedName("accessToken") val accessToken: String
+    @SerializedName("token") val token: String
 )


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #284

## ✨ 작업 내용
> 틈틈 서버의 소셜 로그인 API 요청 dto가 아래와 같이 변경되었습니다.
> accessToken -> token
> 따라서 KakaoLoginRequest를 서버 API에 맞게 변경하였습니다.

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 로그인 작동 확인(마이페이지 -> 톱니바퀴 -> 계정 설정 -> 로그아웃 후에 다시 로그인 해보기)

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항
