### PR TITLE
[REFACTOR/#421] 내프로필 화면 하단 버튼 가려짐 해결

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/myhome/MyProfileFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/myhome/MyProfileFragment.kt
@@ -1,10 +1,13 @@
 package com.example.teumteum.ui.myhome
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.bumptech.glide.Glide
 import com.example.teumteum.R
@@ -40,6 +43,13 @@ class MyProfileFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         (activity as? MainActivity)?.hideBottomBar()
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.fragmentMyProfileContainer) { _, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+
+            binding.fragmentMyProfileContainer.updatePadding(bottom = systemBars.bottom)
+            insets
+        }
 
         binding.backBtn.setOnClickListener {
             parentFragmentManager.beginTransaction()


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #421

## ✨ 작업 내용
> 내프로필 화면 하단의 프로필 수정 버튼이 시스템바에 가려지는 현상을 해결
> 시스템바 높이만큼 패딩 적용

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] 내프로필에서 프로필 수정 화면이 가려지지 않는지 

## 📸 스크린샷 (선택)
> 수정 전
<img width="349" height="748" alt="image" src="https://github.com/user-attachments/assets/f37efb98-311a-4491-8ee3-c8fc54a99d2b" />

> 수정 후
<img width="342" height="747" alt="image" src="https://github.com/user-attachments/assets/41fc5e1f-3ad8-4e6a-b966-cca61bbb524b" />


## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 내 프로필 화면에서 시스템 UI 요소에 의해 콘텐츠가 가려지는 문제 해결. 화면 하단 여백을 자동으로 조정하여 시스템 UI와의 겹침을 방지하고 더 나은 사용성 제공.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->