### PR TITLE
[REFACTOR/#342] 빈틈채우기/투두 관련 타임피커 적용

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting02Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting02Fragment.kt
@@ -20,6 +20,8 @@ import com.example.teumteum.data.remote.activity.model.AssignWishRequest
 import com.example.teumteum.databinding.FragmentFillingSetting02Binding
 import com.example.teumteum.ui.activity.viewModel.ActivityViewModel
 import com.example.teumteum.ui.main.HomeFragment
+import com.example.teumteum.utils.AmPmHourMinuteIndex
+import com.example.teumteum.utils.parse24hTimeToPickerValue
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import dagger.hilt.android.AndroidEntryPoint
@@ -171,6 +173,13 @@ class FillingSetting02Fragment : Fragment() {
         minutePicker.displayedValues = minuteValues
         minutePicker.wrapSelectorWheel = true
 
+        parse24hTimeToPickerValue(
+            timeText = targetTextView.text.toString(),
+            minuteOptions = minuteValues
+        )?.let { value ->
+            applyPickerValue(ampmPicker, hourPicker, minutePicker, value)
+        }
+
         val dialog = BottomSheetDialog(requireContext())
         dialog.setContentView(dialogView)
 
@@ -314,6 +323,12 @@ class FillingSetting02Fragment : Fragment() {
         } else {
             startDate to endHHmm
         }
+    }
+
+    private fun applyPickerValue(ampmPicker: NumberPicker, hourPicker: NumberPicker, minutePicker: NumberPicker, value: AmPmHourMinuteIndex) {
+        ampmPicker.value = value.ampmValue
+        hourPicker.value = value.hour12
+        minutePicker.value = value.minuteIndex
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting02Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting02Fragment.kt
@@ -20,7 +20,7 @@ import com.example.teumteum.data.remote.activity.model.AssignWishRequest
 import com.example.teumteum.databinding.FragmentFillingSetting02Binding
 import com.example.teumteum.ui.activity.viewModel.ActivityViewModel
 import com.example.teumteum.ui.main.HomeFragment
-import com.example.teumteum.utils.AmPmHourMinuteIndex
+import com.example.teumteum.utils.applyPickerValue
 import com.example.teumteum.utils.parse24hTimeToPickerValue
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -177,7 +177,11 @@ class FillingSetting02Fragment : Fragment() {
             timeText = targetTextView.text.toString(),
             minuteOptions = minuteValues
         )?.let { value ->
-            applyPickerValue(ampmPicker, hourPicker, minutePicker, value)
+            ampmPicker.applyPickerValue(
+                hourPicker = hourPicker,
+                minutePicker = minutePicker,
+                value = value
+            )
         }
 
         val dialog = BottomSheetDialog(requireContext())
@@ -323,12 +327,6 @@ class FillingSetting02Fragment : Fragment() {
         } else {
             startDate to endHHmm
         }
-    }
-
-    private fun applyPickerValue(ampmPicker: NumberPicker, hourPicker: NumberPicker, minutePicker: NumberPicker, value: AmPmHourMinuteIndex) {
-        ampmPicker.value = value.ampmValue
-        hourPicker.value = value.hour12
-        minutePicker.value = value.minuteIndex
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting03Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting03Fragment.kt
@@ -20,6 +20,8 @@ import com.example.teumteum.data.remote.activity.model.AssignWishRequest
 import com.example.teumteum.databinding.FragmentFillingSetting03Binding
 import com.example.teumteum.ui.activity.viewModel.ActivityViewModel
 import com.example.teumteum.ui.main.HomeFragment
+import com.example.teumteum.utils.applyPickerValue
+import com.example.teumteum.utils.parse24hTimeToPickerValue
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import dagger.hilt.android.AndroidEntryPoint
@@ -146,6 +148,17 @@ class FillingSetting03Fragment : Fragment() {
         minutePicker.maxValue = minuteValues.size - 1
         minutePicker.displayedValues = minuteValues
         minutePicker.wrapSelectorWheel = true
+
+        parse24hTimeToPickerValue(
+            timeText = targetTextView.text.toString(),
+            minuteOptions = minuteValues
+        )?.let { value ->
+            ampmPicker.applyPickerValue(
+                hourPicker = hourPicker,
+                minutePicker = minutePicker,
+                value = value
+            )
+        }
 
         val dialog = BottomSheetDialog(requireContext())
         dialog.setContentView(dialogView)

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
@@ -49,9 +49,11 @@ import com.example.teumteum.databinding.DialogConfirmWishDeleteBinding
 import com.example.teumteum.ui.friend.viewModel.FriendViewModel
 import com.example.teumteum.ui.todo.adapter.TeumProfileAdapter
 import com.example.teumteum.ui.todo.viewModel.TodoViewModel
+import com.example.teumteum.utils.AmPmHourMinuteIndex
 import com.example.teumteum.utils.TimeUtils.combineDateTime
 import com.example.teumteum.utils.disableScroll
 import com.example.teumteum.utils.dpToPx
+import com.example.teumteum.utils.parseKoreanAmPmTimeToPickerValue
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.kizitonwose.calendar.core.CalendarDay
@@ -113,6 +115,8 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
 
     private var _normalTextColor: Int? = null
     private var _normalHintColor: Int? = null
+
+    private val minuteOptions = arrayOf("00", "10", "20", "30", "40", "50")
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -202,10 +206,17 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
             if (isCalendarVisible) {
                 toggleCalendarVisibility(show = false)
             }
+
             val isVisibleNow = binding.timePickerStartContainer.isVisible
             if (isVisibleNow) {
                 applySelectedTime(isStart = true)
+            } else {
+                parseKoreanAmPmTimeToPickerValue(
+                    timeText = binding.startTimeTv.text.toString(),
+                    minuteOptions = minuteOptions
+                )?.let { applyPickerValue(isStart = true, value = it) }
             }
+
             binding.timePickerStartContainer.isVisible = !isVisibleNow
             binding.timePickerEndContainer.isVisible = false
             currentTargetTextView = binding.startTimeTv.takeIf { !isVisibleNow }
@@ -215,10 +226,17 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
             if (isCalendarVisible) {
                 toggleCalendarVisibility(show = false)
             }
+
             val isVisibleNow = binding.timePickerEndContainer.isVisible
             if (isVisibleNow) {
                 applySelectedTime(isStart = false)
+            } else {
+                parseKoreanAmPmTimeToPickerValue(
+                    timeText = binding.endTimeTv.text.toString(),
+                    minuteOptions = minuteOptions
+                )?.let { applyPickerValue(isStart = false, value = it) }
             }
+
             binding.timePickerEndContainer.isVisible = !isVisibleNow
             binding.timePickerStartContainer.isVisible = false
             currentTargetTextView = binding.endTimeTv.takeIf { !isVisibleNow }
@@ -1170,6 +1188,18 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
                 t.context,
                 if (enabled) R.drawable.style_toggle_thumb else R.drawable.style_toggle_disabled_thumb
             )?.mutate()
+        }
+    }
+
+    private fun applyPickerValue(isStart: Boolean, value: AmPmHourMinuteIndex) {
+        if (isStart) {
+            binding.ampmPicker01Np.value = value.ampmValue
+            binding.hourPicker01Np.value = value.hour12
+            binding.minutePicker01Np.value = value.minuteIndex
+        } else {
+            binding.ampmPicker02Np.value = value.ampmValue
+            binding.hourPicker02Np.value = value.hour12
+            binding.minutePicker02Np.value = value.minuteIndex
         }
     }
 

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
@@ -49,8 +49,8 @@ import com.example.teumteum.databinding.DialogConfirmWishDeleteBinding
 import com.example.teumteum.ui.friend.viewModel.FriendViewModel
 import com.example.teumteum.ui.todo.adapter.TeumProfileAdapter
 import com.example.teumteum.ui.todo.viewModel.TodoViewModel
-import com.example.teumteum.utils.AmPmHourMinuteIndex
 import com.example.teumteum.utils.TimeUtils.combineDateTime
+import com.example.teumteum.utils.applyPickerValue
 import com.example.teumteum.utils.disableScroll
 import com.example.teumteum.utils.dpToPx
 import com.example.teumteum.utils.parseKoreanAmPmTimeToPickerValue
@@ -214,7 +214,13 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
                 parseKoreanAmPmTimeToPickerValue(
                     timeText = binding.startTimeTv.text.toString(),
                     minuteOptions = minuteOptions
-                )?.let { applyPickerValue(isStart = true, value = it) }
+                )?.let { v ->
+                    binding.ampmPicker01Np.applyPickerValue(
+                        hourPicker = binding.hourPicker01Np,
+                        minutePicker = binding.minutePicker01Np,
+                        value = v
+                    )
+                }
             }
 
             binding.timePickerStartContainer.isVisible = !isVisibleNow
@@ -234,7 +240,13 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
                 parseKoreanAmPmTimeToPickerValue(
                     timeText = binding.endTimeTv.text.toString(),
                     minuteOptions = minuteOptions
-                )?.let { applyPickerValue(isStart = false, value = it) }
+                )?.let { v ->
+                    binding.ampmPicker02Np.applyPickerValue(
+                        hourPicker = binding.hourPicker02Np,
+                        minutePicker = binding.minutePicker02Np,
+                        value = v
+                    )
+                }
             }
 
             binding.timePickerEndContainer.isVisible = !isVisibleNow
@@ -1188,18 +1200,6 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
                 t.context,
                 if (enabled) R.drawable.style_toggle_thumb else R.drawable.style_toggle_disabled_thumb
             )?.mutate()
-        }
-    }
-
-    private fun applyPickerValue(isStart: Boolean, value: AmPmHourMinuteIndex) {
-        if (isStart) {
-            binding.ampmPicker01Np.value = value.ampmValue
-            binding.hourPicker01Np.value = value.hour12
-            binding.minutePicker01Np.value = value.minuteIndex
-        } else {
-            binding.ampmPicker02Np.value = value.ampmValue
-            binding.hourPicker02Np.value = value.hour12
-            binding.minutePicker02Np.value = value.minuteIndex
         }
     }
 

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
@@ -42,7 +42,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
 import com.example.teumteum.ui.myhome.viewModel.MyHomeViewModel
 import com.example.teumteum.ui.todo.viewModel.TodoViewModel
-import com.example.teumteum.utils.AmPmHourMinuteIndex
+import com.example.teumteum.utils.applyPickerValue
 import com.example.teumteum.utils.disableScroll
 import com.example.teumteum.utils.dpToPx
 import com.example.teumteum.utils.parseKoreanAmPmTimeToPickerValue
@@ -195,7 +195,13 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
                 parseKoreanAmPmTimeToPickerValue(
                     timeText = binding.startTimeTv.text.toString(),
                     minuteOptions = minuteOptions
-                )?.let { applyPickerValue(isStart = true, value = it) }
+                )?.let { v ->
+                    binding.ampmPicker01Np.applyPickerValue(
+                        hourPicker = binding.hourPicker01Np,
+                        minutePicker = binding.minutePicker01Np,
+                        value = v
+                    )
+                }
             }
 
             binding.timePickerStartContainer.isVisible = !isVisibleNow
@@ -215,7 +221,13 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
                 parseKoreanAmPmTimeToPickerValue(
                     timeText = binding.endTimeTv.text.toString(),
                     minuteOptions = minuteOptions
-                )?.let { applyPickerValue(isStart = false, value = it) }
+                )?.let { v ->
+                    binding.ampmPicker02Np.applyPickerValue(
+                        hourPicker = binding.hourPicker02Np,
+                        minutePicker = binding.minutePicker02Np,
+                        value = v
+                    )
+                }
             }
 
             binding.timePickerEndContainer.isVisible = !isVisibleNow
@@ -834,18 +846,6 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
     // DayView의 뷰 홀더
     private inner class DayViewContainer(view: View) : ViewContainer(view) {
         val textView: TextView = view.findViewById(R.id.calendar_day_tv)
-    }
-
-    private fun applyPickerValue(isStart: Boolean, value: AmPmHourMinuteIndex) {
-        if (isStart) {
-            binding.ampmPicker01Np.value = value.ampmValue
-            binding.hourPicker01Np.value = value.hour12
-            binding.minutePicker01Np.value = value.minuteIndex
-        } else {
-            binding.ampmPicker02Np.value = value.ampmValue
-            binding.hourPicker02Np.value = value.hour12
-            binding.minutePicker02Np.value = value.minuteIndex
-        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
@@ -42,8 +42,10 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
 import com.example.teumteum.ui.myhome.viewModel.MyHomeViewModel
 import com.example.teumteum.ui.todo.viewModel.TodoViewModel
+import com.example.teumteum.utils.AmPmHourMinuteIndex
 import com.example.teumteum.utils.disableScroll
 import com.example.teumteum.utils.dpToPx
+import com.example.teumteum.utils.parseKoreanAmPmTimeToPickerValue
 import com.kizitonwose.calendar.core.CalendarDay
 import com.kizitonwose.calendar.core.DayPosition
 import com.kizitonwose.calendar.core.firstDayOfWeekFromLocale
@@ -90,6 +92,8 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
 
     private val viewModel: TodoViewModel by activityViewModels()
     private val myHomeViewModel: MyHomeViewModel by activityViewModels()
+
+    private val minuteOptions = arrayOf("00", "10", "20", "30", "40", "50")
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -183,10 +187,17 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
             if (isCalendarVisible) {
                 toggleCalendarVisibility(show = false)
             }
+
             val isVisibleNow = binding.timePickerStartContainer.isVisible
             if (isVisibleNow) {
                 applySelectedTime(isStart = true)
+            } else {
+                parseKoreanAmPmTimeToPickerValue(
+                    timeText = binding.startTimeTv.text.toString(),
+                    minuteOptions = minuteOptions
+                )?.let { applyPickerValue(isStart = true, value = it) }
             }
+
             binding.timePickerStartContainer.isVisible = !isVisibleNow
             binding.timePickerEndContainer.isVisible = false
             currentTargetTextView = binding.startTimeTv.takeIf { !isVisibleNow }
@@ -196,10 +207,17 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
             if (isCalendarVisible) {
                 toggleCalendarVisibility(show = false)
             }
+
             val isVisibleNow = binding.timePickerEndContainer.isVisible
             if (isVisibleNow) {
                 applySelectedTime(isStart = false)
+            } else {
+                parseKoreanAmPmTimeToPickerValue(
+                    timeText = binding.endTimeTv.text.toString(),
+                    minuteOptions = minuteOptions
+                )?.let { applyPickerValue(isStart = false, value = it) }
             }
+
             binding.timePickerEndContainer.isVisible = !isVisibleNow
             binding.timePickerStartContainer.isVisible = false
             currentTargetTextView = binding.endTimeTv.takeIf { !isVisibleNow }
@@ -816,6 +834,18 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
     // DayView의 뷰 홀더
     private inner class DayViewContainer(view: View) : ViewContainer(view) {
         val textView: TextView = view.findViewById(R.id.calendar_day_tv)
+    }
+
+    private fun applyPickerValue(isStart: Boolean, value: AmPmHourMinuteIndex) {
+        if (isStart) {
+            binding.ampmPicker01Np.value = value.ampmValue
+            binding.hourPicker01Np.value = value.hour12
+            binding.minutePicker01Np.value = value.minuteIndex
+        } else {
+            binding.ampmPicker02Np.value = value.ampmValue
+            binding.hourPicker02Np.value = value.hour12
+            binding.minutePicker02Np.value = value.minuteIndex
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishSetting02Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishSetting02Fragment.kt
@@ -20,6 +20,8 @@ import com.example.teumteum.databinding.FragmentWishSetting02Binding
 import com.example.teumteum.ui.main.HomeFragment
 import com.example.teumteum.ui.main.viewModel.HomeViewModel
 import com.example.teumteum.ui.wish.viewModel.WishViewModel
+import com.example.teumteum.utils.AmPmHourMinuteIndex
+import com.example.teumteum.utils.parse24hTimeToPickerValue
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import dagger.hilt.android.AndroidEntryPoint
@@ -152,6 +154,13 @@ class WishSetting02Fragment : Fragment() {
         minutePicker.displayedValues = minuteValues
         minutePicker.wrapSelectorWheel = true
 
+        parse24hTimeToPickerValue(
+            timeText = targetTextView.text.toString(),
+            minuteOptions = minuteValues
+        )?.let { value ->
+            applyPickerValue(ampmPicker, hourPicker, minutePicker, value)
+        }
+
         val dialog = BottomSheetDialog(requireContext())
         dialog.setContentView(dialogView)
 
@@ -280,6 +289,12 @@ class WishSetting02Fragment : Fragment() {
         } else {
             startDate to endHHmm
         }
+    }
+
+    private fun applyPickerValue(ampmPicker: NumberPicker, hourPicker: NumberPicker, minutePicker: NumberPicker, value: AmPmHourMinuteIndex) {
+        ampmPicker.value = value.ampmValue
+        hourPicker.value = value.hour12
+        minutePicker.value = value.minuteIndex
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishSetting02Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishSetting02Fragment.kt
@@ -20,7 +20,7 @@ import com.example.teumteum.databinding.FragmentWishSetting02Binding
 import com.example.teumteum.ui.main.HomeFragment
 import com.example.teumteum.ui.main.viewModel.HomeViewModel
 import com.example.teumteum.ui.wish.viewModel.WishViewModel
-import com.example.teumteum.utils.AmPmHourMinuteIndex
+import com.example.teumteum.utils.applyPickerValue
 import com.example.teumteum.utils.parse24hTimeToPickerValue
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -158,7 +158,11 @@ class WishSetting02Fragment : Fragment() {
             timeText = targetTextView.text.toString(),
             minuteOptions = minuteValues
         )?.let { value ->
-            applyPickerValue(ampmPicker, hourPicker, minutePicker, value)
+            ampmPicker.applyPickerValue(
+                hourPicker = hourPicker,
+                minutePicker = minutePicker,
+                value = value
+            )
         }
 
         val dialog = BottomSheetDialog(requireContext())
@@ -289,12 +293,6 @@ class WishSetting02Fragment : Fragment() {
         } else {
             startDate to endHHmm
         }
-    }
-
-    private fun applyPickerValue(ampmPicker: NumberPicker, hourPicker: NumberPicker, minutePicker: NumberPicker, value: AmPmHourMinuteIndex) {
-        ampmPicker.value = value.ampmValue
-        hourPicker.value = value.hour12
-        minutePicker.value = value.minuteIndex
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishSetting03Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishSetting03Fragment.kt
@@ -19,6 +19,8 @@ import com.example.teumteum.data.remote.activity.model.AssignWishRequest
 import com.example.teumteum.databinding.FragmentWishSetting03Binding
 import com.example.teumteum.ui.main.HomeFragment
 import com.example.teumteum.ui.wish.viewModel.WishViewModel
+import com.example.teumteum.utils.applyPickerValue
+import com.example.teumteum.utils.parse24hTimeToPickerValue
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import dagger.hilt.android.AndroidEntryPoint
@@ -124,6 +126,17 @@ class WishSetting03Fragment : Fragment() {
         minutePicker.maxValue = minuteValues.size - 1
         minutePicker.displayedValues = minuteValues
         minutePicker.wrapSelectorWheel = true
+
+        parse24hTimeToPickerValue(
+            timeText = targetTextView.text.toString(),
+            minuteOptions = minuteValues
+        )?.let { value ->
+            ampmPicker.applyPickerValue(
+                hourPicker = hourPicker,
+                minutePicker = minutePicker,
+                value = value
+            )
+        }
 
         val dialog = BottomSheetDialog(requireContext())
         dialog.setContentView(dialogView)

--- a/app/src/main/java/com/example/teumteum/utils/TimePickerUtil.kt
+++ b/app/src/main/java/com/example/teumteum/utils/TimePickerUtil.kt
@@ -1,10 +1,22 @@
 package com.example.teumteum.utils
 
+import android.widget.NumberPicker
+
 data class AmPmHourMinuteIndex(
-    val ampmValue: Int,   // 0=오전, 1=오후
+    val ampmValue: Int, // 0=오전, 1=오후
     val hour12: Int,
     val minuteIndex: Int
 )
+
+fun NumberPicker.applyPickerValue(
+    hourPicker: NumberPicker,
+    minutePicker: NumberPicker,
+    value: AmPmHourMinuteIndex
+) {
+    this.value = value.ampmValue
+    hourPicker.value = value.hour12
+    minutePicker.value = value.minuteIndex
+}
 
 fun parseKoreanAmPmTimeToPickerValue(
     timeText: String,

--- a/app/src/main/java/com/example/teumteum/utils/TimePickerUtil.kt
+++ b/app/src/main/java/com/example/teumteum/utils/TimePickerUtil.kt
@@ -1,0 +1,36 @@
+package com.example.teumteum.utils
+
+data class AmPmHourMinuteIndex(
+    val ampmValue: Int,   // 0=오전, 1=오후
+    val hour12: Int,
+    val minuteIndex: Int
+)
+
+fun parseKoreanAmPmTimeToPickerValue(
+    timeText: String,
+    minuteOptions: Array<String> = arrayOf("00", "10", "20", "30", "40", "50"),
+    startPlaceholder: String = "시작 시간",
+    endPlaceholder: String = "종료 시간"
+): AmPmHourMinuteIndex? {
+    val t = timeText.trim()
+    if (t.isEmpty() || t == startPlaceholder || t == endPlaceholder) return null
+
+    val parts = t.split(" ")
+    if (parts.size < 2) return null
+
+    val ampmStr = parts[0]
+    val hm = parts[1].split(":")
+    if (hm.size < 2) return null
+
+    val hour12 = hm[0].toIntOrNull() ?: return null
+    val minuteStr = hm[1].padStart(2, '0')
+
+    val ampmValue = if (ampmStr == "오후") 1 else 0
+    val minuteIndex = minuteOptions.indexOf(minuteStr).takeIf { it >= 0 } ?: 0
+
+    return AmPmHourMinuteIndex(
+        ampmValue = ampmValue,
+        hour12 = hour12.coerceIn(1, 12),
+        minuteIndex = minuteIndex
+    )
+}

--- a/app/src/main/java/com/example/teumteum/utils/TimePickerUtil.kt
+++ b/app/src/main/java/com/example/teumteum/utils/TimePickerUtil.kt
@@ -34,3 +34,28 @@ fun parseKoreanAmPmTimeToPickerValue(
         minuteIndex = minuteIndex
     )
 }
+
+fun parse24hTimeToPickerValue(
+    timeText: String,
+    minuteOptions: Array<String> = arrayOf("00", "10", "20", "30", "40", "50")
+): AmPmHourMinuteIndex? {
+    val t = timeText.trim()
+    if (t.isEmpty()) return null
+
+    val hm = t.split(":")
+    if (hm.size < 2) return null
+
+    val hour24 = hm[0].toIntOrNull() ?: return null
+    val minuteStr = hm[1].padStart(2, '0')
+    val minuteIndex = minuteOptions.indexOf(minuteStr).takeIf { it >= 0 } ?: 0
+
+    val ampmValue = if (hour24 >= 12) 1 else 0
+    var hour12 = hour24 % 12
+    if (hour12 == 0) hour12 = 12
+
+    return AmPmHourMinuteIndex(
+        ampmValue = ampmValue,
+        hour12 = hour12.coerceIn(1, 12),
+        minuteIndex = minuteIndex
+    )
+}


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #342 

## ✨ 작업 내용
> 기존에 설정한 시간대가 빈틈채우기/투두에서 타임피커 클릭 시 적용되어 있도록 수정하였습니다.

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] 타임피커에서 시간 설정 후 다시 클릭하면 설정한 시간이 적용되어 있는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선사항**
  * 시간 선택기가 기존에 표시된 시간을 자동으로 불러와 초기값으로 채워줍니다.
  * 24시간 형식과 한국식 오전/오후 표기를 모두 인식해 파싱합니다.
  * 분 단위를 10분 단위로 처리하여 일관된 선택 경험을 제공합니다.
  * 설정, 할일, 위시 등 관련 화면에서 시간 처리 동작이 통일되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->