### PR TITLE
[BUG/#329] 빈틈채우기 날짜 변경 시 시간표가 갱신되지 않는 문제 해결

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting01Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting01Fragment.kt
@@ -110,6 +110,8 @@ class FillingSetting01Fragment : Fragment() {
 
         homeViewModel.getTodaySchedule(selectedDateServer)
 
+        clockAdapter.refreshAll()
+
         binding.amPmTv.setOnClickListener {
             val amPos = clockAdapter.positionOf(ClockHalf.AM)
             val pmPos = clockAdapter.positionOf(ClockHalf.PM)

--- a/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting01Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting01Fragment.kt
@@ -110,8 +110,6 @@ class FillingSetting01Fragment : Fragment() {
 
         homeViewModel.getTodaySchedule(selectedDateServer)
 
-        clockAdapter.refreshAll()
-
         binding.amPmTv.setOnClickListener {
             val amPos = clockAdapter.positionOf(ClockHalf.AM)
             val pmPos = clockAdapter.positionOf(ClockHalf.PM)

--- a/app/src/main/java/com/example/teumteum/ui/main/viewModel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/teumteum/ui/main/viewModel/HomeViewModel.kt
@@ -76,11 +76,18 @@ class HomeViewModel @Inject constructor(
             repository.getTodaySchedule(date)
                 .onSuccess { result ->
                     Log.d("TodaySchedule", result.toString())
-                    _scheduleList.value = result.map {
+
+                    val blocks = result.map {
                         val start = timeToMinutes(it.startTime)
                         val end = timeToMinutes(it.endTime)
                         TimeBlock(start, end, it.type)
                     }
+
+                    _scheduleList.value = blocks
+
+                    // clock용 데이터 분리
+                    _sleepTimeList.value = blocks.filter { it.type == TimeType.SLEEP }
+                    _todoTimeList.value = blocks.filter { it.type == TimeType.TODO }
                 }
                 .onFailure {
                     _error.value = "스케줄 조회 실패: ${it.message}"

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishSetting01Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishSetting01Fragment.kt
@@ -112,8 +112,6 @@ class WishSetting01Fragment : Fragment() {
 
         homeViewModel.getTodaySchedule(selectedDateServer)
 
-        clockAdapter.refreshAll()
-
         binding.amPmTv.setOnClickListener {
             val amPos = clockAdapter.positionOf(ClockHalf.AM)
             val pmPos = clockAdapter.positionOf(ClockHalf.PM)

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishSetting01Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishSetting01Fragment.kt
@@ -205,6 +205,14 @@ class WishSetting01Fragment : Fragment() {
         }
 
         updateIndicator(isAM)
+
+        homeViewModel.sleepTimeList.observe(viewLifecycleOwner) {
+            clockAdapter.refreshAll()
+        }
+
+        homeViewModel.todoTimeList.observe(viewLifecycleOwner) {
+            clockAdapter.refreshAll()
+        }
     }
 
     private fun setupObservers() {

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishSetting01Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishSetting01Fragment.kt
@@ -112,6 +112,8 @@ class WishSetting01Fragment : Fragment() {
 
         homeViewModel.getTodaySchedule(selectedDateServer)
 
+        clockAdapter.refreshAll()
+
         binding.amPmTv.setOnClickListener {
             val amPos = clockAdapter.positionOf(ClockHalf.AM)
             val pmPos = clockAdapter.positionOf(ClockHalf.PM)


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #329 

## ✨ 작업 내용
> 빈틈채우기 날짜 변경 시 시간대 카드뷰는 갱신되지만, 원형시간표에는 데이터가 갱신되지 않던 문제 해결

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 날짜 변경 시 해당 날짜의 빈틈 시간표가 정상적으로 조회되는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 개선사항

* 오늘의 일정 데이터가 수면 시간과 할일 항목으로 체계적으로 구분되어 표시됩니다.
* 시계 인터페이스가 일정 정보 변경 시 자동으로 새로고침되어 항상 최신 상태를 유지합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->