### PR TITLE
[REFACTOR/#353] 서로의 빈틈을 함께 한 시간일 때 보이는 화면 수정

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/friend/SharedTeumTimeFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/SharedTeumTimeFragment.kt
@@ -33,7 +33,7 @@ class SharedTeumTimeFragment : Fragment() {
         val targetUserId = arguments?.getInt("targetUserId") ?: -1
 
         //  로그인 유저 ID 주입해서 좌/우 결정
-        adapter = SharedTeumAdapter(currentUserId = AppUserManager.userId)
+        adapter = SharedTeumAdapter()
         binding.sharedTeumRecyclerView.layoutManager = LinearLayoutManager(requireContext())
         binding.sharedTeumRecyclerView.adapter = adapter
 
@@ -52,6 +52,7 @@ class SharedTeumTimeFragment : Fragment() {
         viewModel.sharedTeumList.observe(viewLifecycleOwner) { list ->
             adapter.submitList(list)
         }
+
 
         // 에러
         viewModel.errorMessage.observe(viewLifecycleOwner) { event ->

--- a/app/src/main/java/com/example/teumteum/ui/friend/adapter/SharedTeumAdapter.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/adapter/SharedTeumAdapter.kt
@@ -12,7 +12,6 @@ import com.example.teumteum.databinding.ItemSharedTeumLeftBinding
 import com.example.teumteum.databinding.ItemSharedTeumRightBinding
 
 class SharedTeumAdapter(
-    private val currentUserId: Int
 ) : ListAdapter<SharedTeumItem, RecyclerView.ViewHolder>(diff) {
 
     companion object {
@@ -32,8 +31,7 @@ class SharedTeumAdapter(
 
     override fun getItemViewType(position: Int): Int {
         val item = getItem(position)
-        //  로그인 유저가 보낸 건 오른쪽, 나머지는 왼쪽
-        return if (item.sender.userId == currentUserId) TYPE_RIGHT else TYPE_LEFT
+        return if (item.isSender) TYPE_RIGHT else TYPE_LEFT
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {

--- a/app/src/main/res/layout/item_shared_teum_right.xml
+++ b/app/src/main/res/layout/item_shared_teum_right.xml
@@ -92,7 +92,7 @@
     <!-- 말풍선 -->
     <LinearLayout
         android:id="@+id/messageLayout"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="12dp"
         android:background="@drawable/bg_teum_time_left"
@@ -101,8 +101,16 @@
         android:paddingTop="10dp"
         android:paddingEnd="14dp"
         android:paddingBottom="10dp"
+        android:gravity="center_vertical|end"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/dateTv">
+
+        <!-- 왼쪽 공간 채우는 스페이서(이게 핵심) -->
+        <View
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
 
         <!-- 제목 -->
         <TextView
@@ -144,7 +152,7 @@
             android:textSize="12sp"
             tools:text="모교 뒷편 야산에서 텐트 치고..." />
 
-
     </LinearLayout>
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #353

## ✨ 작업 내용
> 서로의 빈틈을 함께 한 시간일 때 보이는 UI 화면 수정

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] 내가 보냈던 틈일 경우 오른쪽, 상대가 보냈던 틈일 경우 왼쪽에 표시되는지


## 📸 스크린샷 (선택)
> 
<img width="390" height="824" alt="image" src="https://github.com/user-attachments/assets/b1086aff-055a-4b41-b4ac-40a3a1264c79" />


## 💬 기타 참고 사항
> x


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**버그 수정**
* 공유 메시지 화면에서 사용자가 보낸 메시지의 우측 정렬 표시를 개선했습니다.
* 메시지 레이아웃 렌더링을 최적화하여 더욱 명확한 시각적 표현을 제공합니다.
* 메시지 식별 및 표시 로직을 개선하여 안정성을 강화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->