### PR TITLE
[REFACTOR/#394] 차단시 차단됨으로 텍스트 수정하기

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendBlockBottomSheetFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendBlockBottomSheetFragment.kt
@@ -60,13 +60,6 @@ class FriendBlockBottomSheet : BottomSheetDialogFragment() {
             // 차단 API 호출
             viewModel.blockUser(userId)
 
-            // 토스트 표시
-            Toast.makeText(
-                requireContext(),
-                "${userName}님을 차단했습니다.",
-                Toast.LENGTH_SHORT
-            ).show()
-
             // 바텀시트 닫기
             dismiss()
         }

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendProfileFollowingFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendProfileFollowingFragment.kt
@@ -1,5 +1,6 @@
 package com.example.teumteum.ui.friend
 
+import android.graphics.Color
 import android.os.Bundle
 import android.util.Log
 import android.view.Gravity
@@ -208,6 +209,25 @@ class FriendProfileFollowingFragment : Fragment() {
 
 
     private fun observeViewModel() {
+        // 차단 성공 → 버튼 상태 변경
+        viewModel.blockComplete.observe(viewLifecycleOwner) { event ->
+            event.getContentIfNotHandled()?.let { success ->
+                if (success) {
+                    binding.modifyProfileBtn.text = "차단됨"
+                    binding.modifyProfileBtn.isEnabled = false
+                    binding.modifyProfileBtn.alpha = 0.5f
+
+                    binding.modifyProfileBtn.setTextColor(
+                        Color.parseColor("#0F0F0F")
+                    )
+
+                    binding.starBtn.isEnabled = false
+                    binding.sendBtn.isEnabled = false
+                    binding.settingBtn.isEnabled = false
+                }
+            }
+        }
+
         // 언팔로우 결과 메시지
         viewModel.unfollowMessage.observe(viewLifecycleOwner) { event ->
             event.getContentIfNotHandled()?.let { msg ->


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #394

## ✨ 작업 내용
> 차단시 텍스트를 차단됨을 수정하기 

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 차단시 밑에 버튼부분에 있는 텍스트가 팔로잉 - > 차단됨으로 바뀌는지 


## 📸 스크린샷 (선택)
> 
<img width="509" height="1041" alt="image" src="https://github.com/user-attachments/assets/2dd74d53-4132-4894-a4a6-e93c171ff1e9" />


## 💬 기타 참고 사항
> x


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 사용자 차단 완료 후 토스트 알림 제거로 간결한 사용 경험 제공
  * 차단된 사용자 프로필에 명확한 차단 상태 표시: "차단됨" 텍스트와 비활성화된 버튼
  * 차단 상태에서 프로필 조회, 메시지 전송 등 관련 기능 버튼 자동 비활성화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->