### PR TITLE
[REFACTOR/#402] 틈 요청 카드 UI 수정

### DIFF
--- a/app/src/main/res/layout/fragment_friend.xml
+++ b/app/src/main/res/layout/fragment_friend.xml
@@ -138,7 +138,7 @@
             android:id="@+id/recommendRecyclerView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="183dp"
+            android:layout_marginTop="185dp"
             android:clipToPadding="false"
             android:overScrollMode="never"
             android:paddingStart="21dp"

--- a/app/src/main/res/layout/friend01_item_recommend_card.xml
+++ b/app/src/main/res/layout/friend01_item_recommend_card.xml
@@ -11,16 +11,14 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:paddingTop="10dp"
-        android:paddingBottom="10dp">
+        android:layout_height="match_parent">
 
         <!-- 프로필 이미지 -->
         <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/profile_iv"
             android:layout_width="57dp"
             android:layout_height="57dp"
-            android:layout_marginTop="10dp"
+            android:layout_marginTop="15dp"
             android:scaleType="centerCrop"
             android:background="@drawable/freind01_circle_profile"
             app:layout_constraintTop_toTopOf="parent"
@@ -50,7 +48,7 @@
             android:id="@+id/border"
             android:layout_width="0dp"
             android:layout_height="0.95dp"
-            android:layout_marginTop="8dp"
+            android:layout_marginTop="7dp"
             android:background="#7770FE"
             app:layout_constraintTop_toBottomOf="@id/tvName"
             app:layout_constraintStart_toStartOf="parent"
@@ -62,16 +60,15 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
-            android:text="사용자가 작성한 제목"
-            android:textSize="12sp"
-            android:textColor="#0F0F0F"
             android:fontFamily="@font/noto_sans_kr_regular"
             android:includeFontPadding="false"
             android:lineSpacingExtra="0dp"
-            app:layout_constraintTop_toBottomOf="@id/border"
-            app:layout_constraintBottom_toBottomOf="parent"
+            android:text="사용자가 작성한 제목"
+            android:textColor="#0F0F0F"
+            android:textSize="12sp"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            app:layout_constraintTop_toBottomOf="@id/border" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/friend01_item_recommend_card_read.xml
+++ b/app/src/main/res/layout/friend01_item_recommend_card_read.xml
@@ -21,16 +21,14 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:paddingTop="10dp"
-            android:paddingBottom="10dp">
+            android:layout_height="match_parent">
 
             <!-- 프로필 이미지 -->
             <com.google.android.material.imageview.ShapeableImageView
                 android:id="@+id/profile_iv"
                 android:layout_width="57dp"
                 android:layout_height="57dp"
-                android:layout_marginTop="10dp"
+                android:layout_marginTop="15dp"
                 android:scaleType="centerCrop"
                 android:background="@drawable/freind01_circle_profile"
                 app:layout_constraintTop_toTopOf="parent"
@@ -60,7 +58,7 @@
                 android:id="@+id/border"
                 android:layout_width="0dp"
                 android:layout_height="0.95dp"
-                android:layout_marginTop="8dp"
+                android:layout_marginTop="7dp"
                 android:background="#7770FE"
                 app:layout_constraintTop_toBottomOf="@id/tvName"
                 app:layout_constraintStart_toStartOf="parent"
@@ -72,16 +70,15 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
-                android:text="사용자가 작성한 제목"
-                android:textSize="12sp"
-                android:textColor="#0F0F0F"
                 android:fontFamily="@font/noto_sans_kr_regular"
                 android:includeFontPadding="false"
                 android:lineSpacingExtra="0dp"
-                app:layout_constraintTop_toBottomOf="@id/border"
-                app:layout_constraintBottom_toBottomOf="parent"
+                android:text="사용자가 작성한 제목"
+                android:textColor="#0F0F0F"
+                android:textSize="12sp"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent" />
+                app:layout_constraintTop_toBottomOf="@id/border" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #402

## ✨ 작업 내용
> 친구 메인화면에서 상단에 있는 틈 요청 카드 UI 수정하기 

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 틈 요청 카드에서 하단 텍스트 부분 간격이 넓어졌는지 


## 📸 스크린샷 (선택)
> 
<img width="392" height="828" alt="image" src="https://github.com/user-attachments/assets/0e5b5143-9065-4415-94c8-9e63a4f34991" />


## 💬 기타 참고 사항
> X


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 친구 추천 카드의 레이아웃 간격을 조정했습니다.
  * 프로필 이미지 및 구분선의 상단 여백을 최적화했습니다.
  * 추천 카드 내 텍스트 배치를 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->