### PR TITLE
[REFACTOR/#345] 특정 날짜의 투두 작업 시 해당 날짜의 빈틈 시간표 조회

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting02Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting02Fragment.kt
@@ -293,12 +293,8 @@ class FillingSetting02Fragment : Fragment() {
                 viewModel.assignSuccess.collect {
                     Log.d("ASSIGN_FRAGMENT", "빈틈채우기에 성공하였습니다.")
 
-                    val dateStr = getStartDate() // "yyyy-MM-dd"
-                    val safeDateStr = runCatching { LocalDate.parse(dateStr).toString() }
-                        .getOrElse { LocalDate.now().toString() }
-
                     val result = Bundle().apply {
-                        putString("date", safeDateStr)
+                        putString("date", getStartDate())
                     }
                     parentFragmentManager.setFragmentResult("assign_home", result)
 

--- a/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting02Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting02Fragment.kt
@@ -293,6 +293,15 @@ class FillingSetting02Fragment : Fragment() {
                 viewModel.assignSuccess.collect {
                     Log.d("ASSIGN_FRAGMENT", "빈틈채우기에 성공하였습니다.")
 
+                    val dateStr = getStartDate() // "yyyy-MM-dd"
+                    val safeDateStr = runCatching { LocalDate.parse(dateStr).toString() }
+                        .getOrElse { LocalDate.now().toString() }
+
+                    val result = Bundle().apply {
+                        putString("date", safeDateStr)
+                    }
+                    parentFragmentManager.setFragmentResult("assign_home", result)
+
                     parentFragmentManager.beginTransaction()
                         .replace(R.id.main_frm, HomeFragment())
                         .addToBackStack(null)

--- a/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting03Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting03Fragment.kt
@@ -289,6 +289,15 @@ class FillingSetting03Fragment : Fragment() {
                 viewModel.assignSuccess.collect {
                     Log.d("ASSIGN_FRAGMENT", "빈틈채우기에 성공하였습니다.")
 
+                    val dateStr = getStartDate() // "yyyy-MM-dd"
+                    val safeDateStr = runCatching { LocalDate.parse(dateStr).toString() }
+                        .getOrElse { LocalDate.now().toString() }
+
+                    val result = Bundle().apply {
+                        putString("date", safeDateStr)
+                    }
+                    parentFragmentManager.setFragmentResult("assign_home", result)
+
                     parentFragmentManager.beginTransaction()
                         .replace(R.id.main_frm, HomeFragment())
                         .addToBackStack(null)

--- a/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting03Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting03Fragment.kt
@@ -289,12 +289,8 @@ class FillingSetting03Fragment : Fragment() {
                 viewModel.assignSuccess.collect {
                     Log.d("ASSIGN_FRAGMENT", "빈틈채우기에 성공하였습니다.")
 
-                    val dateStr = getStartDate() // "yyyy-MM-dd"
-                    val safeDateStr = runCatching { LocalDate.parse(dateStr).toString() }
-                        .getOrElse { LocalDate.now().toString() }
-
                     val result = Bundle().apply {
-                        putString("date", safeDateStr)
+                        putString("date", getStartDate())
                     }
                     parentFragmentManager.setFragmentResult("assign_home", result)
 

--- a/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
@@ -486,7 +486,6 @@ class HomeFragment : Fragment() {
 
         onDateSelected(date)
         viewModel.getTeumTime()
-        refreshTodolist()
 
         // dot 범위 재요청
         binding.root.post {

--- a/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
@@ -42,8 +42,6 @@ import com.example.teumteum.ui.todo.viewModel.TodoViewModel
 import com.example.teumteum.ui.clock.ChartUtils
 import com.example.teumteum.ui.clock.ClockHalf
 import com.example.teumteum.ui.clock.ClockVPAdapter
-import com.example.teumteum.ui.clock.IconPieChartRenderer
-import com.example.teumteum.ui.main.data.TimeType
 import com.example.teumteum.ui.main.viewModel.HomeViewModel
 import com.example.teumteum.ui.myhome.viewModel.MyHomeViewModel
 import com.example.teumteum.utils.applyBlurShadow
@@ -417,29 +415,12 @@ class HomeFragment : Fragment() {
             binding.clockPager.setCurrentItem(next, true)
         }
 
-        // 투두 등록 성공 이벤트 수신
-        parentFragmentManager.setFragmentResultListener("todo_register_home", viewLifecycleOwner) { _, _ ->
-            viewModel.refreshTodaySchedule()
-            viewModel.getTeumTime()
-            refreshTodolist()
-            refreshCalendarDots()
-        }
-
-        // 투두 수정 성공 이벤트 수신
-        parentFragmentManager.setFragmentResultListener("todo_edit_home", viewLifecycleOwner) { _, _ ->
-            viewModel.refreshTodaySchedule()
-            viewModel.getTeumTime()
-            refreshTodolist()
-            refreshCalendarDots()
-        }
-
-        // 투두 삭제 성공 이벤트 수신
-        parentFragmentManager.setFragmentResultListener("todo_delete_home", viewLifecycleOwner) { _, _ ->
-            viewModel.refreshTodaySchedule()
-            viewModel.getTeumTime()
-            refreshTodolist()
-            refreshCalendarDots()
-        }
+        listOf("todo_register_home", "todo_edit_home", "todo_delete_home")
+            .forEach { key ->
+                parentFragmentManager.setFragmentResultListener(key, viewLifecycleOwner) { _, bundle ->
+                    handleTodoChanged(bundle)
+                }
+            }
 
         // 오버레이 닫힘 이벤트 수신
         parentFragmentManager.setFragmentResultListener("tutorial_closed", viewLifecycleOwner) { _, _ ->
@@ -447,7 +428,7 @@ class HomeFragment : Fragment() {
             binding.fabShadowIv.isVisible = true
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                requireActivity().window.insetsController?.show(android.view.WindowInsets.Type.systemBars())
+                requireActivity().window.insetsController?.show(WindowInsets.Type.systemBars())
             }
 
             backCallback?.remove()
@@ -456,13 +437,6 @@ class HomeFragment : Fragment() {
 
         todoViewModel.getTodoList(date)
         myHomeViewModel.getMyInfo()
-
-//        viewModel.scheduleList.observe(viewLifecycleOwner) {
-//            clockAdapter.refreshAll()
-//            val amPos = clockAdapter.positionOf(ClockHalf.AM)
-//            isAM = (binding.clockPager.currentItem == amPos)
-//            updateIndicator(isAM)
-//        }
 
         viewModel.sleepTimeList.observe(viewLifecycleOwner) {
             refreshClockPager()
@@ -484,6 +458,20 @@ class HomeFragment : Fragment() {
             if (isWeeklyMode) weekCalendar.findFirstVisibleWeek()?.let { requestForWeek(it) }
             else monthCalendar.findFirstVisibleMonth()?.let { requestForMonth(it) }
         }
+    }
+
+    private fun handleTodoChanged(bundle: Bundle?) {
+        val dateStr = bundle?.getString("date") ?: selectedDate.format(serverFormatter)
+        val date = runCatching { LocalDate.parse(dateStr) }.getOrNull() ?: selectedDate
+
+        selectedDate = date
+        weekCursorDate = date
+        visibleMonth = YearMonth.from(date)
+
+        onDateSelected(date)
+        viewModel.getTeumTime()
+        refreshTodolist()
+        refreshCalendarDots()
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
@@ -415,7 +415,7 @@ class HomeFragment : Fragment() {
             binding.clockPager.setCurrentItem(next, true)
         }
 
-        listOf("todo_register_home", "todo_edit_home", "todo_delete_home")
+        listOf("todo_register_home", "todo_edit_home", "todo_delete_home", "assign_home")
             .forEach { key ->
                 parentFragmentManager.setFragmentResultListener(key, viewLifecycleOwner) { _, bundle ->
                     handleTodoChanged(bundle)

--- a/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
@@ -464,14 +464,39 @@ class HomeFragment : Fragment() {
         val dateStr = bundle?.getString("date") ?: selectedDate.format(serverFormatter)
         val date = runCatching { LocalDate.parse(dateStr) }.getOrNull() ?: selectedDate
 
+        val oldDate = selectedDate
+
         selectedDate = date
         weekCursorDate = date
         visibleMonth = YearMonth.from(date)
 
+        // 캘린더 갱신
+        monthCalendar.notifyDateChanged(oldDate)
+        monthCalendar.notifyDateChanged(selectedDate)
+        weekCalendar.notifyDateChanged(oldDate)
+        weekCalendar.notifyDateChanged(selectedDate)
+
+        // 선택된 날짜로 캘린더 스크롤
+        if (isWeeklyMode) {
+            weekCalendar.scrollToDate(selectedDate)
+        } else {
+            monthCalendar.scrollToMonth(visibleMonth)
+        }
+        updateHeaderForCurrentMode()
+
         onDateSelected(date)
         viewModel.getTeumTime()
         refreshTodolist()
-        refreshCalendarDots()
+
+        // dot 범위 재요청
+        binding.root.post {
+            lastRequestedRange = null
+            if (isWeeklyMode) {
+                weekCalendar.findFirstVisibleWeek()?.let { requestForWeek(it) }
+            } else {
+                monthCalendar.findFirstVisibleMonth()?.let { requestForMonth(it) }
+            }
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
@@ -1040,9 +1040,9 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
                 disableRoutineEditing()
             }
 
-            // 약속된 틈은 일부 수정 가능(알림 편집, 공개 설정, 빈틈시간 기록 포함, 상세 내용)
+            // 약속된 틈은 일부 수정 가능 (알림 편집, 공개 설정, 빈틈시간 기록 포함, 상세 내용)
             if (todo.type == ScheduleType.TEUM) {
-                disableRoutineEditing()
+                disableTeumEditing()
             }
 
             parentFragmentManager.setFragmentResult("todo_get", Bundle())

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
@@ -306,7 +306,7 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
     }
 
     private fun setupStartCalendar() {
-        val currentMonth = YearMonth.now()
+        val currentMonth = YearMonth.from(selectedStartDate)
         val startMonth = currentMonth.minusYears(50)
         val endMonth = currentMonth.plusYears(50)
         val firstDayOfWeek = firstDayOfWeekFromLocale()
@@ -354,7 +354,7 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
     }
 
     private fun setupEndCalendar() {
-        val currentMonth = YearMonth.now()
+        val currentMonth = YearMonth.from(selectedEndDate)
         val startMonth = currentMonth.minusYears(50)
         val endMonth = currentMonth.plusYears(50)
         val firstDayOfWeek = firstDayOfWeekFromLocale()
@@ -1007,7 +1007,23 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
             binding.todoTitleEt.setText(todo.title)
 
             val startDateTime = parseApiDateTime(todo.startTime)
-            val endDateTime   = parseApiDateTime(todo.endTime)
+            val endDateTime = parseApiDateTime(todo.endTime)
+
+            // 캘린더 선택 날짜를 투두 날짜로 갱신
+            val oldStart = selectedStartDate
+            val oldEnd = selectedEndDate
+
+            selectedStartDate = startDateTime.toLocalDate()
+            selectedEndDate = endDateTime.toLocalDate()
+
+            // 캘린더 선택 표시 갱신
+            binding.calendarView01.notifyDateChanged(oldStart)
+            binding.calendarView01.notifyDateChanged(selectedStartDate)
+            binding.calendarView01.scrollToMonth(YearMonth.from(selectedStartDate))
+
+            binding.calendarView02.notifyDateChanged(oldEnd)
+            binding.calendarView02.notifyDateChanged(selectedEndDate)
+            binding.calendarView02.scrollToMonth(YearMonth.from(selectedEndDate))
 
             val dateFormatter = DateTimeFormatter.ofPattern("M월 d일 (E)", Locale.KOREAN)
             val timeFormatter = DateTimeFormatter.ofPattern("a h:mm", Locale.KOREAN)

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
@@ -1054,8 +1054,10 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
                 launch {
                     viewModel.editSuccess.collect {
                         Log.d("TODO_EDIT_FRAGMENT", "투두가 성공적으로 수정되었습니다.")
-                        parentFragmentManager.setFragmentResult("todo_edit_home", Bundle())
-                        parentFragmentManager.setFragmentResult("todo_edit_calendar", Bundle())
+                        val result = Bundle().apply {
+                            putString("date", selectedStartDate.toString()) // "yyyy-MM-dd"
+                        }
+                        parentFragmentManager.setFragmentResult("todo_edit_home", result)
                         dismissAllSheets()
                     }
                 }
@@ -1064,8 +1066,10 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
                 launch {
                     viewModel.deleteSuccess.collect {
                         Log.d("TODO_EDIT_FRAGMENT", "투두가 성공적으로 삭제되었습니다.")
-                        parentFragmentManager.setFragmentResult("todo_delete_home", Bundle())
-                        parentFragmentManager.setFragmentResult("todo_delete_calendar", Bundle())
+                        val result = Bundle().apply {
+                            putString("date", selectedStartDate.toString()) // "yyyy-MM-dd"
+                        }
+                        parentFragmentManager.setFragmentResult("todo_delete_home", result)
                         dismissAllSheets()
                     }
                 }

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
@@ -802,7 +802,10 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.registerSuccess.collect {
                     Log.d("TODO_REGISTER_FRAGMENT", "투두가 성공적으로 등록되었습니다.")
-                    parentFragmentManager.setFragmentResult("todo_register_home", Bundle())
+                    val result = Bundle().apply {
+                        putString("date", selectedStartDate.toString()) // "yyyy-MM-dd"
+                    }
+                    parentFragmentManager.setFragmentResult("todo_register_home", result)
 
                     // 모든 바텀시트 닫기
                     (requireActivity().supportFragmentManager.fragments).forEach { fragment ->

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishSetting02Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishSetting02Fragment.kt
@@ -257,7 +257,14 @@ class WishSetting02Fragment : Fragment() {
                 viewModel.assignSuccess.collect {
                     Log.d("ASSIGN_FRAGMENT", "빈틈채우기에 성공하였습니다.")
 
-                    homeViewModel.refreshTodaySchedule()
+                    val dateStr = getStartDate() // "yyyy-MM-dd"
+                    val safeDateStr = runCatching { LocalDate.parse(dateStr).toString() }
+                        .getOrElse { LocalDate.now().toString() }
+
+                    val result = Bundle().apply {
+                        putString("date", safeDateStr)
+                    }
+                    parentFragmentManager.setFragmentResult("assign_home", result)
 
                     parentFragmentManager.beginTransaction()
                         .replace(R.id.main_frm, HomeFragment())

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishSetting02Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishSetting02Fragment.kt
@@ -257,12 +257,8 @@ class WishSetting02Fragment : Fragment() {
                 viewModel.assignSuccess.collect {
                     Log.d("ASSIGN_FRAGMENT", "빈틈채우기에 성공하였습니다.")
 
-                    val dateStr = getStartDate() // "yyyy-MM-dd"
-                    val safeDateStr = runCatching { LocalDate.parse(dateStr).toString() }
-                        .getOrElse { LocalDate.now().toString() }
-
                     val result = Bundle().apply {
-                        putString("date", safeDateStr)
+                        putString("date", getStartDate())
                     }
                     parentFragmentManager.setFragmentResult("assign_home", result)
 

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishSetting03Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishSetting03Fragment.kt
@@ -250,6 +250,15 @@ class WishSetting03Fragment : Fragment() {
                 viewModel.assignSuccess.collect {
                     Log.d("ASSIGN_FRAGMENT", "빈틈채우기에 성공하였습니다.")
 
+                    val dateStr = getStartDate() // "yyyy-MM-dd"
+                    val safeDateStr = runCatching { LocalDate.parse(dateStr).toString() }
+                        .getOrElse { LocalDate.now().toString() }
+
+                    val result = Bundle().apply {
+                        putString("date", safeDateStr)
+                    }
+                    parentFragmentManager.setFragmentResult("assign_home", result)
+
                     parentFragmentManager.beginTransaction()
                         .replace(R.id.main_frm, HomeFragment())
                         .addToBackStack(null)

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishSetting03Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishSetting03Fragment.kt
@@ -250,12 +250,8 @@ class WishSetting03Fragment : Fragment() {
                 viewModel.assignSuccess.collect {
                     Log.d("ASSIGN_FRAGMENT", "빈틈채우기에 성공하였습니다.")
 
-                    val dateStr = getStartDate() // "yyyy-MM-dd"
-                    val safeDateStr = runCatching { LocalDate.parse(dateStr).toString() }
-                        .getOrElse { LocalDate.now().toString() }
-
                     val result = Bundle().apply {
-                        putString("date", safeDateStr)
+                        putString("date", getStartDate())
                     }
                     parentFragmentManager.setFragmentResult("assign_home", result)
 


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #345 

## ✨ 작업 내용
- 투두 등록/수정/삭제 시 선택한 날짜의 일정을 조회
- 오늘이 아닌 다른 날짜로 등록한 투두 조회 시 캘린더 선택 날짜 보라색 원을 해당 날짜로 갱신
- 틈 약속 disableRoutineEditing -> disableTeumEditing 오류 수정

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 일정 조회
- [x] 다른 날짜의 투두 조회 시 캘린더 선택 날짜가 갱신되어 있는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 할일 등록/편집/삭제 및 과제 할당 시 홈 화면으로 선택한 날짜 정보가 전달되어 즉시 동기화됩니다.
  * 홈 화면의 변경 이벤트 수신이 통합되어 다양한 변경을 한곳에서 처리합니다.

* **버그 수정**
  * 편집 시 캘린더가 선택한 시작/종료일을 기준으로 정확히 표시됩니다.
  * 변경 이후 달력 및 목록이 일관되게 새로고침됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->