### PR TITLE
[FEAT/#358] 신고 생성 API 연동하기 

### DIFF
--- a/app/src/main/java/com/example/teumteum/data/remote/friend/model/ReportRequest.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/friend/model/ReportRequest.kt
@@ -1,0 +1,10 @@
+package com.example.teumteum.data.remote.friend.model
+
+import com.google.gson.annotations.SerializedName
+
+data class ReportRequest(
+    @SerializedName("targetType") val targetType: String,
+    @SerializedName("targetId") val targetId: Long,
+    @SerializedName("reasonId") val reasonId: Int,
+    @SerializedName("otherReason") val otherReason: String?
+)

--- a/app/src/main/java/com/example/teumteum/data/remote/friend/repository/FriendRepository.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/friend/repository/FriendRepository.kt
@@ -13,6 +13,7 @@ import com.example.teumteum.data.remote.friend.model.PagingResponse
 import com.example.teumteum.data.remote.friend.model.PossibleTimeRequest
 import com.example.teumteum.data.remote.friend.model.PossibleTimeResult
 import com.example.teumteum.data.remote.friend.model.PublicTodoResult
+import com.example.teumteum.data.remote.friend.model.ReportRequest
 import com.example.teumteum.data.remote.friend.model.ResendTeumRequest
 import com.example.teumteum.data.remote.friend.model.ResendTeumResult
 import com.example.teumteum.data.remote.friend.model.SharedTeumItem
@@ -469,5 +470,19 @@ class FriendRepository @Inject constructor(
             throw Exception("${body.code} - ${body.message}")
         }
     }
+
+    // 신고 생성
+    suspend fun createReport(request: ReportRequest): Result<ApiResponse<Unit>> =
+        runCatching {
+            val response = api.createReport(request)
+            val body = response.body()
+
+            if (!response.isSuccessful || body == null) {
+                throw Exception("HTTP ${response.code()} - ${response.errorBody()?.string() ?: response.message()}")
+            }
+
+            if (body.isSuccess) body
+            else throw Exception("${body.code} - ${body.message}")
+        }
 
 }

--- a/app/src/main/java/com/example/teumteum/data/remote/friend/service/FriendService.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/friend/service/FriendService.kt
@@ -12,6 +12,7 @@ import com.example.teumteum.data.remote.friend.model.PagingResponse
 import com.example.teumteum.data.remote.friend.model.PossibleTimeRequest
 import com.example.teumteum.data.remote.friend.model.PossibleTimeResult
 import com.example.teumteum.data.remote.friend.model.PublicTodoResult
+import com.example.teumteum.data.remote.friend.model.ReportRequest
 import com.example.teumteum.data.remote.friend.model.ResendTeumRequest
 import com.example.teumteum.data.remote.friend.model.ResendTeumResult
 import com.example.teumteum.data.remote.friend.model.SharedTeumListResult
@@ -198,4 +199,10 @@ interface FriendService {
         @Query("startTime") startTime: String, // HH:MM
         @Query("endTime") endTime: String      // HH:MM
     ): Response<ApiResponse<TodoConflictResponse>>
+
+    // 신고 생성
+    @POST("/api/reports")
+    suspend fun createReport(
+        @Body request: ReportRequest
+    ): Response<ApiResponse<Unit>>
 }

--- a/app/src/main/java/com/example/teumteum/ui/friend/Friend02RequestFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/Friend02RequestFragment.kt
@@ -93,12 +93,12 @@ class Friend02RequestFragment : Fragment() {
             if (response == null) return@observe
 
             if (response.hasConflict) {
-                // ✅ 겹침 있음 → 다른 바텀시트
+                // 겹침 있음 → 다른 바텀시트
                 val conflictList = ArrayList(response.conflictingSchedules)
                 val bottomSheet = FriendTodoBottomSheetFragment.newInstance(responseId, conflictList)
                 bottomSheet.show(parentFragmentManager, bottomSheet.tag)
             } else {
-                // ✅ 겹침 없음 → 기존 수락 바텀시트
+                // 겹침 없음 → 기존 수락 바텀시트
                 val bottomSheet = Friend02AcceptBottomSheetFragment.newInstance(responseId)
                 bottomSheet.show(parentFragmentManager, bottomSheet.tag)
             }
@@ -178,9 +178,18 @@ class Friend02RequestFragment : Fragment() {
 
         popupView.findViewById<View>(R.id.btn_report).setOnClickListener {
             popupWindow.dismiss()
-            val bottomSheet = FriendReportChoiceBottomSheet()
-            bottomSheet.show(parentFragmentManager, bottomSheet.tag)
+
+            val current = teumList.getOrNull(binding.requestViewPager.currentItem) ?: return@setOnClickListener
+
+            // 신고 대상: 받은 틈 요청 자체
+            val targetType = "TEUM_REQUEST"
+            val targetId = current.requestId.toLong()
+
+            FriendReportChoiceBottomSheet
+                .newInstance(targetType, targetId)
+                .show(parentFragmentManager, "FriendReportChoiceBottomSheet")
         }
+
     }
 
     //  미확인 → 최신순 정렬

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendProfileFollowFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendProfileFollowFragment.kt
@@ -157,7 +157,10 @@ class FriendProfileFollowFragment : Fragment() {
         popupView.findViewById<View>(R.id.btn_report).setOnClickListener {
             popupWindow.dismiss()
 
-            FriendReportChoiceBottomSheet()
+            if (targetUserId == -1) return@setOnClickListener
+
+            FriendReportChoiceBottomSheet
+                .newInstance("USER", targetUserId.toLong())
                 .show(parentFragmentManager, "FriendReportChoiceBottomSheet")
         }
     }

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendProfileFollowingFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendProfileFollowingFragment.kt
@@ -201,7 +201,10 @@ class FriendProfileFollowingFragment : Fragment() {
         popupView.findViewById<View>(R.id.btn_report).setOnClickListener {
             popupWindow.dismiss()
 
-            FriendReportChoiceBottomSheet()
+            if (targetUserId == -1) return@setOnClickListener
+
+            FriendReportChoiceBottomSheet
+                .newInstance("USER", targetUserId.toLong())
                 .show(parentFragmentManager, "FriendReportChoiceBottomSheet")
         }
     }

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendReportChoiceBottomSheet.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendReportChoiceBottomSheet.kt
@@ -92,6 +92,7 @@ class FriendReportChoiceBottomSheet : BottomSheetDialogFragment() {
             if (targetType.isNullOrBlank() || targetId <= 0L) {
                 return@setOnClickListener
             }
+            binding.reportBtn.isEnabled = false
 
             viewModel.createReport(
                 targetType = targetType,
@@ -113,6 +114,7 @@ class FriendReportChoiceBottomSheet : BottomSheetDialogFragment() {
         viewModel.errorMessage.observe(viewLifecycleOwner) { event ->
             event.getContentIfNotHandled()?.let { message ->
                 Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
+                binding.reportBtn.isEnabled = true
             }
         }
     }

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendReportChoiceBottomSheet.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendReportChoiceBottomSheet.kt
@@ -1,6 +1,8 @@
 package com.example.teumteum.ui.friend
 
 import android.app.Dialog
+import android.content.res.ColorStateList
+import android.graphics.Color
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -51,6 +53,8 @@ class FriendReportChoiceBottomSheet : BottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        applyCheckBoxTint()
+
 
         // 1~6만 선택 가능
         setupSingleSelection(binding.optAbuseCb, 8)
@@ -106,6 +110,30 @@ class FriendReportChoiceBottomSheet : BottomSheetDialogFragment() {
             clearAllChecks()
             checkBox.isChecked = true
             selectedReasonId = reasonId
+        }
+    }
+
+    private fun applyCheckBoxTint() {
+        val tint = ColorStateList(
+            arrayOf(
+                intArrayOf(android.R.attr.state_checked), // checked
+                intArrayOf(-android.R.attr.state_checked) // unchecked
+            ),
+            intArrayOf(
+                Color.parseColor("#0F0F0F"), // 체크됨
+                Color.parseColor("#788084")  // 체크 안됨
+            )
+        )
+
+        listOf(
+            binding.optAbuseCb,
+            binding.optSexualCb,
+            binding.optScamCb,
+            binding.optIllegalCb,
+            binding.optPrivacyCb,
+            binding.optSpamCb
+        ).forEach { cb ->
+            cb.buttonTintList = tint
         }
     }
 

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendReportChoiceBottomSheet.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendReportChoiceBottomSheet.kt
@@ -2,13 +2,16 @@ package com.example.teumteum.ui.friend
 
 import android.app.Dialog
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.CheckBox
-import androidx.constraintlayout.widget.ConstraintLayout
+import android.widget.Toast
+import androidx.fragment.app.activityViewModels
 import com.example.teumteum.R
 import com.example.teumteum.databinding.BottomSheetFriendReportChoiceBinding
+import com.example.teumteum.ui.friend.viewModel.FriendViewModel
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -18,7 +21,10 @@ class FriendReportChoiceBottomSheet : BottomSheetDialogFragment() {
     private var _binding: BottomSheetFriendReportChoiceBinding? = null
     private val binding get() = _binding!!
 
-    private var selectedReason: String? = null
+    private val viewModel: FriendViewModel by activityViewModels()
+
+    //  서버용: reasonId를 저장
+    private var selectedReasonId: Int? = null
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialog = super.onCreateDialog(savedInstanceState) as BottomSheetDialog
@@ -29,11 +35,10 @@ class FriendReportChoiceBottomSheet : BottomSheetDialogFragment() {
             val behavior = BottomSheetBehavior.from(bottomSheet!!)
             behavior.state = BottomSheetBehavior.STATE_EXPANDED
 
-            bottomSheet?.setBackgroundResource(R.drawable.calendar_background)
+            bottomSheet.setBackgroundResource(R.drawable.calendar_background)
         }
         return dialog
     }
-
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -47,39 +52,60 @@ class FriendReportChoiceBottomSheet : BottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        setupSingleSelection(binding.optAbuseCb, "욕설 등 혐오 발언")
-        setupSingleSelection(binding.optSexualCb, "성희롱 또는 음란 발언")
-        setupSingleSelection(binding.optScamCb, "사기 또는 거짓")
-        setupSingleSelection(binding.optIllegalCb, "불법 또는 유해 콘텐츠 공유")
-        setupSingleSelection(binding.optPrivacyCb, "개인정보 노출 요구")
-        setupSingleSelection(binding.optSpamCb, "스팸")
+        // 1~6만 선택 가능
+        setupSingleSelection(binding.optAbuseCb, 8)
+        setupSingleSelection(binding.optSexualCb, 9)
+        setupSingleSelection(binding.optScamCb, 10)
+        setupSingleSelection(binding.optIllegalCb, 11)
+        setupSingleSelection(binding.optPrivacyCb, 12)
+        setupSingleSelection(binding.optSpamCb, 13)
 
-        // "해당 리스트에 관련 사유 없음" → 다음 바텀시트 이동
+        // 14번은 무조건 텍스트 바텀시트로 이동 (여기서 신고 X)
         binding.optOtherArrow.setOnClickListener {
-            val sheet = FriendReportTextBottomSheet()
-            sheet.show(parentFragmentManager, "FriendReportTextBottomSheet")
-            dismiss() // 이전 바텀시트 닫기 (선택)
+            val targetType =
+                requireArguments().getString(ARG_TARGET_TYPE) ?: return@setOnClickListener
+            val targetId = requireArguments().getLong(ARG_TARGET_ID)
+
+            FriendReportTextBottomSheet
+                .newInstance(targetType, targetId)
+                .show(parentFragmentManager, "FriendReportTextBottomSheet")
+
+            dismiss()
         }
 
-        //  신고 버튼 클릭
+        // 신고 버튼: 8~13만 여기서 신고됨
         binding.reportBtn.setOnClickListener {
-            if (selectedReason == null) {
-                // 필요 시 토스트:
-                // Toast.makeText(requireContext(), "신고 사유를 선택해주세요.", Toast.LENGTH_SHORT).show()
+
+            val reasonId = selectedReasonId
+            if (reasonId == null) {
                 return@setOnClickListener
             }
 
-            // TODO: API 연결
+            val targetType = arguments?.getString(ARG_TARGET_TYPE)
+            val targetId = arguments?.getLong(ARG_TARGET_ID, -1L) ?: -1L
+
+            if (targetType.isNullOrBlank() || targetId <= 0L) {
+                return@setOnClickListener
+            }
+
+            viewModel.createReport(
+                targetType = targetType,
+                targetId = targetId,
+                reasonId = reasonId,
+                otherReason = null
+            )
+
+            Toast.makeText(requireContext(), "신고가 성공적으로 접수되었습니다.", Toast.LENGTH_SHORT).show()
+
             dismiss()
         }
     }
 
-    /** 체크박스 단일 선택 처리 */
-    private fun setupSingleSelection(checkBox: CheckBox, reason: String) {
+    private fun setupSingleSelection(checkBox: CheckBox, reasonId: Int) {
         checkBox.setOnClickListener {
             clearAllChecks()
             checkBox.isChecked = true
-            selectedReason = reason
+            selectedReasonId = reasonId
         }
     }
 
@@ -96,5 +122,17 @@ class FriendReportChoiceBottomSheet : BottomSheetDialogFragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    companion object {
+        private const val ARG_TARGET_TYPE = "arg_target_type"
+        private const val ARG_TARGET_ID = "arg_target_id"
+
+        fun newInstance(targetType: String, targetId: Long) = FriendReportChoiceBottomSheet().apply {
+            arguments = Bundle().apply {
+                putString(ARG_TARGET_TYPE, targetType) // "USER" | "TEUM_REQUEST"
+                putLong(ARG_TARGET_ID, targetId)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendReportChoiceBottomSheet.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendReportChoiceBottomSheet.kt
@@ -55,6 +55,7 @@ class FriendReportChoiceBottomSheet : BottomSheetDialogFragment() {
         super.onViewCreated(view, savedInstanceState)
         applyCheckBoxTint()
 
+        observeReportResult()
 
         // 1~6만 선택 가능
         setupSingleSelection(binding.optAbuseCb, 8)
@@ -98,10 +99,21 @@ class FriendReportChoiceBottomSheet : BottomSheetDialogFragment() {
                 reasonId = reasonId,
                 otherReason = null
             )
+        }
+    }
 
-            Toast.makeText(requireContext(), "신고가 성공적으로 접수되었습니다.", Toast.LENGTH_SHORT).show()
+    private fun observeReportResult() {
+        viewModel.successMessage.observe(viewLifecycleOwner) { event ->
+            event.getContentIfNotHandled()?.let { message ->
+                Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
+                dismiss()
+            }
+        }
 
-            dismiss()
+        viewModel.errorMessage.observe(viewLifecycleOwner) { event ->
+            event.getContentIfNotHandled()?.let { message ->
+                Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
+            }
         }
     }
 

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendReportChoiceBottomSheet.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendReportChoiceBottomSheet.kt
@@ -67,8 +67,14 @@ class FriendReportChoiceBottomSheet : BottomSheetDialogFragment() {
 
         // 14번은 무조건 텍스트 바텀시트로 이동 (여기서 신고 X)
         binding.optOtherArrow.setOnClickListener {
+            binding.optOtherArrow.isEnabled = false
+
             val targetType =
-                requireArguments().getString(ARG_TARGET_TYPE) ?: return@setOnClickListener
+                requireArguments().getString(ARG_TARGET_TYPE) ?: run {
+                    binding.optOtherArrow.isEnabled = true
+                    return@setOnClickListener
+                }
+            
             val targetId = requireArguments().getLong(ARG_TARGET_ID)
 
             FriendReportTextBottomSheet

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendReportTextBottomSheet.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendReportTextBottomSheet.kt
@@ -2,12 +2,16 @@ package com.example.teumteum.ui.friend
 
 import android.app.Dialog
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.example.teumteum.R
+import android.widget.Toast
 import androidx.core.widget.addTextChangedListener
+import androidx.fragment.app.activityViewModels
+import com.example.teumteum.R
 import com.example.teumteum.databinding.BottomSheetFriendReportTextBinding
+import com.example.teumteum.ui.friend.viewModel.FriendViewModel
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -16,6 +20,9 @@ class FriendReportTextBottomSheet : BottomSheetDialogFragment() {
 
     private var _binding: BottomSheetFriendReportTextBinding? = null
     private val binding get() = _binding!!
+
+    // ViewModel 추가 (activity 범위 공유)
+    private val viewModel: FriendViewModel by activityViewModels()
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialog = super.onCreateDialog(savedInstanceState) as BottomSheetDialog
@@ -26,7 +33,7 @@ class FriendReportTextBottomSheet : BottomSheetDialogFragment() {
             val behavior = BottomSheetBehavior.from(bottomSheet!!)
             behavior.state = BottomSheetBehavior.STATE_EXPANDED
 
-            bottomSheet?.setBackgroundResource(R.drawable.calendar_background)
+            bottomSheet.setBackgroundResource(R.drawable.calendar_background)
         }
         return dialog
     }
@@ -43,6 +50,10 @@ class FriendReportTextBottomSheet : BottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        // target 정보 꺼내기 (없으면 그냥 종료)
+        val targetType = arguments?.getString(ARG_TARGET_TYPE) ?: return
+        val targetId = arguments?.getLong(ARG_TARGET_ID) ?: return
+
         // 실시간 글자수 표시
         binding.etReportDetail.addTextChangedListener { editable ->
             val length = editable?.length ?: 0
@@ -51,33 +62,57 @@ class FriendReportTextBottomSheet : BottomSheetDialogFragment() {
 
         // 뒤로가기 버튼
         binding.btnBack.setOnClickListener {
-            // 이전 바텀시트 열기
-            val previousSheet = FriendReportChoiceBottomSheet()
-            previousSheet.show(parentFragmentManager, "FriendReportChoiceBottomSheet")
-
-            // 현재 바텀시트 닫기
+            FriendReportChoiceBottomSheet
+                .newInstance(targetType, targetId)
+                .show(parentFragmentManager, "FriendReportChoiceBottomSheet")
             dismiss()
         }
 
-
-        // 신고 버튼 클릭
+        // 신고 버튼: 14번(기타) 신고는 여기서만
         binding.btnReportSubmit.setOnClickListener {
-            val detailText = binding.etReportDetail.text.toString().trim()
+            val raw = binding.etReportDetail.text?.toString()
+            val trimmed = raw?.trim()
 
-            if (detailText.isEmpty()) {
-                // 필요시 토스트
-                // Toast.makeText(requireContext(),"사유를 입력해주세요.",Toast.LENGTH_SHORT).show()
+            Log.e("REPORT_TEXT", "raw=[$raw], trimmed=[$trimmed], len=${trimmed?.length}")
+
+            if (trimmed.isNullOrBlank()) {
+                Toast.makeText(requireContext(), "사유를 입력해주세요.", Toast.LENGTH_SHORT).show()
                 return@setOnClickListener
             }
 
-            // TODO: API로 detailText 전달
+            // 중복 클릭 방지
+            binding.btnReportSubmit.isEnabled = false
+
+            viewModel.createReport(
+                targetType = targetType,
+                targetId = targetId,
+                reasonId = 14,
+                otherReason = trimmed
+            )
+
+            Toast.makeText(requireContext(), "신고가 성공적으로 접수되었습니다.", Toast.LENGTH_SHORT).show()
+
             dismiss()
         }
-    }
 
+    }
 
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    companion object {
+        private const val ARG_TARGET_TYPE = "arg_target_type"
+        private const val ARG_TARGET_ID = "arg_target_id"
+
+        fun newInstance(targetType: String, targetId: Long): FriendReportTextBottomSheet {
+            return FriendReportTextBottomSheet().apply {
+                arguments = Bundle().apply {
+                    putString(ARG_TARGET_TYPE, targetType)
+                    putLong(ARG_TARGET_ID, targetId)
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendReportTextBottomSheet.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendReportTextBottomSheet.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.core.view.ViewCompat
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.activityViewModels
 import com.example.teumteum.R
@@ -26,13 +27,25 @@ class FriendReportTextBottomSheet : BottomSheetDialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialog = super.onCreateDialog(savedInstanceState) as BottomSheetDialog
+
+        dialog.window?.setSoftInputMode(
+            android.view.WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING or
+                    android.view.WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN
+        )
+
         dialog.setOnShowListener { dialogInterface ->
             val bottomSheet = (dialogInterface as BottomSheetDialog)
-                .findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
+                .findViewById<View>(com.google.android.material.R.id.design_bottom_sheet) ?: return@setOnShowListener
 
-            val behavior = BottomSheetBehavior.from(bottomSheet!!)
+            val behavior = BottomSheetBehavior.from(bottomSheet)
             behavior.state = BottomSheetBehavior.STATE_EXPANDED
 
+            // ✅ 키보드 인셋 반영 막기 (올라가는 원인 차단)
+            ViewCompat.setOnApplyWindowInsetsListener(bottomSheet) { _, insets ->
+                insets
+            }
+
+            bottomSheet.setPadding(0, 0, 0, 0)
             bottomSheet.setBackgroundResource(R.drawable.calendar_background)
         }
         return dialog

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendReportTextBottomSheet.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendReportTextBottomSheet.kt
@@ -2,7 +2,6 @@ package com.example.teumteum.ui.friend
 
 import android.app.Dialog
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -22,7 +21,6 @@ class FriendReportTextBottomSheet : BottomSheetDialogFragment() {
     private var _binding: BottomSheetFriendReportTextBinding? = null
     private val binding get() = _binding!!
 
-    // ViewModel 추가 (activity 범위 공유)
     private val viewModel: FriendViewModel by activityViewModels()
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
@@ -35,15 +33,13 @@ class FriendReportTextBottomSheet : BottomSheetDialogFragment() {
 
         dialog.setOnShowListener { dialogInterface ->
             val bottomSheet = (dialogInterface as BottomSheetDialog)
-                .findViewById<View>(com.google.android.material.R.id.design_bottom_sheet) ?: return@setOnShowListener
+                .findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
+                ?: return@setOnShowListener
 
             val behavior = BottomSheetBehavior.from(bottomSheet)
             behavior.state = BottomSheetBehavior.STATE_EXPANDED
 
-            // ✅ 키보드 인셋 반영 막기 (올라가는 원인 차단)
-            ViewCompat.setOnApplyWindowInsetsListener(bottomSheet) { _, insets ->
-                insets
-            }
+            ViewCompat.setOnApplyWindowInsetsListener(bottomSheet) { _, insets -> insets }
 
             bottomSheet.setPadding(0, 0, 0, 0)
             bottomSheet.setBackgroundResource(R.drawable.calendar_background)
@@ -63,17 +59,17 @@ class FriendReportTextBottomSheet : BottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        // target 정보 꺼내기 (없으면 그냥 종료)
         val targetType = arguments?.getString(ARG_TARGET_TYPE) ?: return
         val targetId = arguments?.getLong(ARG_TARGET_ID) ?: return
 
-        // 실시간 글자수 표시
+        // ViewModel 결과 관찰 (성공/실패에 따라 토스트/버튼/닫기 처리)
+        observeReportResult()
+
         binding.etReportDetail.addTextChangedListener { editable ->
             val length = editable?.length ?: 0
             binding.tvCharCount.text = "$length / 100"
         }
 
-        // 뒤로가기 버튼
         binding.btnBack.setOnClickListener {
             FriendReportChoiceBottomSheet
                 .newInstance(targetType, targetId)
@@ -81,19 +77,15 @@ class FriendReportTextBottomSheet : BottomSheetDialogFragment() {
             dismiss()
         }
 
-        // 신고 버튼: 14번(기타) 신고는 여기서만
         binding.btnReportSubmit.setOnClickListener {
-            val raw = binding.etReportDetail.text?.toString()
-            val trimmed = raw?.trim()
-
-            Log.e("REPORT_TEXT", "raw=[$raw], trimmed=[$trimmed], len=${trimmed?.length}")
+            val trimmed = binding.etReportDetail.text?.toString()?.trim()
 
             if (trimmed.isNullOrBlank()) {
                 Toast.makeText(requireContext(), "사유를 입력해주세요.", Toast.LENGTH_SHORT).show()
                 return@setOnClickListener
             }
 
-            // 중복 클릭 방지
+            // 중복 클릭 방지 (응답 오기 전까지 비활성화)
             binding.btnReportSubmit.isEnabled = false
 
             viewModel.createReport(
@@ -102,12 +94,24 @@ class FriendReportTextBottomSheet : BottomSheetDialogFragment() {
                 reasonId = 14,
                 otherReason = trimmed
             )
+        }
+    }
 
-            Toast.makeText(requireContext(), "신고가 성공적으로 접수되었습니다.", Toast.LENGTH_SHORT).show()
-
-            dismiss()
+    private fun observeReportResult() {
+        viewModel.successMessage.observe(viewLifecycleOwner) { event ->
+            event.getContentIfNotHandled()?.let { message ->
+                Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
+                dismiss()
+            }
         }
 
+        viewModel.errorMessage.observe(viewLifecycleOwner) { event ->
+            event.getContentIfNotHandled()?.let { message ->
+                Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
+                // 실패 시 재시도 가능하도록 버튼 다시 활성화
+                binding.btnReportSubmit.isEnabled = true
+            }
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/teumteum/ui/friend/viewModel/FriendViewModel.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/viewModel/FriendViewModel.kt
@@ -13,6 +13,7 @@ import com.example.teumteum.data.remote.friend.model.FriendSearchResult
 import com.example.teumteum.data.remote.friend.model.MutualFriendItem
 import com.example.teumteum.data.remote.friend.model.PossibleTimeRequest
 import com.example.teumteum.data.remote.friend.model.PublicTodoResult
+import com.example.teumteum.data.remote.friend.model.ReportRequest
 import com.example.teumteum.data.remote.friend.model.ResendTeumRequest
 import com.example.teumteum.data.remote.friend.model.SharedTeumItem
 import com.example.teumteum.data.remote.friend.model.TeumConflictResponse
@@ -1002,6 +1003,46 @@ class FriendViewModel @Inject constructor(
         }
     }
 
+    // 신고 생성
+    fun createReport(
+        targetType: String,   // "USER" | "TEUM_REQUEST"
+        targetId: Long,
+        reasonId: Int,        // 8~14
+        otherReason: String? // reasonId=14 일 때 필수
+    ) {
+        Log.d(
+            "REPORT_API",
+            "createReport 호출 → targetType=$targetType, targetId=$targetId, reasonId=$reasonId, otherReasonText=$otherReason"
+        )
 
+        viewModelScope.launch {
+            repository.createReport(
+                ReportRequest(
+                    targetType = targetType,
+                    targetId = targetId,
+                    reasonId = reasonId,
+                    otherReason = otherReason
+                )
+            ).onSuccess { response ->
+                Log.d(
+                    "REPORT201",
+                    "신고 성공 → code=${response.code}, message=${response.message}"
+                )
+
+                _successMessage.value = Event(response.message)
+
+            }.onFailure { throwable ->
+
+                Log.e(
+                    "REPORT_API",
+                    "신고 실패 → ${throwable.message}",
+                    throwable
+                )
+
+                _errorMessage.value =
+                    Event(throwable.message ?: "신고에 실패했습니다.")
+            }
+        }
+    }
 
 }

--- a/app/src/main/res/layout/bottom_sheet_friend_report_choice.xml
+++ b/app/src/main/res/layout/bottom_sheet_friend_report_choice.xml
@@ -10,8 +10,8 @@
     <!-- drag handle -->
     <View
         android:id="@+id/bottomSheetHandle"
-        android:layout_width="match_parent"
-        android:layout_height="5dp"
+        android:layout_width="54dp"
+        android:layout_height="4dp"
         android:layout_gravity="center_horizontal"
         android:layout_marginTop="12dp"
         android:layout_marginStart="168dp"

--- a/app/src/main/res/layout/bottom_sheet_friend_report_text.xml
+++ b/app/src/main/res/layout/bottom_sheet_friend_report_text.xml
@@ -7,10 +7,10 @@
 
     <View
     android:id="@+id/handle"
-    android:layout_width="match_parent"
+    android:layout_width="54dp"
         android:layout_marginEnd="168dp"
         android:layout_marginStart="168dp"
-    android:layout_height="5dp"
+    android:layout_height="4dp"
     android:layout_marginTop="12dp"
     android:background="@drawable/friend_bottom_sheet_handle"
     app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #358

## ✨ 작업 내용
> 신고 생성 API 연동하기
> 바텀시트 UI(체크하는 부분) 추가하기 

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] 팔로잉 된 친구 프로필, 팔로우하지  않은 친구 프로필, 나에게 온 틈 요청 화면 총 3곳에서 신고 api가 잘 작동하는지 


## 📸 스크린샷 (선택)
> 신고 선택 시 뜨는 바텀 시트
<img width="383" height="812" alt="image" src="https://github.com/user-attachments/assets/b08ae1ae-79a4-472e-b423-8f4891544231" />

> 신고가 성공적으로 접수되었습니다 토스트가 화면에 뜸 
<img width="378" height="814" alt="image" src="https://github.com/user-attachments/assets/b9107657-46f6-4485-9789-818b56c3fc16" />
<img width="1274" height="45" alt="image" src="https://github.com/user-attachments/assets/5963464b-ace7-4eaa-a678-f145336bf5af" />

> 해당 리스트에 관련 사유 없을 시 직접 텍스트로 쓸 수 있음
<img width="364" height="685" alt="image" src="https://github.com/user-attachments/assets/a5a1dc44-ff88-4850-833b-abc9c4d058eb" />


## 💬 기타 참고 사항
> x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 신고 기능이 추가되었습니다 — 사전 정의된 단일 선택 사유(숫자 ID) 및 직접 입력(기타) 지원, 프로필 및 요청 화면에서 신고 가능.
  * 신고 제출 중 버튼 비활성화로 중복 제출 방지 및 제출 결과에 대한 성공/오류 토스트 피드백 제공.
  * 신고 텍스트 입력용 하위 화면과 선택 화면 간 네비게이션이 개선되었습니다.

* **버그 픽스 / 품질 개선**
  * 유효하지 않은 대상에 대한 신고 시도를 사전 차단하고 입력 검증(빈 문자열 방지)을 추가했습니다.

* **스타일**
  * 신고 바텀시트의 핸들 크기가 조정되어 시각적 안정성 향상.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->