### PR TITLE
[REFACTOR/#351] 틈 수락 시 겹치는 스케줄 수정

### DIFF
--- a/app/src/main/java/com/example/teumteum/data/remote/friend/repository/FriendRepository.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/friend/repository/FriendRepository.kt
@@ -453,6 +453,9 @@ class FriendRepository @Inject constructor(
         startTime: String,
         endTime: String
     ): Result<TodoConflictResponse> = runCatching {
+
+        val endTime = if (endTime == "24:00") "00:00" else endTime
+
         val response = api.checkTodoConflict(date, startTime, endTime)
         val body = response.body()
 

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendTodoBottomSheetFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendTodoBottomSheetFragment.kt
@@ -5,7 +5,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.activityViewModels
+import androidx.viewpager2.widget.ViewPager2
 import com.example.teumteum.R
 import com.example.teumteum.data.remote.friend.model.TodoConflictItem
 import com.example.teumteum.databinding.BottomSheetFriendTodoBinding
@@ -24,6 +27,9 @@ class FriendTodoBottomSheetFragment : BottomSheetDialogFragment() {
 
     private lateinit var adapter: TodoEventAdapter
     private val viewModel: FriendViewModel by activityViewModels()
+
+    private lateinit var indicatorLayout: LinearLayout
+
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialog = super.onCreateDialog(savedInstanceState) as BottomSheetDialog
@@ -47,6 +53,8 @@ class FriendTodoBottomSheetFragment : BottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        indicatorLayout = binding.root.findViewById(R.id.clock_indicator_ll)
+
         val conflictList: ArrayList<TodoConflictItem> =
             arguments?.getParcelableArrayList(ARG_CONFLICT_LIST) ?: arrayListOf()
 
@@ -56,7 +64,21 @@ class FriendTodoBottomSheetFragment : BottomSheetDialogFragment() {
 
         adapter = TodoEventAdapter(events)
         binding.existingTodoViewPager.adapter = adapter
-        binding.dotsIndicator.setViewPager2(binding.existingTodoViewPager)
+
+        if (events.isNotEmpty()) {
+            setupIndicator(events.size)
+            updateIndicator(0)
+        } else {
+            indicatorLayout.removeAllViews()
+        }
+
+        binding.existingTodoViewPager.registerOnPageChangeCallback(
+            object : ViewPager2.OnPageChangeCallback() {
+                override fun onPageSelected(position: Int) {
+                    updateIndicator(position)
+                }
+            }
+        )
 
         binding.btnCancel.setOnClickListener { dismiss() }
 
@@ -73,6 +95,53 @@ class FriendTodoBottomSheetFragment : BottomSheetDialogFragment() {
                 .commit()
         }
     }
+
+    private fun setupIndicator(count: Int) {
+        indicatorLayout.removeAllViews()
+
+        repeat(count) {
+            val indicator = View(requireContext())
+            val params = LinearLayout.LayoutParams(
+                dpToPx(4),
+                dpToPx(4)
+            ).apply {
+                marginEnd = dpToPx(6)
+            }
+
+            indicator.layoutParams = params
+            indicator.background =
+                ContextCompat.getDrawable(requireContext(), R.drawable.clock_indicator_dot)
+
+            indicatorLayout.addView(indicator)
+        }
+    }
+
+    private fun updateIndicator(position: Int) {
+        for (i in 0 until indicatorLayout.childCount) {
+            val v = indicatorLayout.getChildAt(i)
+            val params = v.layoutParams as LinearLayout.LayoutParams
+
+            if (i == position) {
+                params.width = dpToPx(28)
+                params.height = dpToPx(4)
+                v.background = ContextCompat.getDrawable(
+                    requireContext(),
+                    R.drawable.clock_indicator_bar_gray
+                )
+            } else {
+                params.width = dpToPx(4)
+                params.height = dpToPx(4)
+                v.background = ContextCompat.getDrawable(
+                    requireContext(),
+                    R.drawable.clock_indicator_dot
+                )
+            }
+            v.layoutParams = params
+        }
+    }
+
+    private fun dpToPx(dp: Int): Int =
+        (dp * resources.displayMetrics.density).toInt()
 
     override fun onDestroyView() {
         super.onDestroyView()

--- a/app/src/main/java/com/example/teumteum/ui/friend/adapter/TodoEventAdapter.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/adapter/TodoEventAdapter.kt
@@ -20,7 +20,7 @@ class TodoEventAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val view = LayoutInflater.from(parent.context)
-            .inflate(R.layout.item_teum_event_card, parent, false)
+            .inflate(R.layout.item_teumm_event_card, parent, false)
         return ViewHolder(view)
     }
 

--- a/app/src/main/res/layout/bottom_sheet_friend_todo.xml
+++ b/app/src/main/res/layout/bottom_sheet_friend_todo.xml
@@ -53,7 +53,7 @@
         android:layout_marginTop="28dp"
         android:layout_marginHorizontal="20dp"
         android:orientation="horizontal"
-        tools:listitem="@layout/item_teum_event_card" />
+        tools:listitem="@layout/item_teumm_event_card" />
 
     <LinearLayout
         android:id="@+id/clock_indicator_ll"

--- a/app/src/main/res/layout/bottom_sheet_friend_todo.xml
+++ b/app/src/main/res/layout/bottom_sheet_friend_todo.xml
@@ -55,24 +55,13 @@
         android:orientation="horizontal"
         tools:listitem="@layout/item_teum_event_card" />
 
-
-    <!-- 하단 공백 / indicator -->
-    <!-- Dots Indicator -->
-    <com.tbuonomo.viewpagerdotsindicator.DotsIndicator
-        android:id="@+id/dotsIndicator"
+    <LinearLayout
+        android:id="@+id/clock_indicator_ll"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
-        app:dotsColor="#B1B2B3"
-        app:dotsCornerRadius="5dp"
-        app:dotsSize="5.68dp"
-        app:dotsSpacing="4dp"
-        app:dotsStrokeWidth="0dp"
-        app:dotsWidthFactor="1.0"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/requestViewPager"
-        app:selectedDotColor="#0F0F0F" />
+        android:orientation="horizontal"
+        android:gravity="center"
+        android:layout_marginTop="12dp"/>
 
     <!-- 버튼 영역 -->
     <LinearLayout
@@ -80,7 +69,7 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:paddingHorizontal="19dp"
-        android:layout_marginTop="46dp">
+        android:layout_marginTop="62dp">
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_cancel"
@@ -91,7 +80,6 @@
             android:textSize="16sp"
             android:textColor="@color/text_primary"
             android:fontFamily="@font/noto_sans_kr_medium"
-            android:layout_marginBottom="19dp"
             app:backgroundTint="#F6F6F6"
             app:cornerRadius="12dp"
             android:layout_marginEnd="8dp"/>
@@ -105,7 +93,6 @@
             android:textSize="16sp"
             android:fontFamily="@font/noto_sans_kr_medium"
             android:textColor="@android:color/white"
-            android:layout_marginBottom="19dp"
             app:backgroundTint="#0f0f0f"
             app:cornerRadius="12dp" />
     </LinearLayout>

--- a/app/src/main/res/layout/item_friend_conflict_card.xml
+++ b/app/src/main/res/layout/item_friend_conflict_card.xml
@@ -82,18 +82,18 @@
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="12dp"
-                        android:layout_marginEnd="10dp"
+                        android:layout_marginEnd="5dp"
                         android:layout_weight="1"
                         android:fontFamily="@font/noto_sans_kr_medium"
                         android:text="이름"
                         android:textColor="#FFFFFF"
-                        android:textSize="16sp" />
+                        android:textSize="15sp" />
 
                     <TextView
                         android:id="@+id/tvDate"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginEnd="8.52dp"
+                        android:layout_marginEnd="7dp"
                         android:fontFamily="@font/noto_sans_kr_regular"
                         android:text="|"
                         android:textColor="#FFFFFF"

--- a/app/src/main/res/layout/item_teumm_event_card.xml
+++ b/app/src/main/res/layout/item_teumm_event_card.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_marginBottom="12dp"
     android:backgroundTint="#FFFFFF"


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #351

## ✨ 작업 내용
> 틈 수락 겹치는 스케줄 수정 
> 24:00 일 때 00:00 로 바뀌게 수정 
> ui 수정 

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] dot가 아닌 indicator로 변경되었는지 


## 📸 스크린샷 (선택)
> 
기존에는 dot 였는데 indicator로 변경 
<img width="391" height="823" alt="image" src="https://github.com/user-attachments/assets/6075d309-0ef1-43f2-833a-fd11850c132f" />


## 💬 기타 참고 사항
> x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 투두 뷰에 동적 페이지 인디케이터 추가 — 페이지 전환 시 실시간으로 가시화
  * 새로운 이벤트 카드 레이아웃 추가 및 투두 목록 카드 표시 개선

* **버그 수정**
  * 투두 충돌 확인 시 종료 시간 "24:00"을 정상화하여 처리 안정성 향상

* **스타일**
  * 충돌 카드 텍스트 크기·간격 소폭 조정
  * 하단 시트 버튼 및 여백 레이아웃 조정으로 간격 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->