### PR TITLE
[REFACTOR/#369] 타임피커 시간 설정 후 빈 영역 클릭 시 적용되도록 수정

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
@@ -10,6 +10,7 @@ import android.util.TypedValue
 import android.view.Gravity
 import android.view.KeyEvent
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
@@ -51,6 +52,7 @@ import com.example.teumteum.databinding.DialogConfirmWishDeleteBinding
 
 import com.example.teumteum.ui.friend.viewModel.FriendViewModel
 import com.example.teumteum.ui.todo.adapter.TeumProfileAdapter
+import com.example.teumteum.ui.todo.data.ActiveTimePicker
 import com.example.teumteum.ui.todo.viewModel.TodoViewModel
 import com.example.teumteum.utils.TimeUtils.combineDateTime
 import com.example.teumteum.utils.applyPickerValue
@@ -129,6 +131,8 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
     private var visibleStartMonth: YearMonth = YearMonth.now()
     private var visibleEndMonth: YearMonth = YearMonth.now()
 
+    private var activeTimePicker: ActiveTimePicker = ActiveTimePicker.NONE
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         todoId = arguments?.getLong("todo_id") ?: -1L
@@ -185,6 +189,7 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
         setupClickListeners(scheduleType)
         setupObservers()
         setupTitleImeDone()
+        setupTapOutsideToApplyTime()
 
         // 원래 스크롤뷰 패딩 저장
         val originalBottomPadding = binding.editScroll.paddingBottom
@@ -220,6 +225,7 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
             val isVisibleNow = binding.timePickerStartContainer.isVisible
             if (isVisibleNow) {
                 applySelectedTime(isStart = true)
+                activeTimePicker = ActiveTimePicker.NONE
             } else {
                 parseKoreanAmPmTimeToPickerValue(
                     timeText = binding.startTimeTv.text.toString(),
@@ -231,6 +237,7 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
                         value = v
                     )
                 }
+                activeTimePicker = ActiveTimePicker.START
             }
 
             binding.timePickerStartContainer.isVisible = !isVisibleNow
@@ -246,6 +253,7 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
             val isVisibleNow = binding.timePickerEndContainer.isVisible
             if (isVisibleNow) {
                 applySelectedTime(isStart = false)
+                activeTimePicker = ActiveTimePicker.NONE
             } else {
                 parseKoreanAmPmTimeToPickerValue(
                     timeText = binding.endTimeTv.text.toString(),
@@ -257,6 +265,7 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
                         value = v
                     )
                 }
+                activeTimePicker = ActiveTimePicker.END
             }
 
             binding.timePickerEndContainer.isVisible = !isVisibleNow
@@ -1322,6 +1331,39 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
     private fun hideKeyboard(view: View) {
         val imm = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
         imm.hideSoftInputFromWindow(view.windowToken, 0)
+    }
+
+    private fun setupTapOutsideToApplyTime() {
+        val touchTargets = listOf(binding.root, binding.editScroll)
+
+        touchTargets.forEach { target ->
+            target.setOnTouchListener { v, event ->
+                when (event.action) {
+                    MotionEvent.ACTION_UP -> {
+                        // 타임피커 안 열려있으면 패스
+                        if (activeTimePicker == ActiveTimePicker.NONE) return@setOnTouchListener false
+
+                        // 바깥 탭이면 적용 + 닫기
+                        when (activeTimePicker) {
+                            ActiveTimePicker.START -> applySelectedTime(isStart = true)
+                            ActiveTimePicker.END -> applySelectedTime(isStart = false)
+                            else -> {}
+                        }
+                        activeTimePicker = ActiveTimePicker.NONE
+                        currentTargetTextView = null
+
+                        v.performClick() // 접근성용 클릭 이벤트
+                        true
+                    }
+
+                    // 다운은 소비하지 않음
+                    MotionEvent.ACTION_DOWN -> false
+                    else -> false
+                }
+            }
+
+            target.isClickable = true
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
@@ -303,6 +303,7 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
                 binding.timePickerStartContainer.isVisible = false
                 binding.timePickerEndContainer.isVisible = false
                 currentTargetTextView = null
+                activeTimePicker = ActiveTimePicker.NONE
             }
             isStartDateSelected = true
             toggleCalendarVisibility(show = true)
@@ -313,6 +314,7 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
                 binding.timePickerStartContainer.isVisible = false
                 binding.timePickerEndContainer.isVisible = false
                 currentTargetTextView = null
+                activeTimePicker = ActiveTimePicker.NONE
             }
             isStartDateSelected = false
             toggleCalendarVisibility(show = true)

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoEditFragment.kt
@@ -1336,12 +1336,22 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
     private fun setupTapOutsideToApplyTime() {
         val touchTargets = listOf(binding.root, binding.editScroll)
 
+        fun isTouchInside(view: View, event: MotionEvent): Boolean {
+            val loc = IntArray(2)
+            view.getLocationOnScreen(loc)
+            val x = event.rawX
+            val y = event.rawY
+            return x >= loc[0] && x <= loc[0] + view.width && y >= loc[1] && y <= loc[1] + view.height
+        }
+
         touchTargets.forEach { target ->
             target.setOnTouchListener { v, event ->
                 when (event.action) {
                     MotionEvent.ACTION_UP -> {
                         // 타임피커 안 열려있으면 패스
                         if (activeTimePicker == ActiveTimePicker.NONE) return@setOnTouchListener false
+
+                        val isOnTarget = currentTargetTextView?.let { isTouchInside(it, event) } ?: false
 
                         // 바깥 탭이면 적용 + 닫기
                         when (activeTimePicker) {
@@ -1353,7 +1363,9 @@ class BottomSheetTodoEditFragment : BottomSheetDialogFragment() {
                         currentTargetTextView = null
 
                         v.performClick() // 접근성용 클릭 이벤트
-                        true
+
+                        // 타임 텍스트 탭은 소비(재오픈 방지), 그 외는 이벤트 전달
+                        return@setOnTouchListener isOnTarget
                     }
 
                     // 다운은 소비하지 않음

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
@@ -971,12 +971,22 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
     private fun setupTapOutsideToApplyTime() {
         val touchTargets = listOf(binding.root, binding.registerScroll)
 
+        fun isTouchInside(view: View, event: MotionEvent): Boolean {
+            val loc = IntArray(2)
+            view.getLocationOnScreen(loc)
+            val x = event.rawX
+            val y = event.rawY
+            return x >= loc[0] && x <= loc[0] + view.width && y >= loc[1] && y <= loc[1] + view.height
+        }
+
         touchTargets.forEach { target ->
             target.setOnTouchListener { v, event ->
                 when (event.action) {
                     MotionEvent.ACTION_UP -> {
                         // 타임피커 안 열려있으면 패스
                         if (activeTimePicker == ActiveTimePicker.NONE) return@setOnTouchListener false
+
+                        val isOnTarget = currentTargetTextView?.let { isTouchInside(it, event) } ?: false
 
                         // 바깥 탭이면 적용 + 닫기
                         when (activeTimePicker) {
@@ -988,7 +998,9 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
                         currentTargetTextView = null
 
                         v.performClick() // 접근성용 클릭 이벤트
-                        true
+
+                        // 타임 텍스트 탭은 소비(재오픈 방지), 그 외는 이벤트 전달
+                        return@setOnTouchListener isOnTarget
                     }
 
                     // 다운은 소비하지 않음

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
@@ -300,6 +300,7 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
                 binding.timePickerStartContainer.isVisible = false
                 binding.timePickerEndContainer.isVisible = false
                 currentTargetTextView = null
+                activeTimePicker = ActiveTimePicker.NONE
             }
             isStartDateSelected = true
             toggleCalendarVisibility(show = true)
@@ -310,6 +311,7 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
                 binding.timePickerStartContainer.isVisible = false
                 binding.timePickerEndContainer.isVisible = false
                 currentTargetTextView = null
+                activeTimePicker = ActiveTimePicker.NONE
             }
             isStartDateSelected = false
             toggleCalendarVisibility(show = true)

--- a/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/BottomSheetTodoRegisterFragment.kt
@@ -10,6 +10,7 @@ import android.util.TypedValue
 import android.view.Gravity
 import android.view.KeyEvent
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
@@ -45,6 +46,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
 import com.example.teumteum.ui.myhome.viewModel.MyHomeViewModel
+import com.example.teumteum.ui.todo.data.ActiveTimePicker
 import com.example.teumteum.ui.todo.viewModel.TodoViewModel
 import com.example.teumteum.utils.applyPickerValue
 import com.example.teumteum.utils.dpToPx
@@ -107,6 +109,8 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
     private var visibleStartMonth: YearMonth = YearMonth.now()
     private var visibleEndMonth: YearMonth = YearMonth.now()
 
+    private var activeTimePicker: ActiveTimePicker = ActiveTimePicker.NONE
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -159,6 +163,7 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
 
         setupTitleImeDone()
         setupClickListeners()
+        setupTapOutsideToApplyTime()
 
         viewModel.getOnboardingReminders()
 
@@ -205,6 +210,7 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
             val isVisibleNow = binding.timePickerStartContainer.isVisible
             if (isVisibleNow) {
                 applySelectedTime(isStart = true)
+                activeTimePicker = ActiveTimePicker.NONE
             } else {
                 parseKoreanAmPmTimeToPickerValue(
                     timeText = binding.startTimeTv.text.toString(),
@@ -216,6 +222,7 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
                         value = v
                     )
                 }
+                activeTimePicker = ActiveTimePicker.START
             }
 
             binding.timePickerStartContainer.isVisible = !isVisibleNow
@@ -231,6 +238,7 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
             val isVisibleNow = binding.timePickerEndContainer.isVisible
             if (isVisibleNow) {
                 applySelectedTime(isStart = false)
+                activeTimePicker = ActiveTimePicker.NONE
             } else {
                 parseKoreanAmPmTimeToPickerValue(
                     timeText = binding.endTimeTv.text.toString(),
@@ -242,6 +250,7 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
                         value = v
                     )
                 }
+                activeTimePicker = ActiveTimePicker.END
             }
 
             binding.timePickerEndContainer.isVisible = !isVisibleNow
@@ -957,6 +966,39 @@ class BottomSheetTodoRegisterFragment : BottomSheetDialogFragment()  {
     private fun hideKeyboard(view: View) {
         val imm = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
         imm.hideSoftInputFromWindow(view.windowToken, 0)
+    }
+
+    private fun setupTapOutsideToApplyTime() {
+        val touchTargets = listOf(binding.root, binding.registerScroll)
+
+        touchTargets.forEach { target ->
+            target.setOnTouchListener { v, event ->
+                when (event.action) {
+                    MotionEvent.ACTION_UP -> {
+                        // 타임피커 안 열려있으면 패스
+                        if (activeTimePicker == ActiveTimePicker.NONE) return@setOnTouchListener false
+
+                        // 바깥 탭이면 적용 + 닫기
+                        when (activeTimePicker) {
+                            ActiveTimePicker.START -> applySelectedTime(isStart = true)
+                            ActiveTimePicker.END -> applySelectedTime(isStart = false)
+                            else -> {}
+                        }
+                        activeTimePicker = ActiveTimePicker.NONE
+                        currentTargetTextView = null
+
+                        v.performClick() // 접근성용 클릭 이벤트
+                        true
+                    }
+
+                    // 다운은 소비하지 않음
+                    MotionEvent.ACTION_DOWN -> false
+                    else -> false
+                }
+            }
+
+            target.isClickable = true
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/teumteum/ui/todo/data/ActiveTimePicker.kt
+++ b/app/src/main/java/com/example/teumteum/ui/todo/data/ActiveTimePicker.kt
@@ -1,0 +1,3 @@
+package com.example.teumteum.ui.todo.data
+
+enum class ActiveTimePicker { NONE, START, END }

--- a/app/src/main/res/layout/bottom_sheet_todo_edit.xml
+++ b/app/src/main/res/layout/bottom_sheet_todo_edit.xml
@@ -90,7 +90,7 @@
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/profile_image_rc"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="38dp"
                 android:layout_marginTop="20dp" />
 


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #369 

## ✨ 작업 내용
> 타임피커 시간 설정 후 빈 영역 클릭 시 적용되도록 수정하였습니다. 시작시간/종료시간 타임피커에서 시간을 설정한 후 바텀시트의 빈 영역을 터치하면 설정한 시간이 적용되면서 타임피커가 닫힙니다. (타임피커 시간 설정 후 시작 시간 텍스트 영역 or 종료 시간 텍스트 영역을 클릭해도 적용 o)

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 빈 영역 클릭 시 타임피커 시간값이 잘 적용되는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 시간 선택기 외부를 탭하면 현재 선택된 시간이 자동으로 적용되며, 편집 및 등록 화면에서 외부 탭으로 시간 선택을 적용·해제하는 흐름이 추가되었습니다.
  * 접근성 반응성(화면 낭독/클릭 트리거)이 개선되어 외부 탭 동작 시 보조 기술과의 상호작용이 향상되었습니다.

* **스타일**
  * 프로필 이미지 영역의 가로 레이아웃이 조정되어 항목 흐름 및 화면 정렬이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->