### PR TITLE
[REFACTOR/#326] 탐색결과에서 친구 카드뷰 클릭 시 네비바 갱신

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/activity/FillingActivity02Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/FillingActivity02Fragment.kt
@@ -87,6 +87,8 @@ class FillingActivity02Fragment : Fragment() {
             val activity = requireActivity()
             val bottomNav = activity.findViewById<BottomNavigationView>(R.id.main_bnv)
 
+            it.isEnabled = false
+
             // 백스택 전부 제거
             activity.supportFragmentManager.popBackStack(
                 null,
@@ -94,6 +96,8 @@ class FillingActivity02Fragment : Fragment() {
             )
 
             bottomNav.selectedItemId = R.id.fragment_friend
+
+            it.postDelayed({ it.isEnabled = true }, 500) // 네비게이션 완료 후 클릭 재활성화
         }
 
         // 새로고침: 시머 -> 재조회

--- a/app/src/main/java/com/example/teumteum/ui/activity/FillingActivity02Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/FillingActivity02Fragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.activityViewModels
 import com.example.teumteum.R
 import com.example.teumteum.data.remote.activity.model.ActivityAiRequest
@@ -18,6 +19,7 @@ import com.example.teumteum.ui.activity.adapter.AiRecommendAdapter
 import com.example.teumteum.ui.activity.adapter.WishRecommendAdapter
 import com.example.teumteum.ui.activity.viewModel.ActivityViewModel
 import com.example.teumteum.ui.friend.FriendFragment
+import com.google.android.material.bottomnavigation.BottomNavigationView
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -82,10 +84,16 @@ class FillingActivity02Fragment : Fragment() {
         }
 
         binding.fillingActivityFriendSearchCv.setOnClickListener {
-            parentFragmentManager.beginTransaction()
-                .replace(R.id.main_frm, FriendFragment())
-                .addToBackStack(null)
-                .commit()
+            val activity = requireActivity()
+            val bottomNav = activity.findViewById<BottomNavigationView>(R.id.main_bnv)
+
+            // 백스택 전부 제거
+            activity.supportFragmentManager.popBackStack(
+                null,
+                FragmentManager.POP_BACK_STACK_INCLUSIVE
+            )
+
+            bottomNav.selectedItemId = R.id.fragment_friend
         }
 
         // 새로고침: 시머 -> 재조회


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #326 

## ✨ 작업 내용
> 채움활동 탐색결과에서 상단의 친구 카드뷰 클릭 시 네비바가 홈 -> 친구 로 갱신되면서 친구 화면으로 이동. 기기의 뒤로가기 클릭 시 앱 종료 (백스택 정리)

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 친구 화면으로 정상적으로 이동하는지
- [x] 백스택 정리 작업으로 인해 -> 친구 화면에서 뒤로가기 클릭 시 앱이 정상적으로 종료되는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
- 친구 화면으로 이동할 때의 네비게이션 흐름을 개선했습니다. 뒤로가기 스택 관리가 더욱 효율적으로 처리되어 사용자가 보다 자연스러운 화면 전환 경험을 할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->