### PR TITLE
[REFACTOR/#398] 채움활동 탐색 후 이전 화면으로 이동 시 데이터 유지

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/activity/FillingActivity01Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/FillingActivity01Fragment.kt
@@ -440,6 +440,9 @@ class FillingActivity01Fragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
+        selectedTimeButton = null
+        selectedLocationButton = null
+        selectedCategoryButton = null
         _binding = null
     }
 

--- a/app/src/main/java/com/example/teumteum/ui/activity/FillingActivity01Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/FillingActivity01Fragment.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.core.widget.doOnTextChanged
@@ -33,6 +34,8 @@ class FillingActivity01Fragment : Fragment() {
 
     private val viewModel: ActivityViewModel by activityViewModels()
 
+    private var isRestoring = false
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -59,12 +62,9 @@ class FillingActivity01Fragment : Fragment() {
         selectedTimeButton = null
         selectedLocationButton = null
         selectedCategoryButton = null
-
-        // 내부 상태 동기화
-        selectedLocationText = binding.fillingActivityLocationEt.text?.toString()?.trim()?.takeIf { it.isNotEmpty() }
-        selectedCategoryText = binding.fillingActivityCategoryEt.text?.toString()?.trim()?.takeIf { it.isNotEmpty() }
-
-        updateNextButtonState()
+        selectedTimeTag = null
+        selectedLocationText = null
+        selectedCategoryText = null
 
         activity?.findViewById<BottomNavigationView>(R.id.main_bnv)?.visibility = View.GONE
 
@@ -97,6 +97,8 @@ class FillingActivity01Fragment : Fragment() {
                 timeBtn.strokeWidth = 4
                 selectedTimeTag = timeBtn.tag as String
                 selectedTimeButton = timeBtn
+
+                viewModel.updateFillingFormState { it.copy(selectedTime = selectedTimeTag) }
                 updateNextButtonState()
             }
         }
@@ -126,6 +128,8 @@ class FillingActivity01Fragment : Fragment() {
                     locationBtn.setBackgroundColor(defaultBg)
                     locationBtn.setTextColor(defaultText)
                     selectedLocationButton = null
+                    viewModel.updateFillingFormState { it.copy(locationId = null, customLocation = null) }
+
                     updateNextButtonState()
                     return@setOnClickListener
                 }
@@ -138,23 +142,33 @@ class FillingActivity01Fragment : Fragment() {
                 locationBtn.setBackgroundColor(selectedBg)
                 locationBtn.setTextColor(selectedText)
                 selectedLocationButton = locationBtn
+
+                val selectedLocationId = locationBtn.tag as? Long
+                viewModel.updateFillingFormState { it.copy(locationId = selectedLocationId, customLocation = null) }
+
                 updateNextButtonState()
             }
         }
 
         binding.fillingActivityLocationEt.doOnTextChanged { text, _, _, _ ->
-            val categoryText = text?.toString()?.trim()
+            if (isRestoring) return@doOnTextChanged
 
-            // 직접 입력이 있으면 selectedCategoryText에 반영
-            selectedLocationText = if (!categoryText.isNullOrEmpty()) categoryText else null
+            val locationText = text?.toString()?.trim()
+
+            // 직접 입력이 있으면 selectedLocationText에 반영
+            selectedLocationText = if (!locationText.isNullOrEmpty()) locationText else null
 
             // 직접 입력 선택 시 위치 버튼 해제
-            if (!categoryText.isNullOrEmpty() && selectedLocationButton != null) {
-                (selectedLocationButton as? android.widget.TextView)?.apply {
+            if (!locationText.isNullOrEmpty() && selectedLocationButton != null) {
+                (selectedLocationButton as? TextView)?.apply {
                     setBackgroundColor(defaultBg)
                     setTextColor(defaultText)
                 }
                 selectedLocationButton = null
+            }
+
+            viewModel.updateFillingFormState {
+                it.copy(customLocation = selectedLocationText, locationId = null)
             }
 
             // 버튼 상태 갱신
@@ -186,6 +200,9 @@ class FillingActivity01Fragment : Fragment() {
                     categoryBtn.setBackgroundColor(defaultBg)
                     categoryBtn.setTextColor(defaultText)
                     selectedCategoryButton = null
+
+                    viewModel.updateFillingFormState { it.copy(categoryId = null, customCategory = null) }
+
                     updateNextButtonState()
                     return@setOnClickListener
                 }
@@ -198,11 +215,17 @@ class FillingActivity01Fragment : Fragment() {
                 categoryBtn.setBackgroundColor(selectedBg)
                 categoryBtn.setTextColor(selectedText)
                 selectedCategoryButton = categoryBtn
+
+                val selectedCategoryId = categoryBtn.tag as? Long
+                viewModel.updateFillingFormState { it.copy(categoryId = selectedCategoryId, customCategory = null) }
+
                 updateNextButtonState()
             }
         }
 
         binding.fillingActivityCategoryEt.doOnTextChanged { text, _, _, _ ->
+            if (isRestoring) return@doOnTextChanged
+
             val categoryText = text?.toString()?.trim()
 
             // 직접 입력이 있으면 selectedCategoryText에 반영
@@ -210,11 +233,15 @@ class FillingActivity01Fragment : Fragment() {
 
             // 직접 입력 선택 시 카테고리 버튼 해제
             if (!categoryText.isNullOrEmpty() && selectedCategoryButton != null) {
-                (selectedCategoryButton as? android.widget.TextView)?.apply {
+                (selectedCategoryButton as? TextView)?.apply {
                     setBackgroundColor(defaultBg)
                     setTextColor(defaultText)
                 }
                 selectedCategoryButton = null
+            }
+
+            viewModel.updateFillingFormState {
+                it.copy(customCategory = selectedCategoryText, categoryId = null)
             }
 
             // 버튼 상태 갱신
@@ -222,6 +249,7 @@ class FillingActivity01Fragment : Fragment() {
         }
 
         binding.backArrowIv.setOnClickListener {
+            viewModel.clearFillingFormState()
             requireActivity().onBackPressedDispatcher.onBackPressed()
         }
 
@@ -271,11 +299,116 @@ class FillingActivity01Fragment : Fragment() {
 
         setupObservers()
 
-        // 초기화 이벤트 수신
-        parentFragmentManager.setFragmentResultListener("reset_form", viewLifecycleOwner) { _, _ ->
-            clearAllInputs()
+        restoreFormFromViewModel() // viewModel 값으로 ui 복원
+        updateNextButtonState()
+    }
+
+    private fun restoreFormFromViewModel() {
+        val state = viewModel.fillingFormState.value ?: return
+
+        val selectedStroke = ContextCompat.getColor(requireContext(), R.color.main_1)
+        val defaultStroke = ContextCompat.getColor(requireContext(), R.color.teumteum_bg)
+
+        val selectedBg = ContextCompat.getColor(requireContext(), R.color.main_1)
+        val selectedText = ContextCompat.getColor(requireContext(), R.color.white)
+        val defaultBg = ContextCompat.getColor(requireContext(), R.color.main_2)
+        val defaultText = ContextCompat.getColor(requireContext(), R.color.text_primary)
+
+        isRestoring = true
+        try {
+            // 시간 복원
+            val timeCards = listOf(
+                binding.fillingActivityTime01Cv.apply { tag = "10m" },
+                binding.fillingActivityTime02Cv.apply { tag = "20m" },
+                binding.fillingActivityTime03Cv.apply { tag = "30m" },
+                binding.fillingActivityTime04Cv.apply { tag = "1h" }
+            )
+
+            timeCards.forEach {
+                it.strokeColor = defaultStroke
+                it.strokeWidth = 0
+            }
+
+            selectedTimeTag = state.selectedTime
+            val timeView = timeCards.firstOrNull { it.tag == state.selectedTime }
+            timeView?.let {
+                it.strokeColor = selectedStroke
+                it.strokeWidth = 4
+                selectedTimeButton = it
+            }
+
+            // 위치 복원
+            val locationButtons = listOf(
+                binding.btnFillingActivityLocation01,
+                binding.btnFillingActivityLocation02,
+                binding.btnFillingActivityLocation03,
+                binding.btnFillingActivityLocation04,
+                binding.btnFillingActivityLocation05,
+                binding.btnFillingActivityLocation06
+            )
+
+            locationButtons.forEach {
+                it.setBackgroundColor(defaultBg)
+                it.setTextColor(defaultText)
+            }
+            selectedLocationButton = null
+            selectedLocationText = null
+            binding.fillingActivityLocationEt.setText("")
+
+            when {
+                state.locationId != null -> {
+                    val btn = locationButtons.firstOrNull { (it.tag as? Long) == state.locationId }
+                    btn?.let {
+                        it.setBackgroundColor(selectedBg)
+                        it.setTextColor(selectedText)
+                        selectedLocationButton = it
+                    }
+                }
+                !state.customLocation.isNullOrBlank() -> {
+                    binding.fillingActivityLocationEt.setText(state.customLocation)
+                    selectedLocationText = state.customLocation
+                }
+            }
+
+            // 카테고리 복원
+            val categoryButtons = listOf(
+                binding.btnFillingActivityCategory01,
+                binding.btnFillingActivityCategory02,
+                binding.btnFillingActivityCategory03,
+                binding.btnFillingActivityCategory04,
+                binding.btnFillingActivityCategory05,
+                binding.btnFillingActivityCategory06
+            )
+
+            categoryButtons.forEach {
+                it.setBackgroundColor(defaultBg)
+                it.setTextColor(defaultText)
+            }
+            selectedCategoryButton = null
+            selectedCategoryText = null
+            binding.fillingActivityCategoryEt.setText("")
+
+            when {
+                state.categoryId != null -> {
+                    val btn = categoryButtons.firstOrNull { (it.tag as? Long) == state.categoryId }
+                    btn?.let {
+                        it.setBackgroundColor(selectedBg)
+                        it.setTextColor(selectedText)
+                        selectedCategoryButton = it
+                    }
+                }
+                !state.customCategory.isNullOrBlank() -> {
+                    binding.fillingActivityCategoryEt.setText(state.customCategory)
+                    selectedCategoryText = state.customCategory
+                }
+            }
+
+            updateNextButtonState()
+        } finally {
+            isRestoring = false
         }
     }
+
 
     private fun updateNextButtonState() {
 
@@ -305,69 +438,16 @@ class FillingActivity01Fragment : Fragment() {
         }
     }
 
-    private fun clearAllInputs() {
-        val defaultStroke = ContextCompat.getColor(requireContext(), R.color.teumteum_bg)
-        val defaultBg = ContextCompat.getColor(requireContext(), R.color.main_2)
-        val defaultText = ContextCompat.getColor(requireContext(), R.color.text_primary)
-
-        // 시간 카드 초기화
-        val timeCards = listOf(
-            binding.fillingActivityTime01Cv,
-            binding.fillingActivityTime02Cv,
-            binding.fillingActivityTime03Cv,
-            binding.fillingActivityTime04Cv
-        )
-        timeCards.forEach {
-            it.strokeColor = defaultStroke
-            it.strokeWidth = 0
-        }
-        selectedTimeTag = null
-        selectedTimeButton = null
-
-        // 위치 버튼 초기화
-        val locationButtons = listOf(
-            binding.btnFillingActivityLocation01,
-            binding.btnFillingActivityLocation02,
-            binding.btnFillingActivityLocation03,
-            binding.btnFillingActivityLocation04,
-            binding.btnFillingActivityLocation05,
-            binding.btnFillingActivityLocation06
-        )
-        locationButtons.forEach {
-            it.setBackgroundColor(defaultBg)
-            it.setTextColor(defaultText)
-        }
-        selectedLocationButton = null
-        selectedLocationText = null
-        binding.fillingActivityLocationEt.setText("")
-
-        // 카테고리 버튼 초기화
-        val categoryButtons = listOf(
-            binding.btnFillingActivityCategory01,
-            binding.btnFillingActivityCategory02,
-            binding.btnFillingActivityCategory03,
-            binding.btnFillingActivityCategory04,
-            binding.btnFillingActivityCategory05,
-            binding.btnFillingActivityCategory06
-        )
-        categoryButtons.forEach {
-            it.setBackgroundColor(defaultBg)
-            it.setTextColor(defaultText)
-        }
-        selectedCategoryButton = null
-        selectedCategoryText = null
-        binding.fillingActivityCategoryEt.setText("")
-
-        binding.searchBtn.isEnabled = false
-
-        updateNextButtonState()
-
-        // 포커스 해제
-        binding.root.clearFocus()
-    }
-
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    override fun onDestroy() {
+        // 폼 초기화
+        if (isRemoving || (activity?.isFinishing == true)) {
+            viewModel.clearFillingFormState()
+        }
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/com/example/teumteum/ui/activity/FillingActivity02Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/FillingActivity02Fragment.kt
@@ -18,7 +18,6 @@ import com.example.teumteum.databinding.FragmentFillingActivity02Binding
 import com.example.teumteum.ui.activity.adapter.AiRecommendAdapter
 import com.example.teumteum.ui.activity.adapter.WishRecommendAdapter
 import com.example.teumteum.ui.activity.viewModel.ActivityViewModel
-import com.example.teumteum.ui.friend.FriendFragment
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -78,8 +77,6 @@ class FillingActivity02Fragment : Fragment() {
         }
 
         binding.backArrowIv.setOnClickListener {
-            // 초기화 신호 전송
-            parentFragmentManager.setFragmentResult("reset_form", Bundle.EMPTY)
             requireActivity().onBackPressedDispatcher.onBackPressed()
         }
 

--- a/app/src/main/java/com/example/teumteum/ui/activity/data/FillingFormState.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/data/FillingFormState.kt
@@ -1,0 +1,9 @@
+package com.example.teumteum.ui.activity.data
+
+data class FillingFormState(
+    val selectedTime: String? = null,
+    val locationId: Long? = null,
+    val customLocation: String? = null,
+    val categoryId: Long? = null,
+    val customCategory: String? = null
+)

--- a/app/src/main/java/com/example/teumteum/ui/activity/viewModel/ActivityViewModel.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/viewModel/ActivityViewModel.kt
@@ -11,6 +11,7 @@ import com.example.teumteum.data.remote.activity.model.ActivityWishResult
 import com.example.teumteum.data.remote.activity.model.AssignAiRequest
 import com.example.teumteum.data.remote.activity.model.AssignWishRequest
 import com.example.teumteum.data.remote.activity.repository.ActivityRepository
+import com.example.teumteum.ui.activity.data.FillingFormState
 import com.example.teumteum.utils.ApiException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -51,9 +52,8 @@ class ActivityViewModel @Inject constructor(
     private val _assignError = MutableSharedFlow<ApiException>(replay = 0, extraBufferCapacity = 1)
     val assignError: SharedFlow<ApiException> = _assignError.asSharedFlow()
 
-    // 마지막으로 성공적으로 조회한 파라미터 키
-    var lastQueryKey: String? = null
-        private set
+    private val _fillingFormState = MutableLiveData(FillingFormState())
+    val fillingFormState: LiveData<FillingFormState> = _fillingFormState
 
     private val _loading = MutableLiveData(false)
     val loading: LiveData<Boolean> = _loading
@@ -149,6 +149,14 @@ class ActivityViewModel @Inject constructor(
                 _assignError.tryEmit(ApiException(code ?: "UNKNOWN", msg))
             }
         }
+    }
+
+    fun updateFillingFormState(reducer: (FillingFormState) -> FillingFormState) {
+        _fillingFormState.value = reducer(_fillingFormState.value ?: FillingFormState())
+    }
+
+    fun clearFillingFormState() {
+        _fillingFormState.value = FillingFormState()
     }
 
     fun clearActivityResults() {


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #398 

## ✨ 작업 내용
채움 활동 탐색 이후 이전 화면으로 이동할 경우, 시간·위치·카테고리 선택 정보가 유지되도록 수정하였습니다.
로딩 화면 또는 탐색 결과 화면에서 뒤로가기 버튼을 클릭하면, 폼에 이전에 입력한 데이터가 그대로 남아 있으며 하단의 탐색 버튼도 활성화된 상태로 표시됩니다.
반면, 폼 화면에서 이전 화면(홈 화면)으로 이동한 뒤 홈 화면의 "채움 활동 찾기" 배너를 다시 클릭하여 진입하면, 이전 입력 값은 모두 초기화되어 새로운 폼을 작성할 수 있습니다.

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 탐색 결과 화면에서 이전 화면으로 돌아갔을 때 입력한 데이터가 유지되어 있는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 작성 중인 양식 복원 흐름 개선으로 화면 복원 시 입력값이 즉시 반영됩니다.
  * 위치/카테고리 직접 입력과 버튼 선택 간 충돌을 방지해 의도치 않은 변경을 줄였습니다.
  * 뒤로가기나 화면 종료 시 임시 작성 상태가 안전하게 초기화됩니다.

* **리팩토링**
  * 양식 상태 관리 체계가 중앙화되어 전반적인 안정성과 유지보수성이 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->