### PR TITLE
[REFACTOR/#363] 캘린더 높이 간격 수정

### DIFF
--- a/app/src/main/res/layout/bottom_sheet_assign_calendar.xml
+++ b/app/src/main/res/layout/bottom_sheet_assign_calendar.xml
@@ -94,6 +94,7 @@
             app:cv_dayViewResource="@layout/calendar_day_layout"
             app:cv_orientation="horizontal"
             app:cv_outDateStyle="endOfRow"
+            app:cv_daySize="rectangle"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/calendar_weekdays_row" />

--- a/app/src/main/res/layout/bottom_sheet_todo_register.xml
+++ b/app/src/main/res/layout/bottom_sheet_todo_register.xml
@@ -178,6 +178,7 @@
                         app:cv_dayViewResource="@layout/calendar_day_layout"
                         app:cv_orientation="horizontal"
                         app:cv_outDateStyle="endOfRow"
+                        app:cv_daySize="rectangle"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/calendar_weekdays_row_01" />
@@ -309,6 +310,7 @@
                         app:cv_dayViewResource="@layout/calendar_day_layout"
                         app:cv_orientation="horizontal"
                         app:cv_outDateStyle="endOfRow"
+                        app:cv_daySize="rectangle"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/calendar_weekdays_row_02" />

--- a/app/src/main/res/layout/calendar_day_layout.xml
+++ b/app/src/main/res/layout/calendar_day_layout.xml
@@ -2,12 +2,13 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:minHeight="40dp"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <TextView
         android:id="@+id/calendar_day_tv"
-        android:layout_width="28dp"
-        android:layout_height="28dp"
+        android:layout_width="25dp"
+        android:layout_height="25dp"
         android:gravity="center"
         android:textSize="12sp"
         app:layout_constraintTop_toTopOf="parent"
@@ -19,7 +20,6 @@
         android:id="@+id/dot_view"
         android:layout_width="5dp"
         android:layout_height="5dp"
-        android:layout_marginBottom="4dp"
         android:background="@drawable/dot_schedule_exists"
         android:visibility="gone"
         app:layout_constraintTop_toBottomOf="@id/calendar_day_tv"

--- a/app/src/main/res/layout/fragment_friend_promise.xml
+++ b/app/src/main/res/layout/fragment_friend_promise.xml
@@ -125,6 +125,7 @@
             app:cv_dayViewResource="@layout/calendar_day_layout"
             app:cv_orientation="horizontal"
             app:cv_outDateStyle="endOfRow"
+            app:cv_daySize="rectangle"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/calendar_weekdays_row" />

--- a/app/src/main/res/layout/fragment_friend_roommate_date.xml
+++ b/app/src/main/res/layout/fragment_friend_roommate_date.xml
@@ -207,6 +207,7 @@
             app:cv_dayViewResource="@layout/calendar_day_layout"
             app:cv_orientation="horizontal"
             app:cv_outDateStyle="endOfRow"
+            app:cv_daySize="rectangle"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/calendar_weekdays_row" />

--- a/app/src/main/res/layout/fragment_friend_teum_request.xml
+++ b/app/src/main/res/layout/fragment_friend_teum_request.xml
@@ -105,6 +105,7 @@
                 app:cv_dayViewResource="@layout/calendar_day_layout"
                 app:cv_orientation="horizontal"
                 app:cv_outDateStyle="endOfRow"
+                app:cv_daySize="rectangle"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/calendar_weekdays_row" />

--- a/app/src/main/res/layout/fragment_friend_todo_list.xml
+++ b/app/src/main/res/layout/fragment_friend_todo_list.xml
@@ -125,6 +125,7 @@
             app:cv_dayViewResource="@layout/calendar_day_layout"
             app:cv_orientation="horizontal"
             app:cv_outDateStyle="endOfRow"
+            app:cv_daySize="rectangle"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/calendar_weekdays_row" />

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -278,6 +278,7 @@
                         app:cv_dayViewResource="@layout/calendar_day_layout"
                         app:cv_orientation="horizontal"
                         app:cv_outDateStyle="endOfRow"
+                        app:cv_daySize="rectangle"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/calendar_weekdays_row" />


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #363 

## ✨ 작업 내용
틈틈 서비스 내에서 사용되는 모든 캘린더에 `app:cv_daySize="rectangle"` 속성을 추가하고` android:minHeight="40dp"` 값이 적용되도록 수정하였습니다. 
적용한 캘린더: 홈, 투두, 빈틈 채우기, 틈 요청 기록, 약속된 틈 일정, 틈 요청 날짜 선택, 공개 투두 조회
현재 월별캘린더가 2월(4행), 3월(5행), 5월(6행) 이런식으로 각각 높이가 달라서 전환하게 되면 약간 부자연스러운 느낌이 있기 때문에, 관련하여 디자이너분께 여쭤보고 6행으로 고정하는 방식으로 간다면 그에 맞게 수정할 예정입니다.

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 캘린더 높이 간격이 피그마의 캘린더 높이 간격과 유사한지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 캘린더 날짜 셀이 직사각형으로 표시되도록 변경
  * 캘린더 날짜 레이아웃의 크기 및 간격 조정
  * 캘린더 전반에 걸쳐 일관된 시각적 모양 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->