### PR TITLE
[REFACTOR/#335] 캘린더 날짜 클릭 시 해당 날짜의 빈틈 시간표 조회

### DIFF
--- a/app/src/main/java/com/example/teumteum/data/remote/home/repository/HomeRepository.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/home/repository/HomeRepository.kt
@@ -14,8 +14,8 @@ import javax.inject.Singleton
 class HomeRepository @Inject constructor(
     private val homeService: HomeService
 ){
-    suspend fun getTodaySchedule(date: String): Result<List<ScheduleResult>> = runCatching {
-        val response = homeService.getTodaySchedule(date)
+    suspend fun getScheduleForDate(date: String): Result<List<ScheduleResult>> = runCatching {
+        val response = homeService.getScheduleForDate(date)
         Log.d("HomeSchedule", "response = ${response.body()}")
         handleApiResponse(response)
     }

--- a/app/src/main/java/com/example/teumteum/data/remote/home/service/HomeService.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/home/service/HomeService.kt
@@ -12,7 +12,7 @@ import retrofit2.http.Query
 interface HomeService {
 
     @GET("/api/home/teum")
-    suspend fun getTodaySchedule( @Query("date") date: String ): Response<ApiResponse<List<ScheduleResult>>>
+    suspend fun getScheduleForDate( @Query("date") date: String ): Response<ApiResponse<List<ScheduleResult>>>
 
     @GET("/api/home/teum-time")
     suspend fun getTeumTime(): Response<ApiResponse<TeumTimeResponse>>

--- a/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting01Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting01Fragment.kt
@@ -108,7 +108,7 @@ class FillingSetting01Fragment : Fragment() {
         setupClockPager()
         setupObservers()
 
-        homeViewModel.getTodaySchedule(selectedDateServer)
+        homeViewModel.getScheduleForDate(selectedDateServer)
 
         binding.amPmTv.setOnClickListener {
             val amPos = clockAdapter.positionOf(ClockHalf.AM)
@@ -143,7 +143,7 @@ class FillingSetting01Fragment : Fragment() {
             binding.nextBtn.setTextColor(ContextCompat.getColor(requireContext(), R.color.text_primary))
 
             wishTimeAdapter.clearSelection()
-            homeViewModel.getTodaySchedule(server)
+            homeViewModel.getScheduleForDate(server)
         }
 
         binding.nextBtn.setOnClickListener {

--- a/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
@@ -748,8 +748,9 @@ class HomeFragment : Fragment() {
     }
 
     private fun onDateSelected(date: LocalDate) {
-        val dateStr = date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+        val dateStr = date.format(serverFormatter) // "yyyy-MM-dd"
         todoViewModel.getTodoList(dateStr)
+        viewModel.getTodaySchedule(dateStr)
     }
 
     private fun updateIndicator(isAM: Boolean) {

--- a/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
@@ -750,7 +750,7 @@ class HomeFragment : Fragment() {
     private fun onDateSelected(date: LocalDate) {
         val dateStr = date.format(serverFormatter) // "yyyy-MM-dd"
         todoViewModel.getTodoList(dateStr)
-        viewModel.getTodaySchedule(dateStr)
+        viewModel.getScheduleForDate(dateStr)
     }
 
     private fun updateIndicator(isAM: Boolean) {
@@ -800,7 +800,7 @@ class HomeFragment : Fragment() {
     }
 
     private fun refreshTodolist() {
-        val dateStr = selectedDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+        val dateStr = selectedDate.format(serverFormatter)
         todoViewModel.getTodoList(dateStr)
     }
 

--- a/app/src/main/java/com/example/teumteum/ui/main/viewModel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/teumteum/ui/main/viewModel/HomeViewModel.kt
@@ -70,12 +70,12 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    /** 오늘의 스케줄 가져오기 */
-    fun getTodaySchedule(date: String) {
+    /** 스케줄 가져오기 */
+    fun getScheduleForDate(date: String) {
         viewModelScope.launch {
-            repository.getTodaySchedule(date)
+            repository.getScheduleForDate(date)
                 .onSuccess { result ->
-                    Log.d("TodaySchedule", result.toString())
+                    Log.d("Schedule", result.toString())
 
                     val blocks = result.map {
                         val start = timeToMinutes(it.startTime)
@@ -91,7 +91,7 @@ class HomeViewModel @Inject constructor(
                 }
                 .onFailure {
                     _error.value = "스케줄 조회 실패: ${it.message}"
-                    Log.d("TodaySchedule", _error.value.toString() )
+                    Log.d("Schedule", _error.value.toString() )
                 }
         }
     }

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishSetting01Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishSetting01Fragment.kt
@@ -110,7 +110,7 @@ class WishSetting01Fragment : Fragment() {
         setupClockPager()
         setupObservers()
 
-        homeViewModel.getTodaySchedule(selectedDateServer)
+        homeViewModel.getScheduleForDate(selectedDateServer)
 
         binding.amPmTv.setOnClickListener {
             val amPos = clockAdapter.positionOf(ClockHalf.AM)
@@ -147,7 +147,7 @@ class WishSetting01Fragment : Fragment() {
             binding.nextBtn.setTextColor(ContextCompat.getColor(requireContext(), R.color.text_primary))
 
             wishTimeAdapter.clearSelection()
-            homeViewModel.getTodaySchedule(server)
+            homeViewModel.getScheduleForDate(server)
         }
 
         binding.nextBtn.setOnClickListener {


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #335 

## ✨ 작업 내용
> 캘린더 날짜 클릭 시 해당 날짜의 빈틈 시간표가 조회되도록 수정하였습니다.

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] 캘린더 날짜 클릭 시 해당 날짜의 빈틈 시간표가 잘 조회되는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 업데이트 내용

* **새로운 기능**
  * 홈 화면에서 날짜를 선택하면 해당 날짜의 일정과 할일을 함께 자동으로 불러옵니다.

* **개선사항**
  * 앱 전반에서 서버와 주고받는 날짜 형식을 표준화하여 일관된 일정 조회가 가능해졌습니다.
  * 일정 조회 호출이 여러 화면에서 일관되게 동작하도록 정비했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->