### PR TITLE
[REFACTOR/#435] 알림 읽음 처리

### DIFF
--- a/app/src/main/java/com/umc/teumteum/data/remote/alarm/dto/NotificationResponse.kt
+++ b/app/src/main/java/com/umc/teumteum/data/remote/alarm/dto/NotificationResponse.kt
@@ -14,7 +14,8 @@ data class NotificationResponse(
     @SerializedName("friendNickname") val friendNickname: String,
     // 서버에서 오타(firendProfileImage)로 내려오므로 둘 다 매핑
     @SerializedName("friendProfileImage") val friendProfileImage: String? = null,
-    @SerializedName("firendProfileImage") val firendProfileImage: String? = null
+    @SerializedName("firendProfileImage") val firendProfileImage: String? = null,
+    @SerializedName("eventDate") val eventDate: String? = null
 ) {
     fun getProfileImageUrl(): String? {
         return friendProfileImage ?: firendProfileImage

--- a/app/src/main/java/com/umc/teumteum/data/remote/alarm/dto/ReadNotificationResult.kt
+++ b/app/src/main/java/com/umc/teumteum/data/remote/alarm/dto/ReadNotificationResult.kt
@@ -1,0 +1,8 @@
+package com.umc.teumteum.data.remote.alarm.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class ReadNotificationResult(
+    @SerializedName("notificationId") val notificationId: Long,
+    @SerializedName("isRead") val isRead: Boolean
+)

--- a/app/src/main/java/com/umc/teumteum/data/remote/alarm/repository/NotificationRepository.kt
+++ b/app/src/main/java/com/umc/teumteum/data/remote/alarm/repository/NotificationRepository.kt
@@ -2,6 +2,7 @@ package com.umc.teumteum.data.remote.alarm.repository
 
 import android.util.Log
 import com.umc.teumteum.data.remote.alarm.dto.NotificationsPage
+import com.umc.teumteum.data.remote.alarm.dto.ReadNotificationResult
 import com.umc.teumteum.data.remote.alarm.service.NotificationService
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -17,7 +18,20 @@ class NotificationRepository @Inject constructor(
         if (!response.isSuccessful) throw IllegalStateException("HTTP ${response.code()}")
         val body = response.body() ?: throw IllegalStateException("Empty body")
 
-        if (!body.isSuccess || body.code != "COMMON2000") {
+        if (!body.isSuccess || body.code != "NOTIFICATION2001") {
+            throw IllegalStateException(body.message)
+        }
+        body.result ?: throw IllegalStateException("Empty result")
+    }
+
+    suspend fun readNotification(notificationId: Long): Result<ReadNotificationResult> = runCatching {
+        val response = service.readNotification(notificationId)
+        Log.d("Notification", "response = ${response.body()}")
+
+        if (!response.isSuccessful) throw IllegalStateException("HTTP ${response.code()}")
+        val body = response.body() ?: throw IllegalStateException("Empty body")
+
+        if (!body.isSuccess || body.code != "NOTIFICATION2000") {
             throw IllegalStateException(body.message)
         }
         body.result ?: throw IllegalStateException("Empty result")

--- a/app/src/main/java/com/umc/teumteum/data/remote/alarm/service/NotificationService.kt
+++ b/app/src/main/java/com/umc/teumteum/data/remote/alarm/service/NotificationService.kt
@@ -2,9 +2,12 @@ package com.umc.teumteum.data.remote.alarm.service
 
 
 import com.umc.teumteum.data.remote.alarm.dto.NotificationsPage
+import com.umc.teumteum.data.remote.alarm.dto.ReadNotificationResult
 import com.umc.teumteum.utils.ApiResponse
 import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface NotificationService {
@@ -15,4 +18,8 @@ interface NotificationService {
         @Query("page") page: Int,
         @Query("size") size: Int
     ): Response<ApiResponse<NotificationsPage>>
+
+    // 알림 읽음 처리
+    @PATCH("/api/notifications/{notificationId}/read")
+    suspend fun readNotification(@Path("notificationId") notificationId: Long): Response<ApiResponse<ReadNotificationResult>>
 }

--- a/app/src/main/java/com/umc/teumteum/ui/alarm/AlarmFragment.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/alarm/AlarmFragment.kt
@@ -1,7 +1,6 @@
 package com.umc.teumteum.ui.alarm
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -26,6 +25,8 @@ class AlarmFragment : Fragment() {
     private val viewModel: NotificationViewModel by viewModels()
     private lateinit var adapter: AlarmRVAdapter
 
+    private var navigating = false
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -39,6 +40,9 @@ class AlarmFragment : Fragment() {
 
         // 어댑터 생성 시 콜백에서 네비게이터 + 트랜젝션 방식 적용
         adapter = AlarmRVAdapter(mutableListOf()) { notification ->
+            if (navigating) return@AlarmRVAdapter
+            navigating = true
+
             viewModel.readNotification(notification.id.toLong())
 
             val fragment = AlarmNavigator.createFragmentFor(this, notification)
@@ -103,6 +107,11 @@ class AlarmFragment : Fragment() {
         viewModel.error.observe(viewLifecycleOwner) { msg ->
             msg?.let { Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show() }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        navigating = false
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/umc/teumteum/ui/alarm/AlarmFragment.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/alarm/AlarmFragment.kt
@@ -1,6 +1,7 @@
 package com.umc.teumteum.ui.alarm
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -38,6 +39,8 @@ class AlarmFragment : Fragment() {
 
         // 어댑터 생성 시 콜백에서 네비게이터 + 트랜젝션 방식 적용
         adapter = AlarmRVAdapter(mutableListOf()) { notification ->
+            viewModel.readNotification(notification.id.toLong())
+
             val fragment = AlarmNavigator.createFragmentFor(this, notification)
             parentFragmentManager.beginTransaction()
                 .replace(R.id.main_frm, fragment)

--- a/app/src/main/java/com/umc/teumteum/ui/alarm/adapter/AlarmRVAdapter.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/alarm/adapter/AlarmRVAdapter.kt
@@ -64,16 +64,11 @@ class AlarmRVAdapter(
             b.profileIv.imageAlpha = 255
         }
 
-        // 클릭 시(읽음처럼 보이기)
         b.root.setOnClickListener {
-            if (!item.isRead) {
-                val gray = ContextCompat.getColor(b.root.context, R.color.teumteum_gray)
-                b.alarmNameTv.setTextColor(gray)
-                b.alarmContentTv.setTextColor(gray)
-                b.alarmTimeTv.setTextColor(gray)
-                b.profileIv.imageAlpha = 100
-            }
-            onItemClick(item)
+            val adapterPos = holder.bindingAdapterPosition
+            if (adapterPos == RecyclerView.NO_POSITION) return@setOnClickListener
+
+            onItemClick(items[adapterPos]) // 최신 데이터 전달
         }
     }
 

--- a/app/src/main/java/com/umc/teumteum/ui/alarm/viewModel/NotificationViewModel.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/alarm/viewModel/NotificationViewModel.kt
@@ -1,6 +1,5 @@
 package com.umc.teumteum.ui.alarm.viewModel
 
-
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -64,6 +63,27 @@ class NotificationViewModel @Inject constructor(
                     _error.value = e.message
                 }
             isLoading = false
+        }
+    }
+
+    // 알림 읽음 처리
+    fun readNotification(notificationId: Long) {
+        viewModelScope.launch {
+            repo.readNotification(notificationId)
+                .onSuccess { result ->
+                    val id = result.notificationId
+
+                    val current = _items.value.orEmpty()
+                    val updated = current.map { n ->
+                        if (n.id.toLong() == id) {
+                            if (n.isRead) n else n.copy(isRead = true)
+                        } else n
+                    }
+                    _items.value = updated
+                }
+                .onFailure { e ->
+                    _error.value = e.message ?: "읽음 처리에 실패했어요."
+                }
         }
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #435 

## ✨ 작업 내용
알림 카드뷰 클릭 시 해당 알림이 읽음 처리되도록 수정하였습니다. 서버의 성공 응답 코드가 COMMON2000에서 NOTIFICATION2001로 수정됨으로써 프론트에 수정사항 반영하였고 (읽음 처리 성공 응답 코드도 마찬가지) 서버 응답에서 내려오는 eventDate 변수를 추가하였습니다.
```kotlin
@SerializedName("eventDate") val eventDate: String? = null
``` 
현재 알림 화면 -> 친구 관련 화면 에서 기기의 뒤로가기 클릭 시 알림 화면과 겹치는 문제가 있어 캘린더 전환 관련 브랜치 내에서 수정하거나, 버그 이슈를 생성하여 작업할 예정입니다.

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 알림 조회가 정상적으로 되는지
- [x] 알림 클릭 시 읽음 처리되는지 (회색 표시)

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 알림에 이벤트 날짜(eventDate) 정보 추가
  * 알림 클릭 시 서버에 읽음 요청을 보내고 읽음 상태를 반영
  * 읽음 상태를 관리하는 기능 추가

* **개선**
  * 중복/재진입 네비게이션 방지
  * 클릭 처리 안정성 향상(최신 아이템 기준 처리)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->