### PR TITLE
[REFACTOR/#375] 타임피커 텍스트 클릭 시 다음 항목으로 넘기기

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting02Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting02Fragment.kt
@@ -21,6 +21,7 @@ import com.example.teumteum.databinding.FragmentFillingSetting02Binding
 import com.example.teumteum.ui.activity.viewModel.ActivityViewModel
 import com.example.teumteum.ui.main.HomeFragment
 import com.example.teumteum.utils.applyPickerValue
+import com.example.teumteum.utils.enableTapToNext
 import com.example.teumteum.utils.parse24hTimeToPickerValue
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -163,6 +164,7 @@ class FillingSetting02Fragment : Fragment() {
         ampmPicker.minValue = 0
         ampmPicker.maxValue = 1
         ampmPicker.displayedValues = arrayOf("AM", "PM")
+        ampmPicker.wrapSelectorWheel = true
 
         hourPicker.minValue = 1
         hourPicker.maxValue = 12
@@ -183,6 +185,11 @@ class FillingSetting02Fragment : Fragment() {
                 value = value
             )
         }
+
+        // 탭 스크롤
+        ampmPicker.enableTapToNext(wrap = true)
+        hourPicker.enableTapToNext(wrap = true)
+        minutePicker.enableTapToNext(wrap = true)
 
         val dialog = BottomSheetDialog(requireContext())
         dialog.setContentView(dialogView)

--- a/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting03Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/FillingSetting03Fragment.kt
@@ -21,6 +21,7 @@ import com.example.teumteum.databinding.FragmentFillingSetting03Binding
 import com.example.teumteum.ui.activity.viewModel.ActivityViewModel
 import com.example.teumteum.ui.main.HomeFragment
 import com.example.teumteum.utils.applyPickerValue
+import com.example.teumteum.utils.enableTapToNext
 import com.example.teumteum.utils.parse24hTimeToPickerValue
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -139,6 +140,7 @@ class FillingSetting03Fragment : Fragment() {
         ampmPicker.minValue = 0
         ampmPicker.maxValue = 1
         ampmPicker.displayedValues = arrayOf("AM", "PM")
+        ampmPicker.wrapSelectorWheel = true
 
         hourPicker.minValue = 1
         hourPicker.maxValue = 12
@@ -159,6 +161,11 @@ class FillingSetting03Fragment : Fragment() {
                 value = value
             )
         }
+
+        // 탭 스크롤
+        ampmPicker.enableTapToNext(wrap = true)
+        hourPicker.enableTapToNext(wrap = true)
+        minutePicker.enableTapToNext(wrap = true)
 
         val dialog = BottomSheetDialog(requireContext())
         dialog.setContentView(dialogView)

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
@@ -53,6 +53,7 @@ import com.example.teumteum.ui.todo.viewModel.TodoViewModel
 import com.example.teumteum.utils.TimeUtils.combineDateTime
 import com.example.teumteum.utils.applyPickerValue
 import com.example.teumteum.utils.dpToPx
+import com.example.teumteum.utils.enableTapToNext
 import com.example.teumteum.utils.moveCalendarMonth
 import com.example.teumteum.utils.parseKoreanAmPmTimeToPickerValue
 import com.example.teumteum.utils.weekdayShortKorean
@@ -65,7 +66,6 @@ import com.kizitonwose.calendar.view.MonthDayBinder
 import com.kizitonwose.calendar.view.ViewContainer
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
-import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.YearMonth
@@ -602,13 +602,16 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
             minValue = 0
             maxValue = 1
             displayedValues = arrayOf("오전", "오후")
+            wrapSelectorWheel = true
             post { applyTextStyleToNumberPicker(this, context) }
+            enableTapToNext(wrap = true)
         }
         binding.hourPicker01Np.apply {
             minValue = 1
             maxValue = 12
             wrapSelectorWheel = true
             post { applyTextStyleToNumberPicker(this, context) }
+            enableTapToNext(wrap = true)
         }
         binding.minutePicker01Np.apply {
             minValue = 0
@@ -616,19 +619,23 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
             displayedValues = arrayOf("00", "10", "20", "30", "40", "50")
             wrapSelectorWheel = true
             post { applyTextStyleToNumberPicker(this, context) }
+            enableTapToNext(wrap = true)
         }
 
         binding.ampmPicker02Np.apply {
             minValue = 0
             maxValue = 1
             displayedValues = arrayOf("오전", "오후")
+            wrapSelectorWheel = true
             post { applyTextStyleToNumberPicker(this, context) }
+            enableTapToNext(wrap = true)
         }
         binding.hourPicker02Np.apply {
             minValue = 1
             maxValue = 12
             wrapSelectorWheel = true
             post { applyTextStyleToNumberPicker(this, context) }
+            enableTapToNext(wrap = true)
         }
         binding.minutePicker02Np.apply {
             minValue = 0
@@ -636,6 +643,7 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
             displayedValues = arrayOf("00", "10", "20", "30", "40", "50")
             wrapSelectorWheel = true
             post { applyTextStyleToNumberPicker(this, context) }
+            enableTapToNext(wrap = true)
         }
     }
 

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
@@ -45,6 +45,7 @@ import com.example.teumteum.ui.myhome.viewModel.MyHomeViewModel
 import com.example.teumteum.ui.todo.viewModel.TodoViewModel
 import com.example.teumteum.utils.applyPickerValue
 import com.example.teumteum.utils.dpToPx
+import com.example.teumteum.utils.enableTapToNext
 import com.example.teumteum.utils.moveCalendarMonth
 import com.example.teumteum.utils.parseKoreanAmPmTimeToPickerValue
 import com.example.teumteum.utils.weekdayShortKorean
@@ -55,7 +56,6 @@ import com.kizitonwose.calendar.view.MonthDayBinder
 import com.kizitonwose.calendar.view.ViewContainer
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
-import java.time.DayOfWeek
 
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -516,13 +516,16 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
             minValue = 0
             maxValue = 1
             displayedValues = arrayOf("오전", "오후")
+            wrapSelectorWheel = true
             post { applyTextStyleToNumberPicker(this, context) }
+            enableTapToNext(wrap = true)
         }
         binding.hourPicker01Np.apply {
             minValue = 1
             maxValue = 12
             wrapSelectorWheel = true
             post { applyTextStyleToNumberPicker(this, context) }
+            enableTapToNext(wrap = true)
         }
         binding.minutePicker01Np.apply {
             minValue = 0
@@ -530,19 +533,23 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
             displayedValues = arrayOf("00", "10", "20", "30", "40", "50")
             wrapSelectorWheel = true
             post { applyTextStyleToNumberPicker(this, context) }
+            enableTapToNext(wrap = true)
         }
 
         binding.ampmPicker02Np.apply {
             minValue = 0
             maxValue = 1
             displayedValues = arrayOf("오전", "오후")
+            wrapSelectorWheel = true
             post { applyTextStyleToNumberPicker(this, context) }
+            enableTapToNext(wrap = true)
         }
         binding.hourPicker02Np.apply {
             minValue = 1
             maxValue = 12
             wrapSelectorWheel = true
             post { applyTextStyleToNumberPicker(this, context) }
+            enableTapToNext(wrap = true)
         }
         binding.minutePicker02Np.apply {
             minValue = 0
@@ -550,6 +557,7 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
             displayedValues = arrayOf("00", "10", "20", "30", "40", "50")
             wrapSelectorWheel = true
             post { applyTextStyleToNumberPicker(this, context) }
+            enableTapToNext(wrap = true)
         }
     }
 

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishSetting02Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishSetting02Fragment.kt
@@ -21,6 +21,7 @@ import com.example.teumteum.ui.main.HomeFragment
 import com.example.teumteum.ui.main.viewModel.HomeViewModel
 import com.example.teumteum.ui.wish.viewModel.WishViewModel
 import com.example.teumteum.utils.applyPickerValue
+import com.example.teumteum.utils.enableTapToNext
 import com.example.teumteum.utils.parse24hTimeToPickerValue
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -144,6 +145,7 @@ class WishSetting02Fragment : Fragment() {
         ampmPicker.minValue = 0
         ampmPicker.maxValue = 1
         ampmPicker.displayedValues = arrayOf("AM", "PM")
+        ampmPicker.wrapSelectorWheel = true
 
         hourPicker.minValue = 1
         hourPicker.maxValue = 12
@@ -164,6 +166,11 @@ class WishSetting02Fragment : Fragment() {
                 value = value
             )
         }
+
+        // 탭 스크롤
+        ampmPicker.enableTapToNext(wrap = true)
+        hourPicker.enableTapToNext(wrap = true)
+        minutePicker.enableTapToNext(wrap = true)
 
         val dialog = BottomSheetDialog(requireContext())
         dialog.setContentView(dialogView)

--- a/app/src/main/java/com/example/teumteum/ui/wish/WishSetting03Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/wish/WishSetting03Fragment.kt
@@ -20,6 +20,7 @@ import com.example.teumteum.databinding.FragmentWishSetting03Binding
 import com.example.teumteum.ui.main.HomeFragment
 import com.example.teumteum.ui.wish.viewModel.WishViewModel
 import com.example.teumteum.utils.applyPickerValue
+import com.example.teumteum.utils.enableTapToNext
 import com.example.teumteum.utils.parse24hTimeToPickerValue
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -117,6 +118,7 @@ class WishSetting03Fragment : Fragment() {
         ampmPicker.minValue = 0
         ampmPicker.maxValue = 1
         ampmPicker.displayedValues = arrayOf("AM", "PM")
+        ampmPicker.wrapSelectorWheel = true
 
         hourPicker.minValue = 1
         hourPicker.maxValue = 12
@@ -137,6 +139,11 @@ class WishSetting03Fragment : Fragment() {
                 value = value
             )
         }
+
+        // 탭 스크롤
+        ampmPicker.enableTapToNext(wrap = true)
+        hourPicker.enableTapToNext(wrap = true)
+        minutePicker.enableTapToNext(wrap = true)
 
         val dialog = BottomSheetDialog(requireContext())
         dialog.setContentView(dialogView)

--- a/app/src/main/java/com/example/teumteum/utils/TimePickerUtil.kt
+++ b/app/src/main/java/com/example/teumteum/utils/TimePickerUtil.kt
@@ -1,5 +1,7 @@
 package com.example.teumteum.utils
 
+import android.view.accessibility.AccessibilityNodeInfo
+import android.widget.EditText
 import android.widget.NumberPicker
 
 data class AmPmHourMinuteIndex(
@@ -70,4 +72,54 @@ fun parse24hTimeToPickerValue(
         hour12 = hour12.coerceIn(1, 12),
         minuteIndex = minuteIndex
     )
+}
+
+fun NumberPicker.enableTapToNext(
+    wrap: Boolean = true,
+    onAfterChange: ((newValue: Int) -> Unit)? = null
+) {
+    // 편집 모드 방지
+    descendantFocusability = NumberPicker.FOCUS_BLOCK_DESCENDANTS
+
+    post {
+        fun goNext() {
+            val cur = value
+            val min = minValue
+            val max = maxValue
+
+            // 현재 값 기준으로 다음 값 계산
+            val next = when {
+                cur < max -> cur + 1
+                wrap -> min
+                else -> max
+            }
+
+            // 스크롤 액션
+            val animated = (next == cur + 1) &&
+                    performAccessibilityAction(
+                        AccessibilityNodeInfo.ACTION_SCROLL_FORWARD,
+                        null
+                    )
+
+            if (!animated) value = next
+
+            onAfterChange?.invoke(next)
+        }
+
+        // 터치 이벤트 1: 1NumberPicker 자체 클릭
+        setOnClickListener { goNext() }
+
+        // 터치 이벤트 2: 내부 EditText 클릭
+        val editText = (0 until childCount)
+            .map { getChildAt(it) }
+            .filterIsInstance<EditText>()
+            .firstOrNull()
+
+        editText?.apply {
+            isFocusable = false
+            isFocusableInTouchMode = false
+            isCursorVisible = false
+            setOnClickListener { goNext() }
+        }
+    }
 }

--- a/app/src/main/java/com/example/teumteum/utils/TimePickerUtil.kt
+++ b/app/src/main/java/com/example/teumteum/utils/TimePickerUtil.kt
@@ -1,6 +1,5 @@
 package com.example.teumteum.utils
 
-import android.view.accessibility.AccessibilityNodeInfo
 import android.widget.EditText
 import android.widget.NumberPicker
 
@@ -94,19 +93,12 @@ fun NumberPicker.enableTapToNext(
                 else -> max
             }
 
-            // 스크롤 액션
-            val animated = (next == cur + 1) &&
-                    performAccessibilityAction(
-                        AccessibilityNodeInfo.ACTION_SCROLL_FORWARD,
-                        null
-                    )
-
-            if (!animated) value = next
+            value = next
 
             onAfterChange?.invoke(next)
         }
 
-        // 터치 이벤트 1: 1NumberPicker 자체 클릭
+        // 터치 이벤트 1: NumberPicker 자체 클릭
         setOnClickListener { goNext() }
 
         // 터치 이벤트 2: 내부 EditText 클릭


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #375 

## ✨ 작업 내용
> NumberPicker 내부에서 텍스트를 클릭하면 편집 작업으로 바뀌기 때문에, 텍스트 클릭 시 다음 항목으로 넘어가도록 수정하였습니다. (ex: "오전" 텍스트 클릭 시 "오후" 텍스트로 변경)

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 현재 항목 클릭 시 다음 항목으로 넘어가는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
* 시간 선택기에 탭-투-넥스트 탐색 추가 — 탭/키보드로 필드 간 이동이 매끄럽게 동작하도록 개선.
* 시간 선택기에 순환 선택(랩핑) 추가 — 최대/최소 값에서 자동으로 이어지는 직관적 선택 경험 제공.
* 앱 내 설정·할일·위시 화면 등 모든 관련 시간 선택기에 일관되게 적용.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->