### PR TITLE
[REFACTOR/#428] 약속된 틈 취소하기 바텀시트 수정

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/friend/Friend02ResponseFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/Friend02ResponseFragment.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import com.example.teumteum.R
 import com.example.teumteum.data.remote.friend.model.TeumReceivedItem
@@ -35,6 +37,13 @@ class Friend02ResponseFragment  : Fragment(){
         super.onViewCreated(view, savedInstanceState)
 
         (activity as? MainActivity)?.hideBottomBar()
+
+        // 네비게이션 바
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, insets ->
+            val bottomInset = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom
+            v.setPadding(0, 0, 0, bottomInset)
+            insets
+        }
 
         binding.backButton.setOnClickListener {
             parentFragmentManager.popBackStack(null, androidx.fragment.app.FragmentManager.POP_BACK_STACK_INCLUSIVE)

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendTeumDeleteBottomSheet.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendTeumDeleteBottomSheet.kt
@@ -57,12 +57,24 @@ class FriendTeumDeleteBottomSheet(
             viewModel.cancelTeumSchedule(scheduleId)
             Log.d("CANCEL_DEBUG", "취소 요청할 스케줄 ID: $scheduleId")
 
+            binding.btnYes.isEnabled = false
+        }
+
+        viewModel.cancelScheduleSuccess.observe(viewLifecycleOwner) { event ->
+            event.getContentIfNotHandled()?.let { canceledId ->
+                if (canceledId == scheduleId) {
+                    dismissAllowingStateLoss()
+                    Log.d("BOTTOM_SHEET", "취소 성공 이벤트로 닫힘 scheduleId=$canceledId")
+                }
+            }
         }
 
         /** 성공 시 → 바텀시트 닫기 */
         viewModel.successMessage.observe(viewLifecycleOwner) { event ->
             event.getContentIfNotHandled()?.let {
                 dismissAllowingStateLoss()
+
+                Log.d("BOTTOM_SHEET", "successMessage observe 됨")
             }
         }
 
@@ -70,6 +82,7 @@ class FriendTeumDeleteBottomSheet(
         viewModel.errorMessage.observe(viewLifecycleOwner) { event ->
             event.getContentIfNotHandled()?.let {
                 Log.e("DELETE_CONFIRM", it.toString())
+                binding.btnYes.isEnabled = true
             }
         }
     }

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendTeumDeleteBottomSheet.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendTeumDeleteBottomSheet.kt
@@ -14,14 +14,18 @@ import com.example.teumteum.databinding.BottomSheetFriendTeumDeleteBinding
 import com.example.teumteum.ui.friend.viewModel.FriendViewModel
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
-class FriendTeumDeleteBottomSheet(
-    private val scheduleId: Int
-) : BottomSheetDialogFragment() {
+class FriendTeumDeleteBottomSheet : BottomSheetDialogFragment() {
 
     private var _binding: BottomSheetFriendTeumDeleteBinding? = null
     private val binding get() = _binding!!
 
+    // Activity 범위 ViewModel 유지
     private val viewModel: FriendViewModel by activityViewModels()
+
+    // arguments에서 scheduleId 읽기
+    private val scheduleId: Int by lazy {
+        requireArguments().getInt(ARG_SCHEDULE_ID)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -35,53 +39,47 @@ class FriendTeumDeleteBottomSheet(
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        // "취소" 글자만 색상 변경
+        // "취소" 텍스트 색상 강조
         val text = "약속된 틈을 정말 취소할까요?"
         val spannable = SpannableString(text)
         val start = text.indexOf("취소")
-        val end = start + 2
         spannable.setSpan(
             ForegroundColorSpan(Color.parseColor("#7770FE")),
-            start, end,
+            start,
+            start + 2,
             Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
         )
         binding.tvTitle.text = spannable
 
-        /** 아니오 → 그냥 닫기 */
+        /** 아니오 */
         binding.btnNo.setOnClickListener {
             dismiss()
         }
 
-        /** 네 → 틈 취소 API 호출 */
+        /** 네 → 취소 API */
         binding.btnYes.setOnClickListener {
-            viewModel.cancelTeumSchedule(scheduleId)
-            Log.d("CANCEL_DEBUG", "취소 요청할 스케줄 ID: $scheduleId")
-
             binding.btnYes.isEnabled = false
+            viewModel.cancelTeumSchedule(scheduleId)
+            Log.d("CANCEL_DEBUG", "취소 요청 scheduleId=$scheduleId")
         }
 
+        /** 취소 성공 이벤트로만 닫기 */
         viewModel.cancelScheduleSuccess.observe(viewLifecycleOwner) { event ->
             event.getContentIfNotHandled()?.let { canceledId ->
                 if (canceledId == scheduleId) {
                     dismissAllowingStateLoss()
-                    Log.d("BOTTOM_SHEET", "취소 성공 이벤트로 닫힘 scheduleId=$canceledId")
+                    Log.d(
+                        "BOTTOM_SHEET",
+                        "cancelScheduleSuccess로 닫힘 scheduleId=$canceledId"
+                    )
                 }
             }
         }
 
-        /** 성공 시 → 바텀시트 닫기 */
-        viewModel.successMessage.observe(viewLifecycleOwner) { event ->
-            event.getContentIfNotHandled()?.let {
-                dismissAllowingStateLoss()
-
-                Log.d("BOTTOM_SHEET", "successMessage observe 됨")
-            }
-        }
-
-        /** 실패 로그 */
+        /** 실패 처리 */
         viewModel.errorMessage.observe(viewLifecycleOwner) { event ->
             event.getContentIfNotHandled()?.let {
-                Log.e("DELETE_CONFIRM", it.toString())
+                Log.e("DELETE_CONFIRM", it)
                 binding.btnYes.isEnabled = true
             }
         }
@@ -90,5 +88,17 @@ class FriendTeumDeleteBottomSheet(
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    companion object {
+        private const val ARG_SCHEDULE_ID = "ARG_SCHEDULE_ID"
+
+        // 정석 생성 방식
+        fun newInstance(scheduleId: Int) =
+            FriendTeumDeleteBottomSheet().apply {
+                arguments = Bundle().apply {
+                    putInt(ARG_SCHEDULE_ID, scheduleId)
+                }
+            }
     }
 }

--- a/app/src/main/java/com/example/teumteum/ui/friend/FriendTeumDeleteBottomSheet.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/FriendTeumDeleteBottomSheet.kt
@@ -1,0 +1,81 @@
+package com.example.teumteum.ui.friend
+
+import android.graphics.Color
+import android.os.Bundle
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.ForegroundColorSpan
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.activityViewModels
+import com.example.teumteum.databinding.BottomSheetFriendTeumDeleteBinding
+import com.example.teumteum.ui.friend.viewModel.FriendViewModel
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+
+class FriendTeumDeleteBottomSheet(
+    private val scheduleId: Int
+) : BottomSheetDialogFragment() {
+
+    private var _binding: BottomSheetFriendTeumDeleteBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: FriendViewModel by activityViewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = BottomSheetFriendTeumDeleteBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // "취소" 글자만 색상 변경
+        val text = "약속된 틈을 정말 취소할까요?"
+        val spannable = SpannableString(text)
+        val start = text.indexOf("취소")
+        val end = start + 2
+        spannable.setSpan(
+            ForegroundColorSpan(Color.parseColor("#7770FE")),
+            start, end,
+            Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+        binding.tvTitle.text = spannable
+
+        /** 아니오 → 그냥 닫기 */
+        binding.btnNo.setOnClickListener {
+            dismiss()
+        }
+
+        /** 네 → 틈 취소 API 호출 */
+        binding.btnYes.setOnClickListener {
+            viewModel.cancelTeumSchedule(scheduleId)
+            Log.d("CANCEL_DEBUG", "취소 요청할 스케줄 ID: $scheduleId")
+
+        }
+
+        /** 성공 시 → 바텀시트 닫기 */
+        viewModel.successMessage.observe(viewLifecycleOwner) { event ->
+            event.getContentIfNotHandled()?.let {
+                dismissAllowingStateLoss()
+            }
+        }
+
+        /** 실패 로그 */
+        viewModel.errorMessage.observe(viewLifecycleOwner) { event ->
+            event.getContentIfNotHandled()?.let {
+                Log.e("DELETE_CONFIRM", it.toString())
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/example/teumteum/ui/friend/PromiseDetailBottomSheet.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/PromiseDetailBottomSheet.kt
@@ -46,6 +46,17 @@ class PromiseDetailBottomSheet(
         return dialog
     }
 
+    override fun onStart() {
+        super.onStart()
+
+        dialog?.findViewById<View>(
+            com.google.android.material.R.id.design_bottom_sheet
+        )?.let { bottomSheet ->
+            bottomSheet.layoutParams.height =
+                (420 * resources.displayMetrics.density).toInt()
+        }
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -69,15 +80,22 @@ class PromiseDetailBottomSheet(
         // 참여자 프로필 동적 추가
         showParticipantProfiles(detail)
 
-        // 과거 시간이면 버튼 숨기기
-        binding.btnCancelPromise.visibility = if (isPast) View.GONE else View.VISIBLE
+        val isPastLocal = run {
+            val date = LocalDate.parse(detail.date)
+            val endTime = LocalTime.parse(
+                if (detail.endTime == "24:00") "00:00" else detail.endTime
+            )
+            date.atTime(endTime).isBefore(java.time.LocalDateTime.now())
+        }
+
+        binding.btnCancelPromise.visibility =
+            if (isPastLocal) View.GONE else View.VISIBLE
 
         //  클릭 시 취소 요청만 호출
         binding.btnCancelPromise.setOnClickListener {
-            Log.d("CANCEL_DEBUG", "취소 요청할 스케줄 ID: $scheduleId")
-            viewModel.cancelTeumSchedule(scheduleId)  //  이게 진짜 스케줄 ID
+            FriendTeumDeleteBottomSheet(scheduleId)
+                .show(parentFragmentManager, "FriendTeumDeleteBottomSheet")
         }
-
 
         //  성공 메시지
         viewModel.successMessage.observe(viewLifecycleOwner) { event ->

--- a/app/src/main/java/com/example/teumteum/ui/friend/PromiseDetailBottomSheet.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/PromiseDetailBottomSheet.kt
@@ -93,7 +93,8 @@ class PromiseDetailBottomSheet(
 
         //  클릭 시 취소 요청만 호출
         binding.btnCancelPromise.setOnClickListener {
-            FriendTeumDeleteBottomSheet(scheduleId)
+            FriendTeumDeleteBottomSheet
+                .newInstance(scheduleId)
                 .show(parentFragmentManager, "FriendTeumDeleteBottomSheet")
         }
 

--- a/app/src/main/java/com/example/teumteum/ui/friend/viewModel/FriendViewModel.kt
+++ b/app/src/main/java/com/example/teumteum/ui/friend/viewModel/FriendViewModel.kt
@@ -412,11 +412,15 @@ class FriendViewModel @Inject constructor(
     }
 
     // 9. 약속된 틈 취소
+    private val _cancelScheduleSuccess = MutableLiveData<Event<Int>>()
+    val cancelScheduleSuccess: LiveData<Event<Int>> = _cancelScheduleSuccess
+
     fun cancelTeumSchedule(teumId: Int) {
         viewModelScope.launch {
             repository.cancelTeumSchedule(teumId)
                 .onSuccess { result ->
                     _successMessage.value = Event("약속된 틈이 성공적으로 취소되었습니다.")
+                    _cancelScheduleSuccess.value = Event(teumId)
                     Log.d("SCHEDULED_CANCEL", "취소된 유저 ID: ${result.cancelledUserIds}")
                 }
                 .onFailure { e ->

--- a/app/src/main/res/layout/bottom_sheet_friend_teum_delete.xml
+++ b/app/src/main/res/layout/bottom_sheet_friend_teum_delete.xml
@@ -19,31 +19,21 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
-    <ImageView
-        android:id="@+id/iv_icon"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/friend_block"
-        android:layout_marginTop="40dp"
-        app:layout_constraintTop_toBottomOf="@id/handle"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
 
     <TextView
         android:id="@+id/tv_title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="13dp"
+        android:layout_marginTop="49dp"
         android:layout_marginHorizontal="24dp"
         android:lineSpacingExtra="0dp"
         android:includeFontPadding="false"
-        android:text="문혜원님을 차단하시겠어요?"
-        android:textSize="20sp"
-        android:textStyle="bold"
+        android:text="약속된 틈을 정말 취소할까요?"
+        android:textSize="18sp"
         android:textColor="@color/text_primary"
         android:fontFamily="@font/noto_sans_kr_medium"
         android:textAlignment="center"
-        app:layout_constraintTop_toBottomOf="@id/iv_icon"
+        app:layout_constraintTop_toBottomOf="@id/handle"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
@@ -52,30 +42,59 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="24dp"
-        android:layout_marginTop="23dp"
-        android:text="차단된 사용자는 회원님에게 틈 요청을 보내거나\n회원님의 프로필 또는 기록을 찾을 수 없게 됩니다.\n\n상대방에게는 회원님이 차단한 사실을 알리지 않습니다."
+        android:layout_marginTop="5dp"
+        android:lineSpacingExtra="0dp"
+        android:includeFontPadding="false"
+        android:text="삭제 시, 틈 약속이 취소돼요"
         android:textAlignment="center"
-        android:textColor="@color/text_primary"
-        android:textSize="14sp"
+        android:textColor="@color/text_secondary"
+        android:fontFamily="@font/noto_sans_kr_regular"
+        android:textSize="15sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tv_title" />
 
+    <ImageView
+        android:id="@+id/teumImage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginTop="15dp"
+        android:src="@drawable/ic_teum_char_sv"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tv_description" />
+
     <com.google.android.material.button.MaterialButton
-        android:id="@+id/btn_block_confirm"
+        android:id="@+id/btn_no"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="24dp"
-        android:layout_marginTop="76dp"
+        android:layout_marginTop="27.5dp"
         android:fontFamily="@font/noto_sans_kr_medium"
-        android:text="차단"
-        android:textColor="@android:color/white"
+        android:text="아니오"
+        android:textColor="@color/text_primary"
         android:textSize="16sp"
-
-        app:backgroundTint="@color/main_1"
+        app:backgroundTint="#F6F6F6"
         app:cornerRadius="12dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_description" />
+        app:layout_constraintTop_toBottomOf="@id/teumImage" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_yes"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="24dp"
+        android:layout_marginTop="14dp"
+        android:fontFamily="@font/noto_sans_kr_medium"
+        android:text="네"
+        android:textColor="@android:color/white"
+        android:textSize="16sp"
+        app:backgroundTint="@color/text_primary"
+        app:cornerRadius="12dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/btn_no" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_friend02_response.xml
+++ b/app/src/main/res/layout/fragment_friend02_response.xml
@@ -125,7 +125,6 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="19dp"
         android:layout_marginEnd="19dp"
-        android:layout_marginBottom="19dp"
         android:fontFamily="@font/noto_sans_kr_medium"
         android:text="함께할래요"
         android:textColor="#FFFFFF"

--- a/app/src/main/res/layout/friend03_promise_detail_bottom_sheet.xml
+++ b/app/src/main/res/layout/friend03_promise_detail_bottom_sheet.xml
@@ -6,7 +6,7 @@
     android:id="@+id/bottom_sheet_root"
     android:background="@drawable/friend_bg_bottom_sheet"
     android:layout_width="match_parent"
-    android:layout_height="392dp">
+    android:layout_height="wrap_content">
 
     <!-- 드래그 핸들 -->
     <View
@@ -151,28 +151,30 @@
         android:layout_marginBottom="48dp"
         app:layout_constraintTop_toBottomOf="@id/divider2"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/btnCancelPromise">
+        app:layout_constraintBottom_toTopOf="@id/cancelButtonContainer">
     </LinearLayout>
 
 
     <!-- 버튼: 약속된 틈 취소하기 -->
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/btnCancelPromise"
+    <FrameLayout
+        android:id="@+id/cancelButtonContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="19dp"
         android:layout_marginEnd="19dp"
-        android:layout_marginBottom="0dp"
-        android:layout_marginTop="305dp"
-        android:fontFamily="@font/noto_sans_kr_medium"
-        android:text="약속된 틈 취소하기"
-        android:textColor="#FFFFFF"
-        android:textSize="16sp"
-        app:backgroundTint="#0F0F0F"
-        app:cornerRadius="12dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/handle" />
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnCancelPromise"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:text="약속된 틈 취소하기"
+            android:textSize="16sp"
+            android:textColor="#FFFFFF"
+            android:fontFamily="@font/noto_sans_kr_regular"
+            app:backgroundTint="#0F0F0F"
+            app:cornerRadius="12dp"/>
+    </FrameLayout>
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #428

## ✨ 작업 내용
> 약속된 틈 취소하기 바텀시트 화면 추가 및 UI 수정하기 

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] 약속된 틈 보러가기에서 약속 취소 버튼 누르면 바로 취소되는게 아니라 진짜 취소할건지 바텀시트 뜨고 네 -> 취소 / 아니오 -> 이전 바텀시트 화면으로 뜨는지 


## 📸 스크린샷 (선택)
> 
<img width="486" height="1058" alt="image" src="https://github.com/user-attachments/assets/56310beb-4d18-49fd-9ccb-b4910b3d398d" />


## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 약속 취소 확인용 하단 시트 추가(“아니오/네” 선택) 및 취소 요청 처리 흐름 개선

* **버그 수정**
  * 취소 완료 시 해당 대화상자가 자동으로 닫히도록 동작 안정화
  * 취소 처리 중중복 요청 방지 및 오류 발생 시 버튼 복원

* **스타일**
  * 하단 시트 핸들 디자인 조정(크기·배경)
  * 약속 상세 하단 시트 레이아웃과 취소 버튼 배치 최적화

* **품질 개선**
  * 화면 하단 시스템 인셋 처리 추가로 레이아웃 안정성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->