### PR TITLE
[BUG/#338] 채움활동 탐색 중일 때 뒤로가기 클릭 시 일부 화면이 겹쳐보이는 문제

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/activity/LoadingPageFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/LoadingPageFragment.kt
@@ -99,6 +99,7 @@ class LoadingPageFragment : Fragment() {
         super.onDestroyView()
         animator?.cancel()
         animator = null
+        backCallback = null
         _binding = null
     }
 }

--- a/app/src/main/java/com/example/teumteum/ui/activity/LoadingPageFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/LoadingPageFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ProgressBar
+import androidx.activity.OnBackPressedCallback
 import androidx.core.animation.doOnEnd
 import androidx.fragment.app.Fragment
 import com.example.teumteum.databinding.FragmentLoadingPageBinding
@@ -26,6 +27,8 @@ class LoadingPageFragment : Fragment() {
     private var animator: ValueAnimator? = null
     private var current = 0 // 진행률 캐시(선택)
 
+    private var backCallback: OnBackPressedCallback? = null
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View {
@@ -42,6 +45,15 @@ class LoadingPageFragment : Fragment() {
         current = 0
 
         animateProgress(to = 90)
+
+        backCallback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                dismissNow() // 로딩 화면 제거
+                requireActivity().supportFragmentManager.popBackStack()
+            }
+        }.also {
+            requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, it)
+        }
     }
 
     private fun animateProgress(to: Int, onEnd: (() -> Unit)? = null) {
@@ -75,10 +87,18 @@ class LoadingPageFragment : Fragment() {
         }
     }
 
+    fun dismissNow() {
+        animator?.cancel()
+        animator = null
+        parentFragmentManager.beginTransaction()
+            .remove(this)
+            .commitAllowingStateLoss()
+    }
+
     override fun onDestroyView() {
+        super.onDestroyView()
         animator?.cancel()
         animator = null
         _binding = null
-        super.onDestroyView()
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #338 

## ✨ 작업 내용
채움활동 탐색 중일 때 뒤로가기 클릭 시 일부 화면이 겹쳐보이는 문제
이전 화면으로 이동했을 때 시간/위치/카테고리 선택값이 초기화되어야하는지의 여부 등은 논의 필요

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] 로딩 화면에서 뒤로가기 클릭 시 화면이 겹쳐보이는 문제가 발생하지 않는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 로딩 페이지에서 시스템 뒤로가기 버튼으로 화면을 닫을 수 있게 개선되었습니다.
  * 즉시 닫힘 동작이 더 안정적으로 처리되어 빠르게 화면이 종료됩니다.

* **버그 수정**
  * 로딩 페이지 종료 시 리소스 정리와 상태 관리가 개선되어 예기치 않은 잔류 상태가 줄어듭니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->