### PR TITLE
[REFACTOR/#426] 함께 한 시간이 없을 경우 보이는 화면 수정

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/friend/SharedTeumTimeFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/SharedTeumTimeFragment.kt
@@ -50,9 +50,16 @@ class SharedTeumTimeFragment : Fragment() {
 
         // 함께한 틈 목록
         viewModel.sharedTeumList.observe(viewLifecycleOwner) { list ->
-            adapter.submitList(list)
+            if (list.isNullOrEmpty()) {
+                binding.emptyLayout.visibility = View.VISIBLE
+                binding.sharedTeumRecyclerView.visibility = View.GONE
+                binding.sharedTotalTimeTv.text = "0시간 0분"
+            } else {
+                binding.emptyLayout.visibility = View.GONE
+                binding.sharedTeumRecyclerView.visibility = View.VISIBLE
+                adapter.submitList(list)
+            }
         }
-
 
         // 에러
         viewModel.errorMessage.observe(viewLifecycleOwner) { event ->

--- a/app/src/main/res/layout/fragment_shared_teum_time.xml
+++ b/app/src/main/res/layout/fragment_shared_teum_time.xml
@@ -65,4 +65,37 @@
         app:layout_constraintEnd_toEndOf="parent"
         tools:listitem="@layout/item_shared_teum_left" />
 
+
+    <!-- 함께한 틈 없음 상태 -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/emptyLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone">
+
+        <ImageView
+            android:id="@+id/recent_search_not_exists_iv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_teum_char_sleep_sv"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+        <TextView
+            android:id="@+id/recent_search_not_exists_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/noto_sans_kr_medium"
+            android:includeFontPadding="false"
+            android:text="아직 함께한 빈틈이 없어요"
+            android:textColor="@color/teumteum_gray"
+            android:textSize="15sp"
+            app:layout_constraintTop_toBottomOf="@id/recent_search_not_exists_iv"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #426

## ✨ 작업 내용
> 함께 한 시간이 보이는 화면에서 함께 한 시간이 없을 경우 보이는 화면 수정하기 

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] 함께 한 시간이 없을 경우 회색 트미 이미지랑 함꼐 한 시간이 없어요 텍스트가 화면에 보이는지 

## 📸 스크린샷 (선택)
> 
<img width="406" height="813" alt="image" src="https://github.com/user-attachments/assets/cee4d8b0-4935-42c2-a481-b31ae0d7e927" />


## 💬 기타 참고 사항
> x


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 공유 시간 데이터가 없을 때 친화적인 빈 상태 화면이 표시됩니다. 사용자는 이제 데이터 부재 상황을 명확하게 확인할 수 있으며, 시간 정보는 초기화되어 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->