### PR TITLE
[REFACTOR/#382] 타임피커 텍스트 관련 공통 적용

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/friend/Friend02SuggestFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/Friend02SuggestFragment.kt
@@ -20,6 +20,7 @@ import com.example.teumteum.databinding.FragmentFriend02SuggestBinding
 import com.example.teumteum.ui.friend.adapter.FriendRequestCardAdapter
 import com.example.teumteum.ui.friend.viewModel.FriendViewModel
 import com.example.teumteum.ui.main.MainActivity
+import com.example.teumteum.utils.enableTapToNext
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDate
@@ -139,9 +140,23 @@ class Friend02SuggestFragment : Fragment() {
         val m = dialogView.findViewById<NumberPicker>(R.id.minutePicker01Np)
         val mins = arrayOf("00","10","20","30","40","50")
 
-        am.minValue = 0; am.maxValue = 1; am.displayedValues = arrayOf("AM","PM")
-        h.minValue = 1; h.maxValue = 12; h.wrapSelectorWheel = true
-        m.minValue = 0; m.maxValue = mins.size-1; m.displayedValues = mins; m.wrapSelectorWheel = true
+        am.minValue = 0
+        am.maxValue = 1
+        am.displayedValues = arrayOf("AM","PM")
+        am.wrapSelectorWheel = true
+
+        h.minValue = 1
+        h.maxValue = 12
+        h.wrapSelectorWheel = true
+
+        m.minValue = 0
+        m.maxValue = mins.size-1
+        m.displayedValues = mins
+        m.wrapSelectorWheel = true
+
+        am.enableTapToNext(wrap = true)
+        h.enableTapToNext(wrap = true)
+        m.enableTapToNext(wrap = true)
 
         // 초기값 세팅
         runCatching {

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendRoommateMatchingDetailFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendRoommateMatchingDetailFragment.kt
@@ -20,6 +20,7 @@ import com.example.teumteum.ui.friend.viewModel.FriendViewModel
 import com.example.teumteum.ui.main.MainActivity
 import com.example.teumteum.ui.auth.SignUpActivity
 import com.example.teumteum.ui.friend.adapter.TimeConflictCardAdapter
+import com.example.teumteum.utils.enableTapToNext
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDate
@@ -170,9 +171,23 @@ class FriendRoommateMatchingDetailFragment : Fragment() {
         val m = dialogView.findViewById<NumberPicker>(R.id.minutePicker01Np)
         val mins = arrayOf("00","10","20","30","40","50")
 
-        am.minValue = 0; am.maxValue = 1; am.displayedValues = arrayOf("AM","PM")
-        h.minValue = 1; h.maxValue = 12; h.wrapSelectorWheel = true
-        m.minValue = 0; m.maxValue = mins.size-1; m.displayedValues = mins; m.wrapSelectorWheel = true
+        am.minValue = 0
+        am.maxValue = 1
+        am.displayedValues = arrayOf("AM","PM")
+        am.wrapSelectorWheel = true
+
+        h.minValue = 1
+        h.maxValue = 12
+        h.wrapSelectorWheel = true
+
+        m.minValue = 0
+        m.maxValue = mins.size-1
+        m.displayedValues = mins
+        m.wrapSelectorWheel = true
+
+        am.enableTapToNext(wrap = true)
+        h.enableTapToNext(wrap = true)
+        m.enableTapToNext(wrap = true)
 
         // 초기값 세팅
         runCatching {

--- a/app/src/main/java/com/example/teumteum/ui/myhome/BottomSheetRoutineFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/myhome/BottomSheetRoutineFragment.kt
@@ -17,6 +17,7 @@ import com.example.teumteum.R
 import com.example.teumteum.databinding.BottomSheetScheduleBinding
 import com.example.teumteum.ui.myhome.data.MyRoutine
 import com.example.teumteum.ui.myhome.viewModel.MyRoutineViewModel
+import com.example.teumteum.utils.enableTapToNext
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import java.time.LocalTime
@@ -142,6 +143,9 @@ class BottomSheetRoutineFragment(
             it.minValue = 0
             it.maxValue = 1
             it.displayedValues = arrayOf("오전", "오후")
+            it.wrapSelectorWheel = true
+
+            it.enableTapToNext(wrap = true)
             applyTextStyleToNumberPicker(it, context)
         }
 
@@ -149,6 +153,8 @@ class BottomSheetRoutineFragment(
             it.minValue = 1
             it.maxValue = 12
             it.wrapSelectorWheel = true
+
+            it.enableTapToNext(wrap = true)
             applyTextStyleToNumberPicker(it, context)
         }
 
@@ -158,6 +164,8 @@ class BottomSheetRoutineFragment(
             it.maxValue = minuteValues.size - 1
             it.displayedValues = minuteValues
             it.wrapSelectorWheel = true
+
+            it.enableTapToNext(wrap = true)
             applyTextStyleToNumberPicker(it, context)
         }
     }

--- a/app/src/main/java/com/example/teumteum/ui/myhome/BottomSheetRoutineModifyFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/myhome/BottomSheetRoutineModifyFragment.kt
@@ -17,6 +17,7 @@ import com.example.teumteum.R
 import com.example.teumteum.databinding.FragmentBottomSheetRoutineModifyBinding
 import com.example.teumteum.ui.myhome.data.MyRoutine
 import com.example.teumteum.ui.myhome.viewModel.MyRoutineViewModel
+import com.example.teumteum.utils.enableTapToNext
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import java.time.LocalTime
@@ -151,6 +152,9 @@ class BottomSheetRoutineModifyFragment(
             it.minValue = 0
             it.maxValue = 1
             it.displayedValues = arrayOf("오전", "오후")
+            it.wrapSelectorWheel = true
+
+            it.enableTapToNext(wrap = true)
             applyTextStyleToNumberPicker(it, context)
         }
 
@@ -158,6 +162,8 @@ class BottomSheetRoutineModifyFragment(
             it.minValue = 1
             it.maxValue = 12
             it.wrapSelectorWheel = true
+
+            it.enableTapToNext(wrap = true)
             applyTextStyleToNumberPicker(it, context)
         }
 
@@ -167,6 +173,8 @@ class BottomSheetRoutineModifyFragment(
             it.maxValue = minuteValues.size - 1
             it.displayedValues = minuteValues
             it.wrapSelectorWheel = true
+
+            it.enableTapToNext(wrap = true)
             applyTextStyleToNumberPicker(it, context)
         }
     }

--- a/app/src/main/java/com/example/teumteum/ui/myhome/MySleepPatternSettingFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/myhome/MySleepPatternSettingFragment.kt
@@ -21,6 +21,7 @@ import com.example.teumteum.databinding.FragmentMySleepPatternSettingBinding
 import com.example.teumteum.ui.main.MainActivity
 import com.example.teumteum.ui.main.viewModel.HomeViewModel
 import com.example.teumteum.ui.myhome.viewModel.SettingViewModel
+import com.example.teumteum.utils.enableTapToNext
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalTime
@@ -105,13 +106,20 @@ class MySleepPatternSettingFragment : Fragment() {
         ampmPicker.minValue = 0
         ampmPicker.maxValue = 1
         ampmPicker.displayedValues = arrayOf("AM", "PM")
+        ampmPicker.wrapSelectorWheel = true
 
         hourPicker.minValue = 1
         hourPicker.maxValue = 12
+        hourPicker.wrapSelectorWheel = true
 
         minutePicker.minValue = 0
         minutePicker.maxValue = minuteValues.size - 1
         minutePicker.displayedValues = minuteValues
+        minutePicker.wrapSelectorWheel = true
+
+        ampmPicker.enableTapToNext(wrap = true)
+        hourPicker.enableTapToNext(wrap = true)
+        minutePicker.enableTapToNext(wrap = true)
 
         val dialog = BottomSheetDialog(requireContext()).apply {
             setContentView(dialogView)

--- a/app/src/main/java/com/example/teumteum/ui/onboarding/BottomSheetScheduleFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/onboarding/BottomSheetScheduleFragment.kt
@@ -17,6 +17,7 @@ import com.example.teumteum.R
 import com.example.teumteum.databinding.BottomSheetScheduleBinding
 import com.example.teumteum.ui.onboarding.data.Schedule
 import com.example.teumteum.ui.onboarding.viewModel.OnBoardingViewModel
+import com.example.teumteum.utils.enableTapToNext
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import java.time.LocalTime
@@ -148,6 +149,9 @@ class BottomSheetScheduleFragment(
             it.minValue = 0
             it.maxValue = 1
             it.displayedValues = arrayOf("오전", "오후")
+            it.wrapSelectorWheel = true
+
+            it.enableTapToNext(wrap = true)
             applyTextStyleToNumberPicker(it, context)
         }
 
@@ -155,6 +159,8 @@ class BottomSheetScheduleFragment(
             it.minValue = 1
             it.maxValue = 12
             it.wrapSelectorWheel = true
+
+            it.enableTapToNext(wrap = true)
             applyTextStyleToNumberPicker(it, context)
         }
 
@@ -164,6 +170,8 @@ class BottomSheetScheduleFragment(
             it.maxValue = minuteValues.size - 1
             it.displayedValues = minuteValues
             it.wrapSelectorWheel = true
+
+            it.enableTapToNext(wrap = true)
             applyTextStyleToNumberPicker(it, context)
         }
     }

--- a/app/src/main/java/com/example/teumteum/ui/onboarding/OnBoardingSleepPatternFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/onboarding/OnBoardingSleepPatternFragment.kt
@@ -17,6 +17,7 @@ import com.example.teumteum.databinding.FragmentOnBoardingSleepPatternBinding
 import com.example.teumteum.ui.onboarding.viewModel.OnBoardingUiState
 import com.example.teumteum.ui.onboarding.viewModel.OnBoardingViewModel
 import com.example.teumteum.ui.auth.SignUpActivity
+import com.example.teumteum.utils.enableTapToNext
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalTime
@@ -138,13 +139,20 @@ class OnBoardingSleepPatternFragment : Fragment() {
         ampmPicker.minValue = 0
         ampmPicker.maxValue = 1
         ampmPicker.displayedValues = arrayOf("AM", "PM")
+        ampmPicker.wrapSelectorWheel = true
 
         hourPicker.minValue = 1
         hourPicker.maxValue = 12
+        hourPicker.wrapSelectorWheel = true
 
         minutePicker.minValue = 0
         minutePicker.maxValue = minuteValues.size - 1
         minutePicker.displayedValues = minuteValues
+        minutePicker.wrapSelectorWheel = true
+
+        ampmPicker.enableTapToNext(wrap = true)
+        hourPicker.enableTapToNext(wrap = true)
+        minutePicker.enableTapToNext(wrap = true)
 
         val dialog = BottomSheetDialog(requireContext()).apply {
             setContentView(dialogView)


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #382 

## ✨ 작업 내용
이전에 https://github.com/UMC8-TeumTeum/FE/issues/375 에서 타임피커 텍스트 클릭 시 다음 항목으로 넘기는 작업을 진행했었는데, 투두 등록/수정과 빈틈채우기가 아닌 수면패턴, 반복일정, 거절 시 가능한 시간대 선택, 틈 요청 시간대 선택 내에 있는 타임피커에서도 동일하게 작업하였습니다.
기본 캘린더에서 일정 추가할때 시/분 텍스트를 클릭하면 편집 작업 -> 키패드로 숫자 입력하면 타임피커에 시간이 적용되면서 자동 스크롤되는 방식으로 진행되는데 일단은 텍스트 클릭 시 편집 모드가 아닌 다음 항목으로 넘기는 식으로 작업할 예정입니다. (ex. 처음에 타임피커 값이 15:00인데 '01:48'을 입력하면 시: 01(00과 02 사이), 분: 48(40과 50 사이) 이런식으로 자동 스크롤되는 구조)

<img width="367" height="707" alt="Image" src="https://github.com/user-attachments/assets/3d12a38b-a20c-4579-81cd-f463a80bdfa5" />

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 타임피커에서 텍스트 클릭 시 다음 항목으로 넘어가는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 시간 선택기에서 탭-투-넥스트 네비게이션 기능 추가로 사용자가 AM/PM, 시간, 분 간 더 빠르게 이동할 수 있습니다.
  * 순환 네비게이션 활성화로 마지막 항목에서 첫 번째 항목으로 매끄럽게 전환됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->