### PR TITLE
[Feat/#333] 수면패턴 삭제, 틈 요청 수락시 겹치는 투두 확인

### DIFF
--- a/app/src/main/java/com/example/teumteum/data/remote/friend/model/TodoConflictResponse.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/friend/model/TodoConflictResponse.kt
@@ -2,7 +2,7 @@ package com.example.teumteum.data.remote.friend.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 data class TodoConflictResponse(
     @SerializedName("hasConflict") val hasConflict: Boolean,

--- a/app/src/main/java/com/example/teumteum/data/remote/friend/model/TodoConflictResponse.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/friend/model/TodoConflictResponse.kt
@@ -1,0 +1,18 @@
+package com.example.teumteum.data.remote.friend.model
+
+import android.os.Parcelable
+import com.google.gson.annotations.SerializedName
+import kotlinx.android.parcel.Parcelize
+
+data class TodoConflictResponse(
+    @SerializedName("hasConflict") val hasConflict: Boolean,
+    @SerializedName("conflictingSchedules") val conflictingSchedules: List<TodoConflictItem>
+)
+
+@Parcelize
+data class TodoConflictItem(
+    @SerializedName("id") val id: Int,
+    @SerializedName("title") val title: String,
+    @SerializedName("startTime") val startTime: String,
+    @SerializedName("endTime") val endTime: String
+) : Parcelable

--- a/app/src/main/java/com/example/teumteum/data/remote/friend/repository/FriendRepository.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/friend/repository/FriendRepository.kt
@@ -1,7 +1,31 @@
 package com.example.teumteum.data.remote.friend.repository
 
 import android.util.Log
-import com.example.teumteum.data.remote.friend.model.*
+import com.example.teumteum.data.remote.friend.model.CancelTeumResult
+import com.example.teumteum.data.remote.friend.model.FavoriteRequest
+import com.example.teumteum.data.remote.friend.model.FavoriteResult
+import com.example.teumteum.data.remote.friend.model.FollowerResult
+import com.example.teumteum.data.remote.friend.model.FollowingResult
+import com.example.teumteum.data.remote.friend.model.FriendProfileResult
+import com.example.teumteum.data.remote.friend.model.FriendSearchResult
+import com.example.teumteum.data.remote.friend.model.MutualFriendItem
+import com.example.teumteum.data.remote.friend.model.PagingResponse
+import com.example.teumteum.data.remote.friend.model.PossibleTimeRequest
+import com.example.teumteum.data.remote.friend.model.PossibleTimeResult
+import com.example.teumteum.data.remote.friend.model.PublicTodoResult
+import com.example.teumteum.data.remote.friend.model.ResendTeumRequest
+import com.example.teumteum.data.remote.friend.model.ResendTeumResult
+import com.example.teumteum.data.remote.friend.model.SharedTeumItem
+import com.example.teumteum.data.remote.friend.model.TeumConflictResponse
+import com.example.teumteum.data.remote.friend.model.TeumReceivedItem
+import com.example.teumteum.data.remote.friend.model.TeumRequest
+import com.example.teumteum.data.remote.friend.model.TeumRequestDateResult
+import com.example.teumteum.data.remote.friend.model.TeumScheduleDetailResult
+import com.example.teumteum.data.remote.friend.model.TeumScheduledResult
+import com.example.teumteum.data.remote.friend.model.TeumStatusRequest
+import com.example.teumteum.data.remote.friend.model.TeumStatusResult
+import com.example.teumteum.data.remote.friend.model.TeumTimeResult
+import com.example.teumteum.data.remote.friend.model.TodoConflictResponse
 import com.example.teumteum.data.remote.friend.service.FriendService
 import com.example.teumteum.utils.ApiResponse
 import com.example.teumteum.utils.handleApiResponse
@@ -410,6 +434,26 @@ class FriendRepository @Inject constructor(
         endTime: String
     ): Result<TeumConflictResponse> = runCatching {
         val response = api.checkTeumConflict(date, startTime, endTime)
+        val body = response.body()
+
+        if (!response.isSuccessful || body == null) {
+            throw Exception("HTTP ${response.code()} - ${response.errorBody()?.string() ?: response.message()}")
+        }
+
+        if (body.isSuccess && body.result != null) {
+            body.result
+        } else {
+            throw Exception("${body.code} - ${body.message}")
+        }
+    }
+
+    // 틈 요청 시 겹치는 틈 요청 조회
+    suspend fun checkTodoConflict(
+        date: String,
+        startTime: String,
+        endTime: String
+    ): Result<TodoConflictResponse> = runCatching {
+        val response = api.checkTodoConflict(date, startTime, endTime)
         val body = response.body()
 
         if (!response.isSuccessful || body == null) {

--- a/app/src/main/java/com/example/teumteum/data/remote/friend/service/FriendService.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/friend/service/FriendService.kt
@@ -1,7 +1,31 @@
 package com.example.teumteum.data.remote.friend.service
 
+import com.example.teumteum.data.remote.friend.model.CancelTeumResult
+import com.example.teumteum.data.remote.friend.model.FavoriteRequest
+import com.example.teumteum.data.remote.friend.model.FavoriteResult
+import com.example.teumteum.data.remote.friend.model.FollowerResult
+import com.example.teumteum.data.remote.friend.model.FollowingResult
+import com.example.teumteum.data.remote.friend.model.FriendProfileResult
+import com.example.teumteum.data.remote.friend.model.FriendSearchResult
+import com.example.teumteum.data.remote.friend.model.MutualFriendResult
+import com.example.teumteum.data.remote.friend.model.PagingResponse
+import com.example.teumteum.data.remote.friend.model.PossibleTimeRequest
+import com.example.teumteum.data.remote.friend.model.PossibleTimeResult
+import com.example.teumteum.data.remote.friend.model.PublicTodoResult
+import com.example.teumteum.data.remote.friend.model.ResendTeumRequest
+import com.example.teumteum.data.remote.friend.model.ResendTeumResult
+import com.example.teumteum.data.remote.friend.model.SharedTeumListResult
+import com.example.teumteum.data.remote.friend.model.TeumConflictResponse
+import com.example.teumteum.data.remote.friend.model.TeumReceivedResult
+import com.example.teumteum.data.remote.friend.model.TeumRequest
+import com.example.teumteum.data.remote.friend.model.TeumRequestDateResult
+import com.example.teumteum.data.remote.friend.model.TeumScheduleDetailResult
+import com.example.teumteum.data.remote.friend.model.TeumScheduledResult
+import com.example.teumteum.data.remote.friend.model.TeumStatusRequest
+import com.example.teumteum.data.remote.friend.model.TeumStatusResult
+import com.example.teumteum.data.remote.friend.model.TeumTimeResult
+import com.example.teumteum.data.remote.friend.model.TodoConflictResponse
 import com.example.teumteum.utils.ApiResponse
-import com.example.teumteum.data.remote.friend.model.*
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -167,4 +191,11 @@ interface FriendService {
         @Query("startTime") startTime: String, // HH:MM
         @Query("endTime") endTime: String      // HH:MM
     ): Response<ApiResponse<TeumConflictResponse>>
+
+    @GET("/api/teums/conflicts")
+    suspend fun checkTodoConflict(
+        @Query("date") date: String,      // YYYY-MM-DD
+        @Query("startTime") startTime: String, // HH:MM
+        @Query("endTime") endTime: String      // HH:MM
+    ): Response<ApiResponse<TodoConflictResponse>>
 }

--- a/app/src/main/java/com/example/teumteum/data/remote/mypage/repository/SettingRepository.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/mypage/repository/SettingRepository.kt
@@ -41,4 +41,11 @@ class SettingRepository @Inject constructor(
         Log.d("Setting", "response = ${response.body()}")
         handleApiResponse(response)
     }
+
+    //수면패턴 삭제
+    suspend fun deleteSleepPattern(): Result<Unit> = runCatching {
+        val response = settingService.deleteSleepPattern()
+        Log.d("Setting", "response = ${response.body()}")
+        handleApiResponse(response)
+    }
 }

--- a/app/src/main/java/com/example/teumteum/data/remote/mypage/repository/SettingRepository.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/mypage/repository/SettingRepository.kt
@@ -7,6 +7,7 @@ import com.example.teumteum.data.remote.mypage.model.RemindAlarmResponse
 import com.example.teumteum.data.remote.mypage.service.SettingService
 import com.example.teumteum.data.remote.onboarding.model.SleepPatternRequest
 import com.example.teumteum.utils.handleApiResponse
+import com.example.teumteum.utils.handleApiResponseUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -46,6 +47,6 @@ class SettingRepository @Inject constructor(
     suspend fun deleteSleepPattern(): Result<Unit> = runCatching {
         val response = settingService.deleteSleepPattern()
         Log.d("Setting", "response = ${response.body()}")
-        handleApiResponse(response)
+        handleApiResponseUnit(response)
     }
 }

--- a/app/src/main/java/com/example/teumteum/data/remote/mypage/service/SettingService.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/mypage/service/SettingService.kt
@@ -7,6 +7,7 @@ import com.example.teumteum.data.remote.onboarding.model.SleepPatternRequest
 import com.example.teumteum.utils.ApiResponse
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 
@@ -22,4 +23,7 @@ interface SettingService {
 
     @PATCH("/api/users/mypage/sleep-pattern")
     suspend fun updateSleepPattern(@Body sleepPattern: SleepPatternRequest): Response<ApiResponse<Unit>>
+
+    @DELETE("/api/users/mypage/sleep-pattern")
+    suspend fun deleteSleepPattern(): Response<ApiResponse<Unit>>
 }

--- a/app/src/main/java/com/example/teumteum/ui/friend/Friend02RequestFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/Friend02RequestFragment.kt
@@ -19,7 +19,6 @@ import com.example.teumteum.ui.myhome.MyProfileFragment
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-import kotlin.getValue
 
 @AndroidEntryPoint
 class Friend02RequestFragment : Fragment() {
@@ -31,6 +30,9 @@ class Friend02RequestFragment : Fragment() {
     private val viewModel: FriendViewModel by activityViewModels()
 
     var teumList: List<TeumReceivedItem> = emptyList()
+
+    private var pendingAcceptResponseId: Int? = null
+
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -84,13 +86,42 @@ class Friend02RequestFragment : Fragment() {
         // 6. 인디케이터
         binding.dotsIndicator.setViewPager2(binding.requestViewPager)
 
+        viewModel.todoConflict.observe(viewLifecycleOwner) { response ->
+            val responseId = pendingAcceptResponseId ?: return@observe
+            pendingAcceptResponseId = null
+
+            if (response == null) return@observe
+
+            if (response.hasConflict) {
+                // ✅ 겹침 있음 → 다른 바텀시트
+                val conflictList = ArrayList(response.conflictingSchedules)
+                val bottomSheet = FriendTodoBottomSheetFragment.newInstance(responseId, conflictList)
+                bottomSheet.show(parentFragmentManager, bottomSheet.tag)
+            } else {
+                // ✅ 겹침 없음 → 기존 수락 바텀시트
+                val bottomSheet = Friend02AcceptBottomSheetFragment.newInstance(responseId)
+                bottomSheet.show(parentFragmentManager, bottomSheet.tag)
+            }
+        }
+
+
         // 7. 버튼 이벤트
         binding.btnAccept.setOnClickListener {
             val currentItem = binding.requestViewPager.currentItem
             val responseId = teumList.getOrNull(currentItem)?.responseId ?: return@setOnClickListener
 
-            val bottomSheet = Friend02AcceptBottomSheetFragment.newInstance(responseId)
-            bottomSheet.show(parentFragmentManager, bottomSheet.tag)
+            val teum = teumList.getOrNull(currentItem)
+            val date = teum?.date.toString()
+            val start = teum?.timeSlot?.start.toString()
+            val end = teum?.timeSlot?.end.toString()
+
+//            viewModel.checkTodoConflict(date, start, end)
+//
+//            val bottomSheet = Friend02AcceptBottomSheetFragment.newInstance(responseId)
+//            bottomSheet.show(parentFragmentManager, bottomSheet.tag)
+
+            pendingAcceptResponseId = responseId
+            viewModel.checkTodoConflict(date, start, end)
         }
 
         binding.btnReject.setOnClickListener {

--- a/app/src/main/java/com/example/teumteum/ui/friend/Friend02RequestFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/Friend02RequestFragment.kt
@@ -115,11 +115,6 @@ class Friend02RequestFragment : Fragment() {
             val start = teum?.timeSlot?.start.toString()
             val end = teum?.timeSlot?.end.toString()
 
-//            viewModel.checkTodoConflict(date, start, end)
-//
-//            val bottomSheet = Friend02AcceptBottomSheetFragment.newInstance(responseId)
-//            bottomSheet.show(parentFragmentManager, bottomSheet.tag)
-
             pendingAcceptResponseId = responseId
             viewModel.checkTodoConflict(date, start, end)
         }

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendTodoBottomSheetFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendTodoBottomSheetFragment.kt
@@ -5,20 +5,25 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.viewpager2.widget.ViewPager2
+import androidx.fragment.app.activityViewModels
 import com.example.teumteum.R
+import com.example.teumteum.data.remote.friend.model.TodoConflictItem
+import com.example.teumteum.databinding.BottomSheetFriendTodoBinding
 import com.example.teumteum.ui.friend.adapter.TodoEventAdapter
 import com.example.teumteum.ui.friend.data.TeumEvent
+import com.example.teumteum.ui.friend.viewModel.FriendViewModel
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import com.google.android.material.button.MaterialButton
-import com.tbuonomo.viewpagerdotsindicator.DotsIndicator
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class FriendTodoBottomSheetFragment : BottomSheetDialogFragment() {
 
-    private lateinit var viewPager: ViewPager2
+    private var _binding: BottomSheetFriendTodoBinding? = null
+    private val binding get() = _binding!!
+
     private lateinit var adapter: TodoEventAdapter
-    private lateinit var dotsIndicator: DotsIndicator
+    private val viewModel: FriendViewModel by activityViewModels()
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialog = super.onCreateDialog(savedInstanceState) as BottomSheetDialog
@@ -34,32 +39,60 @@ class FriendTodoBottomSheetFragment : BottomSheetDialogFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        val view = inflater.inflate(R.layout.bottom_sheet_friend_todo, container, false)
+    ): View {
+        _binding = BottomSheetFriendTodoBinding.inflate(inflater, container, false)
+        return binding.root
+    }
 
-        viewPager = view.findViewById(R.id.existingTodoViewPager)
-        dotsIndicator = view.findViewById(R.id.dotsIndicator)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
-        // 샘플 데이터
-        val sampleList = listOf(
-            TeumEvent("12:00", "14:30", "강아지 산책 가자"),
-            TeumEvent("15:00", "16:00", "회의"),
-            TeumEvent("17:30", "18:30", "홍대 소품샵 투어")
-        )
+        val conflictList: ArrayList<TodoConflictItem> =
+            arguments?.getParcelableArrayList(ARG_CONFLICT_LIST) ?: arrayListOf()
 
-
-        adapter = TodoEventAdapter(sampleList)
-        viewPager.adapter = adapter
-
-        // DotsIndicator 연결
-        dotsIndicator.setViewPager2(viewPager)
-
-        // 버튼 클릭
-        view.findViewById<MaterialButton>(R.id.btnCancel).setOnClickListener { dismiss() }
-        view.findViewById<MaterialButton>(R.id.btnAccept).setOnClickListener {
-            // 수락 처리
+        val events: List<TeumEvent> = conflictList.map {
+            TeumEvent(it.startTime, it.endTime, it.title)
         }
 
-        return view
+        adapter = TodoEventAdapter(events)
+        binding.existingTodoViewPager.adapter = adapter
+        binding.dotsIndicator.setViewPager2(binding.existingTodoViewPager)
+
+        binding.btnCancel.setOnClickListener { dismiss() }
+
+        binding.btnAccept.setOnClickListener {
+            val responseId = arguments?.getInt(ARG_RESPONSE_ID) ?: return@setOnClickListener
+
+            viewModel.respondToTeum(responseId, "accepted")
+
+            dismiss()
+
+            parentFragmentManager.beginTransaction()
+                .replace(R.id.main_frm, FriendSendFragment())
+                .addToBackStack(null)
+                .commit()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        private const val ARG_RESPONSE_ID = "responseId"
+        private const val ARG_CONFLICT_LIST = "conflictList"
+
+        fun newInstance(
+            responseId: Int,
+            conflictList: ArrayList<TodoConflictItem>
+        ): FriendTodoBottomSheetFragment {
+            return FriendTodoBottomSheetFragment().apply {
+                arguments = Bundle().apply {
+                    putInt(ARG_RESPONSE_ID, responseId)
+                    putParcelableArrayList(ARG_CONFLICT_LIST, conflictList)
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/teumteum/ui/friend/viewModel/FriendViewModel.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/viewModel/FriendViewModel.kt
@@ -6,18 +6,32 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.teumteum.data.AppUserManager
-import com.example.teumteum.data.remote.friend.model.*
+import com.example.teumteum.data.remote.friend.model.FollowerResult
+import com.example.teumteum.data.remote.friend.model.FollowingResult
+import com.example.teumteum.data.remote.friend.model.FriendProfileResult
+import com.example.teumteum.data.remote.friend.model.FriendSearchResult
+import com.example.teumteum.data.remote.friend.model.MutualFriendItem
+import com.example.teumteum.data.remote.friend.model.PossibleTimeRequest
+import com.example.teumteum.data.remote.friend.model.PublicTodoResult
+import com.example.teumteum.data.remote.friend.model.ResendTeumRequest
+import com.example.teumteum.data.remote.friend.model.SharedTeumItem
+import com.example.teumteum.data.remote.friend.model.TeumConflictResponse
+import com.example.teumteum.data.remote.friend.model.TeumReceivedItem
+import com.example.teumteum.data.remote.friend.model.TeumRequest
+import com.example.teumteum.data.remote.friend.model.TeumRequestDateResult
+import com.example.teumteum.data.remote.friend.model.TeumScheduleDetailResult
+import com.example.teumteum.data.remote.friend.model.TeumScheduledResult
+import com.example.teumteum.data.remote.friend.model.TeumStatusResult
+import com.example.teumteum.data.remote.friend.model.TeumTimeResult
+import com.example.teumteum.data.remote.friend.model.TodoConflictResponse
 import com.example.teumteum.data.remote.friend.repository.FriendRepository
 import com.example.teumteum.data.remote.mypage.repository.MyPageRepository
 import com.example.teumteum.ui.friend.data.SelectedTime
-
+import com.example.teumteum.ui.friend.data.TimeCardItem
 import com.example.teumteum.utils.Event
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-
-import com.example.teumteum.ui.friend.data.TimeCardItem
-
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import java.text.Collator
 import java.time.LocalDate
@@ -947,6 +961,36 @@ class FriendViewModel @Inject constructor(
                     )
 
                     _teumConflict.value = response
+                }
+                .onFailure { e ->
+                    Log.e(
+                        "TEUM4001",
+                        "API 실패 → ${e.message}",
+                        e
+                    )
+                }
+        }
+    }
+
+    // 틈 요청 시 겹치는 투두 요청 조회
+    private val _todoConflict = MutableLiveData<TodoConflictResponse?>()
+    val todoConflict: LiveData<TodoConflictResponse?> get() = _todoConflict
+
+    fun checkTodoConflict(
+        date: String,
+        startTime: String,
+        endTime: String
+    ) {
+        viewModelScope.launch {
+            repository.checkTodoConflict(date, startTime, endTime)
+                .onSuccess { response ->
+                    Log.d(
+                        "TEUM2016",
+                        "API 성공 → hasConflict=${response.hasConflict}, " +
+                                "listSize=${response.conflictingSchedules.size}"
+                    )
+
+                    _todoConflict.value = response
                 }
                 .onFailure { e ->
                     Log.e(

--- a/app/src/main/java/com/example/teumteum/ui/main/viewModel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/teumteum/ui/main/viewModel/HomeViewModel.kt
@@ -12,6 +12,7 @@ import com.example.teumteum.ui.main.data.TimeType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
@@ -20,11 +21,19 @@ class HomeViewModel @Inject constructor(
     private val repository: HomeRepository
 ) : ViewModel() {
 
+    private val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+
     private val _scheduleList = MutableLiveData<List<TimeBlock>>(emptyList())
     val scheduleList: LiveData<List<TimeBlock>> = _scheduleList
 
     private val _sleepTimeList = MutableLiveData<List<TimeBlock>>(emptyList())
     val sleepTimeList: LiveData<List<TimeBlock>> = _sleepTimeList
+
+    private val _sleepStartTime = MutableLiveData<LocalTime>()
+    val sleepStartTime: LiveData<LocalTime> = _sleepStartTime
+
+    private val _sleepEndTime = MutableLiveData<LocalTime>()
+    val sleepEndTime: LiveData<LocalTime> = _sleepEndTime
 
     private val _todoTimeList = MutableLiveData<List<TimeBlock>>(emptyList())
     val todoTimeList: LiveData<List<TimeBlock>> = _todoTimeList
@@ -97,6 +106,7 @@ class HomeViewModel @Inject constructor(
                     _sleepTimeList.value = result.sleep.map {
                         val start = timeToMinutes(it.startTime)
                         val end = timeToMinutes(it.endTime)
+                        setSleepTime(it.startTime, it.endTime)
                         TimeBlock(start, end, TimeType.SLEEP)
                     }
 
@@ -143,6 +153,12 @@ class HomeViewModel @Inject constructor(
         date = currentDate
 //        getTodaySchedule(currentDate)
         getTimetable(currentDate)
+    }
+
+    private fun setSleepTime(startTime: String, endTime: String) {
+        _sleepStartTime.value = LocalTime.parse(startTime, timeFormatter)
+        _sleepEndTime.value = LocalTime.parse(endTime, timeFormatter)
+        Log.d("Sleep", _sleepStartTime.toString())
     }
 }
 

--- a/app/src/main/java/com/example/teumteum/ui/myhome/MySleepPatternSettingFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/myhome/MySleepPatternSettingFragment.kt
@@ -8,6 +8,7 @@ import android.widget.Button
 import android.widget.NumberPicker
 import android.widget.TextView
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import com.example.teumteum.R
 import com.example.teumteum.data.remote.onboarding.model.SleepPatternRequest
@@ -26,7 +27,7 @@ class MySleepPatternSettingFragment : Fragment() {
     private lateinit var binding: FragmentMySleepPatternSettingBinding
 
     private val viewModel: SettingViewModel by viewModels()
-    private val homeViewModel: HomeViewModel by viewModels()
+    private val homeViewModel: HomeViewModel by activityViewModels()
 
     private val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
 
@@ -41,6 +42,8 @@ class MySleepPatternSettingFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         (activity as? MainActivity)?.hideBottomBar()
+
+        initSleepPattern()
 
         binding.backButton.setOnClickListener {
             parentFragmentManager.popBackStack()
@@ -144,5 +147,19 @@ class MySleepPatternSettingFragment : Fragment() {
         viewModel.updateSleepPattern(
             SleepPatternRequest(start.toString(), end.toString())
         )
+    }
+
+    private fun initSleepPattern() {
+        homeViewModel.sleepStartTime.observe(viewLifecycleOwner) { start ->
+            if (start != null) {
+                binding.startChoiceTv.text = start.format(timeFormatter)
+            }
+        }
+
+        homeViewModel.sleepEndTime.observe(viewLifecycleOwner) { end ->
+            if (end != null) {
+                binding.endChoiceTv.text = end.format(timeFormatter)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/teumteum/ui/myhome/MySleepPatternSettingFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/myhome/MySleepPatternSettingFragment.kt
@@ -13,6 +13,7 @@ import com.example.teumteum.R
 import com.example.teumteum.data.remote.onboarding.model.SleepPatternRequest
 import com.example.teumteum.databinding.FragmentMySleepPatternSettingBinding
 import com.example.teumteum.ui.main.MainActivity
+import com.example.teumteum.ui.main.viewModel.HomeViewModel
 import com.example.teumteum.ui.myhome.viewModel.SettingViewModel
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import dagger.hilt.android.AndroidEntryPoint
@@ -25,6 +26,7 @@ class MySleepPatternSettingFragment : Fragment() {
     private lateinit var binding: FragmentMySleepPatternSettingBinding
 
     private val viewModel: SettingViewModel by viewModels()
+    private val homeViewModel: HomeViewModel by viewModels()
 
     private val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
 

--- a/app/src/main/java/com/example/teumteum/ui/myhome/MySleepPatternSettingFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/myhome/MySleepPatternSettingFragment.kt
@@ -1,17 +1,22 @@
 package com.example.teumteum.ui.myhome
 
+import android.graphics.Paint
 import android.os.Bundle
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.widget.Button
 import android.widget.NumberPicker
 import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import com.example.teumteum.R
 import com.example.teumteum.data.remote.onboarding.model.SleepPatternRequest
+import com.example.teumteum.databinding.DialogConfirmSleepDeleteBinding
 import com.example.teumteum.databinding.FragmentMySleepPatternSettingBinding
 import com.example.teumteum.ui.main.MainActivity
 import com.example.teumteum.ui.main.viewModel.HomeViewModel
@@ -44,6 +49,7 @@ class MySleepPatternSettingFragment : Fragment() {
         (activity as? MainActivity)?.hideBottomBar()
 
         initSleepPattern()
+        binding.deleteTv.paintFlags = binding.deleteTv.paintFlags or Paint.UNDERLINE_TEXT_FLAG
 
         binding.backButton.setOnClickListener {
             parentFragmentManager.popBackStack()
@@ -81,6 +87,10 @@ class MySleepPatternSettingFragment : Fragment() {
         binding.endDownArrow.setOnClickListener {
             changeHour(binding.endChoiceTv, false, false)
             tryUpdateSleepPattern()
+        }
+
+        binding.deleteTv.setOnClickListener {
+            showDeleteDialog()
         }
     }
 
@@ -159,6 +169,41 @@ class MySleepPatternSettingFragment : Fragment() {
         homeViewModel.sleepEndTime.observe(viewLifecycleOwner) { end ->
             if (end != null) {
                 binding.endChoiceTv.text = end.format(timeFormatter)
+            }
+        }
+    }
+
+    private fun showDeleteDialog() {
+        val dialogBinding = DialogConfirmSleepDeleteBinding.inflate(LayoutInflater.from(requireContext()))
+        val dialog = AlertDialog.Builder(requireContext(), R.style.RoundedAlertDialog)
+            .setView(dialogBinding.root)
+            .create()
+
+        dialogBinding.confirmTv.setOnClickListener {
+            viewModel.deleteSleepPattern()
+            dialog.dismiss()
+        }
+        dialogBinding.cancelTv.setOnClickListener {
+            dialog.dismiss()
+        }
+
+        applyDialogWindow(dialog)
+        dialog.show()
+    }
+
+    private fun applyDialogWindow(dialog: AlertDialog) {
+        dialog.window?.setBackgroundDrawableResource(android.R.color.transparent)
+        dialog.setOnShowListener {
+            dialog.window?.let { window ->
+                val layoutParams = window.attributes
+                layoutParams.width  = (resources.displayMetrics.widthPixels * 0.85).toInt()
+                layoutParams.height = ViewGroup.LayoutParams.WRAP_CONTENT
+                layoutParams.gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
+                layoutParams.y = (resources.displayMetrics.heightPixels * 0.37).toInt()
+                layoutParams.dimAmount = 0.5f
+                window.attributes = layoutParams
+                window.setDimAmount(0.5f)
+                window.addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
             }
         }
     }

--- a/app/src/main/java/com/example/teumteum/ui/myhome/viewModel/SettingViewModel.kt
+++ b/app/src/main/java/com/example/teumteum/ui/myhome/viewModel/SettingViewModel.kt
@@ -77,4 +77,14 @@ class SettingViewModel @Inject constructor(
                 }
         }
     }
+
+    fun deleteSleepPattern() {
+        viewModelScope.launch {
+            repository.deleteSleepPattern()
+                .onFailure {
+                    _error.value = "수면패턴 설정 저장 실패: ${it.message}"
+                    Log.d("Setting", _error.value.toString())
+                }
+        }
+    }
 }

--- a/app/src/main/res/layout/dialog_confirm_sleep_delete.xml
+++ b/app/src/main/res/layout/dialog_confirm_sleep_delete.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="330dp"
+    android:layout_height="275dp"
+    android:orientation="vertical"
+    android:background="@drawable/rounded_white_bg">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center"
+        android:layout_marginTop="30dp"
+        android:layout_marginBottom="-20dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="수면패턴을"
+            android:textSize="18sp"
+            android:fontFamily="@font/noto_sans_kr_medium"
+            android:textColor="@color/main_1" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text=" 삭제 하시겠어요?"
+            android:textSize="18sp"
+            android:fontFamily="@font/noto_sans_kr_medium"
+            android:textColor="@color/text_primary" />
+
+
+    </LinearLayout>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="이전의 수면패턴 기록도 모두 사라져요"
+        android:textSize="15sp"
+        android:fontFamily="@font/noto_sans_kr_regular"
+        android:textColor="@color/text_secondary"
+        android:gravity="center"
+        android:includeFontPadding="false"
+        android:layout_marginTop="10dp"
+        android:layout_marginBottom="5dp" />
+
+    <ImageView
+        android:id="@+id/teum_char_iv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:src="@drawable/ic_teum_char_sv" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="end"
+        android:layout_marginEnd="30dp"
+        android:layout_marginBottom="10dp">
+
+        <TextView
+            android:id="@+id/confirm_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="네"
+            android:fontFamily="@font/noto_sans_kr_medium"
+            android:textSize="15sp"
+            android:textColor="@color/text_primary"
+            android:padding="12dp" />
+
+        <TextView
+            android:id="@+id/cancel_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="아니오"
+            android:fontFamily="@font/noto_sans_kr_medium"
+            android:textSize="15sp"
+            android:textColor="@color/main_1"
+            android:padding="12dp" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_my_sleep_pattern_setting.xml
+++ b/app/src/main/res/layout/fragment_my_sleep_pattern_setting.xml
@@ -168,8 +168,36 @@
         app:layout_constraintTop_toBottomOf="@+id/sleep_pattern_card_ll"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        />
 
+    <TextView
+        android:id="@+id/delete_tv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/noto_sans_kr_regular"
+        android:textColor="@color/text_tertiary"
+        android:includeFontPadding="false"
+        android:text="수면패턴 삭제"
+        android:layout_marginBottom="19dp"
+        app:layout_constraintBottom_toTopOf="@+id/confirm_btn"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        />
 
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/confirm_btn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="적용"
+        style="@style/Md16"
+        app:cornerRadius="12dp"
+        android:backgroundTint="@color/text_primary"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginStart="19dp"
+        android:layout_marginEnd="19dp"
+        android:layout_marginBottom="19dp"
         />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_teum_event_card.xml
+++ b/app/src/main/res/layout/item_teum_event_card.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_marginBottom="12dp"
     android:backgroundTint="#FFFFFF"


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #333

## ✨ 작업 내용
> 수면패턴 삭제
> 틈 요청 수락 시 겹치는 투두 확인 

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] 수면패턴 삭제 -> 백엔드에서 기능 추가했는데 배포가 안된다고 해서 아직 기능 확인이 안됩니다.
- [ ] 틈 요청 수락 시 겹치는 투두 확인

## 📸 스크린샷 (선택)
> 마이페이지 -> 설정 -> 수면패턴 수정 -> 수면패턴 삭제 텍스트 클릭
> 현재는 네 버튼 클릭하면 오류 발생하면서 로그아웃되는 문제가 있는데 서버쪽 배포 되면 다시한번 확인해보겠습니다.
<img width="344" height="740" alt="image" src="https://github.com/user-attachments/assets/4f03ca8d-5de4-4631-b979-eefe6220ac07" />

> 틈 요청 수락 시 겹치는 투두 확인
<img width="348" height="751" alt="image" src="https://github.com/user-attachments/assets/ee37e22f-effe-472d-bdb7-bca5bd4aacfb" />


## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 친구 요청 수락 시 일정 충돌 조회 및 충돌 목록 확인 후 수락 가능
  * 설정에서 수면 패턴 삭제 기능 추가
  * 홈 화면에 수면 시작/종료 시간 표시

* **개선 사항**
  * 친구 수락 흐름을 비동기 충돌 검사로 개선하여 보다 명확한 UX 제공
  * 수면 패턴 설정 화면에 삭제 확인 다이얼로그 및 UI 정리 적용

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->