### PR TITLE
[BUG/#440] 채움활동 새 진입 시 상태 초기화

### DIFF
--- a/app/src/main/java/com/example/teumteum/ui/activity/FillingActivity01Fragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/activity/FillingActivity01Fragment.kt
@@ -46,6 +46,13 @@ class FillingActivity01Fragment : Fragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        val isFreshEntry = arguments?.getBoolean("isFreshEntry", false) == true
+        if (isFreshEntry) {
+            viewModel.clearFillingFormState()
+            viewModel.clearActivityResults()
+            arguments?.remove("isFreshEntry") // 재호출 방지
+        }
+
         val selectedStroke = ContextCompat.getColor(requireContext(), R.color.main_1)
         val defaultStroke = ContextCompat.getColor(requireContext(), R.color.teumteum_bg)
 

--- a/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/example/teumteum/ui/main/HomeFragment.kt
@@ -173,7 +173,9 @@ class HomeFragment : Fragment() {
 
         binding.bannerCard.setOnClickListener {
             parentFragmentManager.beginTransaction()
-                .replace(R.id.main_frm, FillingActivity01Fragment())
+                .replace(R.id.main_frm, FillingActivity01Fragment().apply {
+                    arguments = Bundle().apply { putBoolean("isFreshEntry", true) }
+                })
                 .addToBackStack(null)
                 .commit()
         }


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #440 

## ✨ 작업 내용
> 채움활동 투두 등록 시 화면에 재진입하면 데이터가 유지되어 있는 문제 -> 채움활동 재진입 시 상태가 초기화되도록 플래그를 추가하여 처리하였습니다.


## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 로딩화면 또는 채움활동 탐색결과 화면(02)에서 이전 화면으로 돌아오면 선택한 데이터가 유지되어 있는지
- [x] 정상적으로 투두 등록을 마치고 홈 화면에서 채움활동 찾기 화면(01)으로 진입하면 선택한 데이터가 초기화되어 있는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **버그 수정**
  * 배너를 통해 양식 작성 화면에 진입할 때 이전 입력 상태가 초기화됩니다.
  * 새로운 항목 입력 시 이전 활동 데이터가 자동으로 제거됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->