### PR TITLE
[BUG/#301] 투두 작업 시 캘린더에 갱신되지 않는 문제

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
@@ -427,6 +427,7 @@ class HomeFragment : Fragment() {
             viewModel.refreshTodaySchedule()
             viewModel.getTeumTime()
             refreshTodolist()
+            refreshCalendarDots()
         }
 
         // 투두 수정 성공 이벤트 수신
@@ -434,6 +435,7 @@ class HomeFragment : Fragment() {
             viewModel.refreshTodaySchedule()
             viewModel.getTeumTime()
             refreshTodolist()
+            refreshCalendarDots()
         }
 
         // 투두 삭제 성공 이벤트 수신
@@ -441,6 +443,7 @@ class HomeFragment : Fragment() {
             viewModel.refreshTodaySchedule()
             viewModel.getTeumTime()
             refreshTodolist()
+            refreshCalendarDots()
         }
 
         todoViewModel.getTodoList(date)
@@ -846,6 +849,17 @@ class HomeFragment : Fragment() {
     private inner class DayViewContainer(view: View) : ViewContainer(view) {
         val textView: TextView = view.findViewById(R.id.calendar_day_tv)
         val dotView: View = view.findViewById(R.id.dot_view)
+    }
+
+    // 캘린더 갱신
+    private fun refreshCalendarDots() {
+        lastRequestedRange = null
+
+        if (isWeeklyMode) {
+            weekCalendar.findFirstVisibleWeek()?.let { requestForWeek(it) }
+        } else {
+            monthCalendar.findFirstVisibleMonth()?.let { requestForMonth(it) }
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
@@ -744,7 +744,6 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
                 viewModel.registerSuccess.collect {
                     Log.d("TODO_REGISTER_FRAGMENT", "투두가 성공적으로 등록되었습니다.")
                     parentFragmentManager.setFragmentResult("todo_register_home", Bundle())
-                    parentFragmentManager.setFragmentResult("todo_register_calendar", Bundle())
 
                     // 모든 바텀시트 닫기
                     (requireActivity().supportFragmentManager.fragments).forEach { fragment ->


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #301 

## ✨ 작업 내용
투두 등록/수정/삭제 시 캘린더 dot가 바로 갱신되도록 수정하였습니다.
`refreshCalendarDots` 함수를 통해
- 주별캘린더의 경우 주별캘린더 일정 재조회
- 월별캘린더의 경우 월별캘린더 일정 재조회

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 투두 작업 시 캘린더 dot 부분이 갱신되는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항
