### PR TITLE
[FEAT/#431] 마이페이지 공개투두 조회

### DIFF
--- a/app/src/main/java/com/example/teumteum/data/remote/mypage/model/PublicTodoResponse.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/mypage/model/PublicTodoResponse.kt
@@ -1,0 +1,9 @@
+package com.example.teumteum.data.remote.mypage.model
+
+import com.google.gson.annotations.SerializedName
+
+data class PublicTodoResponse(
+    @SerializedName("title") val title: String,
+    @SerializedName("startTime") val startTime: String,
+    @SerializedName("endTime") val endTime: String
+)

--- a/app/src/main/java/com/example/teumteum/data/remote/mypage/repository/MyPageRepository.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/mypage/repository/MyPageRepository.kt
@@ -6,6 +6,7 @@ import com.example.teumteum.data.remote.mypage.model.MyRoutineRequest
 import com.example.teumteum.data.remote.mypage.model.MyRoutineResponse
 import com.example.teumteum.data.remote.mypage.model.MySocialInfoResponse
 import com.example.teumteum.data.remote.mypage.model.ProfileUpdateRequest
+import com.example.teumteum.data.remote.mypage.model.PublicTodoResponse
 import com.example.teumteum.data.remote.mypage.service.MyPageService
 import com.example.teumteum.data.remote.onboarding.model.PresignedRequest
 import com.example.teumteum.data.remote.onboarding.model.PresignedResponse
@@ -150,5 +151,12 @@ class MyPageRepository @Inject constructor(
         val response = myPageService.deleteUser()
         Log.d("User", "response = ${response.body()}")
         handleApiResponseUnit(response)
+    }
+
+    //나의 공개 투두 조회
+    suspend fun getMyPublicTodos(): Result<List<PublicTodoResponse>> = runCatching {
+        val response = myPageService.getMyPublicTodos()
+        Log.d("User", "response = ${response.body()}")
+        handleApiResponse(response)
     }
 }

--- a/app/src/main/java/com/example/teumteum/data/remote/mypage/service/MyPageService.kt
+++ b/app/src/main/java/com/example/teumteum/data/remote/mypage/service/MyPageService.kt
@@ -5,6 +5,7 @@ import com.example.teumteum.data.remote.mypage.model.MyRoutineRequest
 import com.example.teumteum.data.remote.mypage.model.MyRoutineResponse
 import com.example.teumteum.data.remote.mypage.model.MySocialInfoResponse
 import com.example.teumteum.data.remote.mypage.model.ProfileUpdateRequest
+import com.example.teumteum.data.remote.mypage.model.PublicTodoResponse
 import com.example.teumteum.data.remote.onboarding.model.PresignedRequest
 import com.example.teumteum.data.remote.onboarding.model.PresignedResponse
 import com.example.teumteum.data.remote.onboarding.model.ProfileImageRequest
@@ -27,6 +28,9 @@ interface MyPageService {
 
     @GET("/api/home/todolist")
     suspend fun getRecentTodos(@Query("date") date: String): Response<ApiResponse<List<TodoListResult>>>
+
+    @GET("/api/users/mypage/public-todo")
+    suspend fun getMyPublicTodos(): Response<ApiResponse<List<PublicTodoResponse>>>
 
     @POST("/api/users/mypage/profile-image/presigned-url")
     suspend fun requestPresignedUrl(@Body request: PresignedRequest): Response<ApiResponse<PresignedResponse>>

--- a/app/src/main/java/com/example/teumteum/ui/myhome/MyProfileFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/myhome/MyProfileFragment.kt
@@ -1,21 +1,19 @@
 package com.example.teumteum.ui.myhome
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.bumptech.glide.Glide
 import com.example.teumteum.R
-import com.example.teumteum.data.remote.todo.model.TodoListResult
+import com.example.teumteum.data.remote.mypage.model.PublicTodoResponse
 import com.example.teumteum.databinding.FragmentMyProfileBinding
 import com.example.teumteum.ui.main.MainActivity
 import com.example.teumteum.ui.main.viewModel.HomeViewModel
 import com.example.teumteum.ui.myhome.viewModel.MyHomeViewModel
 import dagger.hilt.android.AndroidEntryPoint
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 
 @AndroidEntryPoint
 class MyProfileFragment : Fragment() {
@@ -60,8 +58,7 @@ class MyProfileFragment : Fragment() {
         homeViewModel.teumTimeHours.observe(viewLifecycleOwner) { updateTeumTime() }
         homeViewModel.teumTimeMinutes.observe(viewLifecycleOwner) { updateTeumTime() }
 
-        val date = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
-        viewModel.fetchRecentTodos(date)
+        viewModel.fetchRecentTodos()
 
         viewModel.nickname.observe(viewLifecycleOwner) { nickname ->
             binding.nicknameTv.text = (nickname + "님의") ?: "닉네임님의"
@@ -98,7 +95,7 @@ class MyProfileFragment : Fragment() {
     }
 
     //  화면 내에 추가
-    private fun bindTodos(list: List<TodoListResult>) {
+    private fun bindTodos(list: List<PublicTodoResponse>) {
         val l = list.take(2)
 
         // 컨테이너 보이기/숨기기

--- a/app/src/main/java/com/example/teumteum/ui/myhome/viewModel/MyHomeViewModel.kt
+++ b/app/src/main/java/com/example/teumteum/ui/myhome/viewModel/MyHomeViewModel.kt
@@ -5,8 +5,8 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.teumteum.data.remote.mypage.model.PublicTodoResponse
 import com.example.teumteum.data.remote.mypage.repository.MyPageRepository
-import com.example.teumteum.data.remote.todo.model.TodoListResult
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -70,12 +70,12 @@ class MyHomeViewModel @Inject constructor(
     }
 
     // 최근 투두 조회
-    private val _recentTodos = MutableLiveData<List<TodoListResult>>()
-    val recentTodos: LiveData<List<TodoListResult>> get() = _recentTodos
+    private val _recentTodos = MutableLiveData<List<PublicTodoResponse>>()
+    val recentTodos: LiveData<List<PublicTodoResponse>> get() = _recentTodos
 
-    fun fetchRecentTodos(date: String) {
+    fun fetchRecentTodos() {
         viewModelScope.launch {
-            repository.getRecentTodos(date)
+            repository.getMyPublicTodos()
                 .onSuccess { list ->
                     // 0개면 UI에서 카드 컨테이너 숨기도록 empty 리스트 그대로 전달
                     _recentTodos.value = list


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #431

## ✨ 작업 내용
> 마이페이지에서 자신의 공개투두를 조회하는 API를 연동

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] 마이페이지에서 자신의 공개투두가 조회되는지

## 📸 스크린샷 (선택)
<img width="340" height="744" alt="image" src="https://github.com/user-attachments/assets/b6b757ea-2b86-4897-a0d7-025176b010f9" />


## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 마이페이지에 공개된 할일 목록 표시 기능 추가

* **변경/개선**
  * 최근 할일 조회 방식 간소화로 더 간편한 데이터 요청 및 처리 제공
  * 할일 목록 표시 관련 UI 및 데이터 바인딩 개선으로 안정성과 일관성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->