### PR TITLE
[REFACTOR/#408] 친구 화면에서 텍스트 가운데로 수정

### DIFF
--- a/app/src/main/res/layout/fragment_friend.xml
+++ b/app/src/main/res/layout/fragment_friend.xml
@@ -121,13 +121,12 @@
                     android:layout_height="wrap_content"
                     android:text="새로운 틈 요청이 없어요"
                     android:includeFontPadding="false"
-                    android:layout_marginStart="108dp"
-                    android:layout_marginEnd="96dp"
-                    android:layout_marginBottom="31dp"
                     android:textSize="15sp"
                     android:textColor="#0F0F0F"
                     android:layout_marginTop="6dp"
-                    android:fontFamily="@font/noto_sans_kr_medium" />
+                    android:layout_marginBottom="31dp"
+                    android:fontFamily="@font/noto_sans_kr_medium"
+                    android:layout_gravity="center_horizontal" />
             </LinearLayout>
 
         </androidx.cardview.widget.CardView>


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #408

## ✨ 작업 내용
> 친구 화면에서 텍스트 가운데로 보이게 수정

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 틈 요청 없을 때 보이는 친구 화면에서 텍스트 가운데로 보이는지 


## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 친구 화면의 메시지 텍스트 정렬을 중앙 정렬로 변경하여 레이아웃을 개선했습니다. 텍스트는 이제 화면 중앙에 표시되며 하단 여백은 유지됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->