### PR TITLE
[REFACTOR/#324] 투두 등록 시 캘린더 스크롤 비활성화

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
@@ -1,6 +1,5 @@
 package com.example.teumteum.ui.todo
 
-import android.annotation.SuppressLint
 import android.app.Dialog
 import android.content.Context
 import android.graphics.Typeface
@@ -11,7 +10,6 @@ import android.util.TypedValue
 import android.view.Gravity
 import android.view.KeyEvent
 import android.view.LayoutInflater
-import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
@@ -52,6 +50,7 @@ import com.example.teumteum.ui.friend.viewModel.FriendViewModel
 import com.example.teumteum.ui.todo.adapter.TeumProfileAdapter
 import com.example.teumteum.ui.todo.viewModel.TodoViewModel
 import com.example.teumteum.utils.TimeUtils.combineDateTime
+import com.example.teumteum.utils.disableScroll
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.kizitonwose.calendar.core.CalendarDay
@@ -270,17 +269,9 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
         }
     }
 
-    @SuppressLint("ClickableViewAccessibility")
     private fun disableCalendarScroll() {
-        val blockScroll = View.OnTouchListener { _, event ->
-            when (event.actionMasked) {
-                MotionEvent.ACTION_MOVE -> true // 스크롤 차단
-                else -> false // 날짜 선택 가능
-            }
-        }
-
-        binding.calendarView01.setOnTouchListener(blockScroll)
-        binding.calendarView02.setOnTouchListener(blockScroll)
+        binding.calendarView01.disableScroll()
+        binding.calendarView02.disableScroll()
     }
 
     private fun setupStartCalendar() {

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
@@ -63,6 +63,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 import java.util.Locale
@@ -283,7 +284,7 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
     }
 
     private fun setupStartCalendar() {
-        val currentMonth = java.time.YearMonth.now()
+        val currentMonth = YearMonth.now()
         val startMonth = currentMonth.minusYears(50)
         val endMonth = currentMonth.plusYears(50)
         val firstDayOfWeek = firstDayOfWeekFromLocale()
@@ -331,7 +332,7 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
     }
 
     private fun setupEndCalendar() {
-        val currentMonth = java.time.YearMonth.now()
+        val currentMonth = YearMonth.now()
         val startMonth = currentMonth.minusYears(50)
         val endMonth = currentMonth.plusYears(50)
         val firstDayOfWeek = firstDayOfWeekFromLocale()

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
@@ -1,5 +1,6 @@
 package com.example.teumteum.ui.todo
 
+import android.annotation.SuppressLint
 import android.app.Dialog
 import android.content.Context
 import android.graphics.Typeface
@@ -10,6 +11,7 @@ import android.util.TypedValue
 import android.view.Gravity
 import android.view.KeyEvent
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
@@ -157,8 +159,11 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
 
         resetAlarmUI()
         setupPickers()
+
         setupStartCalendar()
         setupEndCalendar()
+        disableCalendarScroll()
+
         setupWeekdayLabels()
         setupClickListeners(scheduleType)
         setupObservers()
@@ -262,6 +267,19 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
             isStartDateSelected = false
             toggleCalendarVisibility(show = true)
         }
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private fun disableCalendarScroll() {
+        val blockScroll = View.OnTouchListener { _, event ->
+            when (event.actionMasked) {
+                MotionEvent.ACTION_MOVE -> true // 스크롤 차단
+                else -> false // 날짜 선택 가능
+            }
+        }
+
+        binding.calendarView01.setOnTouchListener(blockScroll)
+        binding.calendarView02.setOnTouchListener(blockScroll)
     }
 
     private fun setupStartCalendar() {

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
@@ -267,7 +267,7 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
     private fun disableCalendarScroll() {
         val blockScroll = View.OnTouchListener { _, event ->
             when (event.actionMasked) {
-                MotionEvent.ACTION_MOVE -> true   // 스크롤 차단
+                MotionEvent.ACTION_MOVE -> true // 스크롤 차단
                 else -> false // 날짜 선택 가능
             }
         }

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
@@ -42,7 +42,6 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
 import com.example.teumteum.ui.myhome.viewModel.MyHomeViewModel
 import com.example.teumteum.ui.todo.viewModel.TodoViewModel
-import com.example.teumteum.utils.TimeUtils.combineDateTime
 import com.kizitonwose.calendar.core.CalendarDay
 import com.kizitonwose.calendar.core.DayPosition
 import com.kizitonwose.calendar.core.firstDayOfWeekFromLocale

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
@@ -1,5 +1,6 @@
 package com.example.teumteum.ui.todo
 
+import android.annotation.SuppressLint
 import android.app.Dialog
 import android.content.Context
 import android.graphics.Typeface
@@ -9,6 +10,7 @@ import android.util.Log
 import android.util.TypedValue
 import android.view.Gravity
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
@@ -128,8 +130,11 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
 
         resetAlarmUI()
         setupPickers()
+
         setupStartCalendar()
         setupEndCalendar()
+        disableCalendarScroll()
+
         setupWeekdayLabels()
         setupObservers()
         setupClickListeners()
@@ -256,6 +261,19 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
             isStartDateSelected = false
             toggleCalendarVisibility(show = true)
         }
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private fun disableCalendarScroll() {
+        val blockScroll = View.OnTouchListener { _, event ->
+            when (event.actionMasked) {
+                MotionEvent.ACTION_MOVE -> true   // 스크롤 차단
+                else -> false // 날짜 선택 가능
+            }
+        }
+
+        binding.calendarView01.setOnTouchListener(blockScroll)
+        binding.calendarView02.setOnTouchListener(blockScroll)
     }
 
     private fun setupStartCalendar() {

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
@@ -1,6 +1,5 @@
 package com.example.teumteum.ui.todo
 
-import android.annotation.SuppressLint
 import android.app.Dialog
 import android.content.Context
 import android.graphics.Typeface
@@ -10,7 +9,6 @@ import android.util.Log
 import android.util.TypedValue
 import android.view.Gravity
 import android.view.LayoutInflater
-import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
@@ -44,6 +42,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
 import com.example.teumteum.ui.myhome.viewModel.MyHomeViewModel
 import com.example.teumteum.ui.todo.viewModel.TodoViewModel
+import com.example.teumteum.utils.disableScroll
 import com.kizitonwose.calendar.core.CalendarDay
 import com.kizitonwose.calendar.core.DayPosition
 import com.kizitonwose.calendar.core.firstDayOfWeekFromLocale
@@ -263,17 +262,9 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
         }
     }
 
-    @SuppressLint("ClickableViewAccessibility")
     private fun disableCalendarScroll() {
-        val blockScroll = View.OnTouchListener { _, event ->
-            when (event.actionMasked) {
-                MotionEvent.ACTION_MOVE -> true // 스크롤 차단
-                else -> false // 날짜 선택 가능
-            }
-        }
-
-        binding.calendarView01.setOnTouchListener(blockScroll)
-        binding.calendarView02.setOnTouchListener(blockScroll)
+        binding.calendarView01.disableScroll()
+        binding.calendarView02.disableScroll()
     }
 
     private fun setupStartCalendar() {

--- a/app/src/main/java/com/example/teumteum/utils/CalendarViewExtensions.kt
+++ b/app/src/main/java/com/example/teumteum/utils/CalendarViewExtensions.kt
@@ -1,0 +1,17 @@
+package com.example.teumteum.utils
+
+import android.annotation.SuppressLint
+import android.view.MotionEvent
+import android.view.View
+import com.kizitonwose.calendar.view.CalendarView
+
+@SuppressLint("ClickableViewAccessibility")
+fun CalendarView.disableScroll() {
+    val blockScroll = View.OnTouchListener { _, event ->
+        when (event.actionMasked) {
+            MotionEvent.ACTION_MOVE -> true // 스크롤 차단
+            else -> false // 날짜 선택 가능
+        }
+    }
+    this.setOnTouchListener(blockScroll)
+}


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #324 

## ✨ 작업 내용
> 투두 등록 및 수정 시 캘린더 스크롤을 비활성화하는 작업 진행, 날짜 클릭은 가능하도록

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 캘린더 스크롤 비활성화

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 편집/등록 화면의 캘린더에서 터치로 인한 불필요한 스크롤을 비활성화하는 동작을 추가했습니다. 날짜 선택은 그대로 유지됩니다.

* **버그 수정**
  * 캘린더 날짜 선택 시 의도치 않은 스크롤 발생을 개선하여 안정적이고 예측 가능한 터치 동작을 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->