### PR TITLE
[BUG/#449] 채움활동 빈틈채우기 이후 뒤로가기 클릭 시 이전 화면(시간 설정 화면)으로 돌아오는 문제

### DIFF
--- a/app/src/main/java/com/umc/teumteum/ui/activity/FillingSetting02Fragment.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/activity/FillingSetting02Fragment.kt
@@ -10,6 +10,7 @@ import android.widget.NumberPicker
 import android.widget.TextView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -305,9 +306,14 @@ class FillingSetting02Fragment : Fragment() {
                     }
                     parentFragmentManager.setFragmentResult("assign_home", result)
 
+                    // 백스택 전부 제거
+                    parentFragmentManager.popBackStack(
+                        null,
+                        FragmentManager.POP_BACK_STACK_INCLUSIVE
+                    )
+
                     parentFragmentManager.beginTransaction()
                         .replace(R.id.main_frm, HomeFragment())
-                        .addToBackStack(null)
                         .commit()
                 }
             }

--- a/app/src/main/java/com/umc/teumteum/ui/activity/FillingSetting03Fragment.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/activity/FillingSetting03Fragment.kt
@@ -10,6 +10,7 @@ import android.widget.NumberPicker
 import android.widget.TextView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -301,9 +302,14 @@ class FillingSetting03Fragment : Fragment() {
                     }
                     parentFragmentManager.setFragmentResult("assign_home", result)
 
+                    // 백스택 전부 제거
+                    parentFragmentManager.popBackStack(
+                        null,
+                        FragmentManager.POP_BACK_STACK_INCLUSIVE
+                    )
+
                     parentFragmentManager.beginTransaction()
                         .replace(R.id.main_frm, HomeFragment())
-                        .addToBackStack(null)
                         .commit()
                 }
             }

--- a/app/src/main/java/com/umc/teumteum/ui/wish/WishSetting02Fragment.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/wish/WishSetting02Fragment.kt
@@ -10,6 +10,7 @@ import android.widget.NumberPicker
 import android.widget.TextView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -269,9 +270,14 @@ class WishSetting02Fragment : Fragment() {
                     }
                     parentFragmentManager.setFragmentResult("assign_home", result)
 
+                    // 백스택 전부 제거
+                    parentFragmentManager.popBackStack(
+                        null,
+                        FragmentManager.POP_BACK_STACK_INCLUSIVE
+                    )
+
                     parentFragmentManager.beginTransaction()
                         .replace(R.id.main_frm, HomeFragment())
-                        .addToBackStack(null)
                         .commit()
                 }
             }

--- a/app/src/main/java/com/umc/teumteum/ui/wish/WishSetting03Fragment.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/wish/WishSetting03Fragment.kt
@@ -10,6 +10,7 @@ import android.widget.NumberPicker
 import android.widget.TextView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -262,9 +263,14 @@ class WishSetting03Fragment : Fragment() {
                     }
                     parentFragmentManager.setFragmentResult("assign_home", result)
 
+                    // 백스택 전부 제거
+                    parentFragmentManager.popBackStack(
+                        null,
+                        FragmentManager.POP_BACK_STACK_INCLUSIVE
+                    )
+
                     parentFragmentManager.beginTransaction()
                         .replace(R.id.main_frm, HomeFragment())
-                        .addToBackStack(null)
                         .commit()
                 }
             }


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #449 

## ✨ 작업 내용
> 채움활동 빈틈채우기 이후 뒤로가기 클릭 시 이전 화면(시간 설정 화면)으로 돌아오는 문제가 발생하여 백스택을 전부 제거 + 추가되지 않도록 수정하였습니다.

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 채움활동 or 위시 빈틈채우기 이후 홈 화면에서 뒤로가기 클릭 시 앱이 정상적으로 종료되는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 설정 및 할당 완료 후 이전 화면으로의 뒤로 가기 네비게이션이 제거되었습니다. 완료 후 홈 화면으로 이동하면 더 이상 이전 단계로 돌아갈 수 없습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->