### PR TITLE
[REFACTOR/#455] 차단된 계정이 없을 경우 화면 수정

### DIFF
--- a/app/src/main/java/com/umc/teumteum/ui/myhome/BlockedAccountFragment.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/myhome/BlockedAccountFragment.kt
@@ -62,7 +62,17 @@ class BlockedAccountFragment : Fragment() {
 
     private fun observeBlockedAccounts() {
         viewModel.blockedAccountList.observe(viewLifecycleOwner) { list ->
-            adapter.submitList(list)
+
+            if (list.isNullOrEmpty()) {
+                // 비어있으면 empty 화면 보여주기
+                binding.blockedAccountRv.visibility = View.GONE
+                binding.recentSearchNotExistsCl.visibility = View.VISIBLE
+            } else {
+                // 있으면 리스트 보여주기
+                binding.recentSearchNotExistsCl.visibility = View.GONE
+                binding.blockedAccountRv.visibility = View.VISIBLE
+                adapter.submitList(list)
+            }
         }
     }
 

--- a/app/src/main/res/layout/fragment_blocked_account.xml
+++ b/app/src/main/res/layout/fragment_blocked_account.xml
@@ -40,5 +40,35 @@
         android:layout_marginTop="50dp"
         />
 
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/recent_search_not_exists_cl"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone">
+
+        <ImageView
+            android:id="@+id/recent_search_not_exists_iv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_teum_char_sleep_sv"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+        <TextView
+            android:id="@+id/recent_search_not_exists_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/noto_sans_kr_medium"
+            android:includeFontPadding="false"
+            android:text="차단된 계정이 없어요"
+            android:textColor="@color/teumteum_gray"
+            android:textSize="15sp"
+            app:layout_constraintTop_toBottomOf="@id/recent_search_not_exists_iv"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #455

## ✨ 작업 내용
> 차단된 계정이 없을 경우 화면에 차단된 계정이 없어요 텍스트로 남기기 

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 차단된 계정이 없을 경우 밑에 이미지처럼 화면에 보이는지 


## 📸 스크린샷 (선택)
> 
<img width="396" height="825" alt="image" src="https://github.com/user-attachments/assets/a54419c2-0dc3-4b93-98a5-c0239ef4e166" />


## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 차단된 계정 목록이 비어있을 때 사용자 친화적인 빈 상태 화면이 표시되도록 개선되었습니다. 사용자는 이제 명확한 시각적 피드백을 통해 차단된 계정이 없음을 한눈에 파악할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->