### PR TITLE
[REFACTOR/#339] 바텀시트 관련 수정

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
@@ -730,7 +730,6 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
                 val behavior = BottomSheetBehavior.from(it)
                 behavior.peekHeight = desiredHeight
                 behavior.state = BottomSheetBehavior.STATE_COLLAPSED
-                behavior.isDraggable = false // 확장 불가능
             }
         }
     }

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
@@ -91,6 +91,10 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
     private val viewModel: TodoViewModel by activityViewModels()
     private val myHomeViewModel: MyHomeViewModel by activityViewModels()
 
+    private var bottomSheetView: View? = null
+    private var downY = 0f
+    private var dragging = false
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -642,7 +646,6 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
                 val behavior = BottomSheetBehavior.from(it)
                 behavior.peekHeight = desiredHeight
                 behavior.state = BottomSheetBehavior.STATE_COLLAPSED
-                behavior.isDraggable = false // 확장 불가능
             }
         }
     }

--- a/app/src/main/java/com/example/teumteum/ui/wish/BottomSheetWishEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/BottomSheetWishEditFragment.kt
@@ -203,7 +203,6 @@ class BottomSheetWishEditFragment : BottomSheetDialogFragment() {
                 val behavior = BottomSheetBehavior.from(it)
                 behavior.peekHeight = desiredHeight
                 behavior.state = BottomSheetBehavior.STATE_COLLAPSED
-                behavior.isDraggable = false // 확장 불가능
             }
         }
     }

--- a/app/src/main/java/com/example/teumteum/ui/wish/BottomSheetWishRegisterFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/BottomSheetWishRegisterFragment.kt
@@ -182,7 +182,6 @@ class BottomSheetWishRegisterFragment : BottomSheetDialogFragment() {
                 val behavior = BottomSheetBehavior.from(it)
                 behavior.peekHeight = desiredHeight
                 behavior.state = BottomSheetBehavior.STATE_COLLAPSED
-                behavior.isDraggable = false // 확장 불가능
             }
         }
     }

--- a/app/src/main/res/layout/bottom_sheet_todo_edit.xml
+++ b/app/src/main/res/layout/bottom_sheet_todo_edit.xml
@@ -494,7 +494,7 @@
                 android:src="@drawable/ic_horizon_sv" />
 
             <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/detail_text_ll"
+                android:id="@+id/detail_text_cl"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="20dp"

--- a/app/src/main/res/layout/bottom_sheet_todo_edit.xml
+++ b/app/src/main/res/layout/bottom_sheet_todo_edit.xml
@@ -493,27 +493,27 @@
                 android:scaleType="centerCrop"
                 android:src="@drawable/ic_horizon_sv" />
 
-            <LinearLayout
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/detail_text_ll"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
+                android:layout_marginTop="20dp"
                 android:layout_marginBottom="40dp"
-                android:orientation="horizontal"
                 android:padding="5dp">
 
                 <ImageView
                     android:id="@+id/detail_text_iv"
                     android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:layout_marginEnd="8dp"
-                    android:contentDescription="상세 내용"
-                    android:src="@drawable/ic_detail_text_sv" />
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_detail_text_sv"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/detail_text_et"/>
 
                 <EditText
                     android:id="@+id/detail_text_et"
-                    android:layout_width="match_parent"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
                     android:background="@color/transparent"
                     android:fontFamily="@font/noto_sans_kr_regular"
                     android:gravity="top|start"
@@ -522,9 +522,14 @@
                     android:maxLines="5"
                     android:minHeight="28dp"
                     android:textColorHint="@color/text_primary"
-                    android:textSize="15sp" />
+                    android:textSize="15sp"
+                    android:includeFontPadding="false"
+                    android:padding="0dp"
+                    app:layout_constraintStart_toEndOf="@id/detail_text_iv"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"/>
 
-            </LinearLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/bottom_sheet_todo_register.xml
+++ b/app/src/main/res/layout/bottom_sheet_todo_register.xml
@@ -506,7 +506,7 @@
                 android:src="@drawable/ic_horizon_sv" />
 
             <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/detail_text_ll"
+                android:id="@+id/detail_text_cl"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="20dp"

--- a/app/src/main/res/layout/bottom_sheet_todo_register.xml
+++ b/app/src/main/res/layout/bottom_sheet_todo_register.xml
@@ -505,27 +505,27 @@
                 android:scaleType="centerCrop"
                 android:src="@drawable/ic_horizon_sv" />
 
-            <LinearLayout
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/detail_text_ll"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
+                android:layout_marginTop="20dp"
                 android:layout_marginBottom="40dp"
-                android:orientation="horizontal"
                 android:padding="5dp">
 
                 <ImageView
                     android:id="@+id/detail_text_iv"
                     android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:layout_marginEnd="8dp"
-                    android:contentDescription="상세 내용"
-                    android:src="@drawable/ic_detail_text_sv" />
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_detail_text_sv"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/detail_text_et"/>
 
                 <EditText
                     android:id="@+id/detail_text_et"
-                    android:layout_width="match_parent"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
                     android:background="@color/transparent"
                     android:fontFamily="@font/noto_sans_kr_regular"
                     android:gravity="top|start"
@@ -534,9 +534,14 @@
                     android:maxLines="5"
                     android:minHeight="28dp"
                     android:textColorHint="@color/text_primary"
-                    android:textSize="15sp" />
+                    android:textSize="15sp"
+                    android:includeFontPadding="false"
+                    android:padding="0dp"
+                    app:layout_constraintStart_toEndOf="@id/detail_text_iv"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"/>
 
-            </LinearLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/bottom_sheet_wish_edit.xml
+++ b/app/src/main/res/layout/bottom_sheet_wish_edit.xml
@@ -121,7 +121,7 @@
                 </LinearLayout>
 
                 <androidx.constraintlayout.widget.ConstraintLayout
-                    android:id="@+id/detail_text_ll"
+                    android:id="@+id/detail_text_cl"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="10dp"

--- a/app/src/main/res/layout/bottom_sheet_wish_edit.xml
+++ b/app/src/main/res/layout/bottom_sheet_wish_edit.xml
@@ -120,24 +120,26 @@
 
                 </LinearLayout>
 
-                <LinearLayout
-                    android:id="@+id/wish_detail_ll"
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/detail_text_ll"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="-3dp"
-                    android:gravity="center_vertical"
-                    android:orientation="horizontal">
+                    android:layout_marginTop="10dp"
+                    android:layout_marginBottom="-3dp">
 
                     <ImageView
+                        android:id="@+id/detail_text_iv"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginEnd="8dp"
-                        android:src="@drawable/ic_detail_text_sv" />
+                        android:src="@drawable/ic_detail_text_sv"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="@id/detail_text_et"/>
 
                     <EditText
                         android:id="@+id/detail_text_et"
-                        android:layout_width="match_parent"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
                         android:background="@color/transparent"
                         android:fontFamily="@font/noto_sans_kr_regular"
                         android:gravity="top|start"
@@ -146,9 +148,14 @@
                         android:maxLines="5"
                         android:minHeight="28dp"
                         android:textColorHint="@color/text_primary"
-                        android:textSize="15sp" />
+                        android:textSize="15sp"
+                        android:includeFontPadding="false"
+                        android:padding="0dp"
+                        app:layout_constraintStart_toEndOf="@id/detail_text_iv"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"/>
 
-                </LinearLayout>
+                </androidx.constraintlayout.widget.ConstraintLayout>
             </LinearLayout>
 
             <ImageView

--- a/app/src/main/res/layout/bottom_sheet_wish_register.xml
+++ b/app/src/main/res/layout/bottom_sheet_wish_register.xml
@@ -133,7 +133,7 @@
                 </LinearLayout>
 
                 <androidx.constraintlayout.widget.ConstraintLayout
-                    android:id="@+id/detail_text_ll"
+                    android:id="@+id/detail_text_cl"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="10dp"

--- a/app/src/main/res/layout/bottom_sheet_wish_register.xml
+++ b/app/src/main/res/layout/bottom_sheet_wish_register.xml
@@ -132,24 +132,26 @@
 
                 </LinearLayout>
 
-                <LinearLayout
-                    android:id="@+id/wish_detail_ll"
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/detail_text_ll"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="-3dp"
-                    android:gravity="center_vertical"
-                    android:orientation="horizontal">
+                    android:layout_marginTop="10dp"
+                    android:layout_marginBottom="-3dp">
 
                     <ImageView
+                        android:id="@+id/detail_text_iv"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginEnd="8dp"
-                        android:src="@drawable/ic_detail_text_sv" />
+                        android:src="@drawable/ic_detail_text_sv"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="@id/detail_text_et"/>
 
                     <EditText
                         android:id="@+id/detail_text_et"
-                        android:layout_width="match_parent"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
                         android:background="@color/transparent"
                         android:fontFamily="@font/noto_sans_kr_regular"
                         android:gravity="top|start"
@@ -158,9 +160,14 @@
                         android:maxLines="5"
                         android:minHeight="28dp"
                         android:textColorHint="@color/text_primary"
-                        android:textSize="15sp" />
+                        android:textSize="15sp"
+                        android:includeFontPadding="false"
+                        android:padding="0dp"
+                        app:layout_constraintStart_toEndOf="@id/detail_text_iv"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"/>
 
-                </LinearLayout>
+                </androidx.constraintlayout.widget.ConstraintLayout>
             </LinearLayout>
 
             <ImageView


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #339 

## ✨ 작업 내용
바텀시트 상단 바를 아래로 스크롤하면 바텀시트가 닫히도록 작업하였으며, 상세내용 입력 시 아이콘과 상세내용 첫줄이 정렬되도록 수정하였습니다. 
작업 체크리스트에 작성해놓은 `제목/상세내용 입력 후 엔터키를 누르면 줄 변경이 아닌 입력 완료가 되도록` 관련해서는 현재 제목과 상세내용이 edittext로 구성되어 있는데 input타입을 textmultiline으로 설정하면 엔터키 -> 완료 텍스트로 변경 불가, text로 설정하면 엔터키 -> 완료 텍스트로 변경은 가능하지만 글을 길게 작성하면 자동으로 줄바꿈되지 않기 때문에.. 해당 부분은 조금 더 찾아보고 이슈를 따로 생성하여 작업할 것 같습니다.

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] 상세 내용 입력 시 아이콘과 정렬이 되어있는지
- [ ] 바텀시트 상단바를 아래로 스크롤하면 닫히는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  - 할일 및 희망사항 화면의 바텀 시트를 드래그로 확장/축소할 수 있게 변경하여 사용자 상호작용을 개선했습니다.

* **Style**
  - 상세 내용 입력 영역을 제약 기반 레이아웃으로 재구성해 아이콘과 텍스트 필드 정렬을 최적화하고 여백/패딩을 조정했습니다.
  - 입력 행에 아이콘을 추가해 가독성과 시각적 안내를 강화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->