### PR TITLE
[BUG/#451] 알림 리스트 스크롤 되지 않는 문제

### DIFF
--- a/app/src/main/res/layout/fragment_home_alarm.xml
+++ b/app/src/main/res/layout/fragment_home_alarm.xml
@@ -37,7 +37,7 @@
         android:layout_marginTop="28dp"
         android:paddingBottom="40dp"
         android:clipToPadding="false"
-        android:nestedScrollingEnabled="true"
+        android:nestedScrollingEnabled="false"
         android:overScrollMode="never"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #451 

## ✨ 작업 내용
> 알림 리스트가 스크롤이 되지 않으며, 이로 인해 과거의 알림을 확인할 수 없음. -> nestedScrollingEnabled 값을 false로 변경하였더니 정상적으로 스크롤됨. (5달 전에 온 첫번째 알림까지 스크롤 되는것 확인)

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 스크롤 되는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 홈 알람 화면에서 목록의 스크롤 동작이 개선되었습니다. 스크롤 처리가 최적화되어 더욱 부드럽고 반응성 있는 사용자 경험을 제공하며, 전반적인 성능이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->