### PR TITLE
[BUG/#322] 다른 연도에 투두가 등록되지 않는 문제 해결

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
@@ -52,6 +52,8 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
 import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -663,16 +665,29 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
             .map { (min, st) -> ReminderAlarm(alarm = min, status = st) }
     }
 
-    private fun getTodayFormatted(): String {
-        val today = LocalDate.now()
-        val formatter = DateTimeFormatter.ofPattern("M월 d일 (E)", Locale.KOREAN)
-        return today.format(formatter)
+    private fun parseKoreanAmPmTime(timeText: String): LocalTime {
+        val parts = timeText.trim().split(" ")
+        val ampm = parts[0] // 오전/오후
+        val (hStr, mStr) = parts[1].split(":")
+        var hour = hStr.toInt()
+        val minute = mStr.toInt()
+
+        if (ampm == "오후" && hour != 12) hour += 12
+        if (ampm == "오전" && hour == 12) hour = 0
+
+        return LocalTime.of(hour, minute)
     }
 
     private fun getTodoRequest(): RegisterTodoRequest {
         val title = binding.todoTitleEt.text.toString()
-        val startTime = combineDateTime(binding.startDateTv, binding.startTimeTv)
-        val endTime = combineDateTime(binding.endDateTv, binding.endTimeTv)
+
+        val startLocalTime = parseKoreanAmPmTime(binding.startTimeTv.text.toString())
+        val endLocalTime = parseKoreanAmPmTime(binding.endTimeTv.text.toString())
+
+        val startDateTime = LocalDateTime.of(selectedStartDate, startLocalTime)
+        val endDateTime = LocalDateTime.of(selectedEndDate, endLocalTime)
+
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm")
 
         val description = binding.detailTextEt.text.toString()
         val isPublic = binding.publicToggle01Iv.isChecked
@@ -681,8 +696,8 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
 
         return RegisterTodoRequest(
             title = title,
-            startTime = startTime,
-            endTime = endTime,
+            startTime = startDateTime.format(formatter),
+            endTime = endDateTime.format(formatter),
             description = description,
             isPublic = isPublic,
             includeTeum = includeTeum,


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #322 

## ✨ 작업 내용
> ex) 2026년 1월에 투두를 등록하면 2025년 1월에 등록되던 문제 -> TextView 대신 LocalDate로 요청 보내기

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 앱 내에서 2026년, 2027년 등 다른 연도에 투두 등록이 정상적으로 되는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 한국어 오전/오후 시간 형식 처리 개선
  * 시작 및 종료 시간 파싱 로직 안정화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->