### PR TITLE
[REFACTOR/#452] 팔로우 알림 클릭 시 팔로우/팔로잉 화면으로 이동

### DIFF
--- a/app/src/main/java/com/umc/teumteum/ui/alarm/AlarmFragment.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/alarm/AlarmFragment.kt
@@ -15,6 +15,9 @@ import com.umc.teumteum.data.remote.alarm.dto.enums.NotificationType
 import com.umc.teumteum.databinding.FragmentHomeAlarmBinding
 import com.umc.teumteum.ui.alarm.adapter.AlarmRVAdapter
 import com.umc.teumteum.ui.alarm.viewModel.NotificationViewModel
+import com.umc.teumteum.ui.friend.FriendProfileFollowFragment
+import com.umc.teumteum.ui.friend.FriendProfileFollowingFragment
+import com.umc.teumteum.ui.friend.viewModel.FriendViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -24,6 +27,8 @@ class AlarmFragment : Fragment() {
     private val binding get() = _binding!!
 
     private val viewModel: NotificationViewModel by viewModels()
+    private val friendViewModel: FriendViewModel by viewModels()
+
     private lateinit var adapter: AlarmRVAdapter
 
     private var navigating = false
@@ -46,12 +51,50 @@ class AlarmFragment : Fragment() {
 
             viewModel.readNotification(notification.id.toLong())
 
+            // 팔로잉 여부에 따른 분기 처리
+            if (notification.type == NotificationType.FOLLOW) {
+
+                val targetUserId = notification.friendId
+
+                friendViewModel.getFriendProfile(targetUserId) { profile ->
+
+                    val fragment: Fragment =
+                        if (profile.following) {
+                            FriendProfileFollowingFragment().apply {
+                                arguments = Bundle().apply {
+                                    putInt("userId", profile.userId)
+                                    putString("name", profile.name)
+                                    putString("field", profile.field)
+                                    putString("imageUrl", profile.profileImageUrl)
+                                }
+                            }
+                        } else {
+                            FriendProfileFollowFragment().apply {
+                                arguments = Bundle().apply {
+                                    putInt("userId", profile.userId)
+                                    putString("name", profile.name)
+                                    putString("field", profile.field)
+                                    putString("imageUrl", profile.profileImageUrl)
+                                }
+                            }
+                        }
+
+                    parentFragmentManager.beginTransaction()
+                        .hide(this@AlarmFragment)
+                        .add(R.id.main_frm, fragment)
+                        .addToBackStack(ALARM_FLOW)
+                        .commit()
+
+                }
+
+                return@AlarmRVAdapter
+            }
+
             val fragment = AlarmNavigator.createFragmentFor(this, notification)
 
             // 이동 대상 판단
             val isFriendTabDestination = notification.type == NotificationType.TEUM_REQUEST ||
-                    notification.type == NotificationType.TEUM_REQUEST_REREQUEST ||
-                    notification.type == NotificationType.FOLLOW
+                    notification.type == NotificationType.TEUM_REQUEST_REREQUEST
 
             activity?.findViewById<BottomNavigationView>(R.id.main_bnv)?.apply {
                 if (isFriendTabDestination) {
@@ -133,6 +176,13 @@ class AlarmFragment : Fragment() {
 
     private companion object {
         const val ALARM_FLOW = "ALARM_FLOW"
+    }
+
+    override fun onHiddenChanged(hidden: Boolean) {
+        super.onHiddenChanged(hidden)
+        if (!hidden) {
+            navigating = false
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/umc/teumteum/ui/alarm/AlarmFragment.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/alarm/AlarmFragment.kt
@@ -42,7 +42,7 @@ class AlarmFragment : Fragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        activity?.findViewById<BottomNavigationView>(R.id.main_bnv)?.visibility = View.GONE
+        hideBottomNav()
 
         // 어댑터 생성 시 콜백에서 네비게이터 + 트랜젝션 방식 적용
         adapter = AlarmRVAdapter(mutableListOf()) { notification ->
@@ -53,40 +53,33 @@ class AlarmFragment : Fragment() {
 
             // 팔로잉 여부에 따른 분기 처리
             if (notification.type == NotificationType.FOLLOW) {
-
                 val targetUserId = notification.friendId
 
                 friendViewModel.getFriendProfile(targetUserId) { profile ->
 
-                    val fragment: Fragment =
-                        if (profile.following) {
-                            FriendProfileFollowingFragment().apply {
-                                arguments = Bundle().apply {
-                                    putInt("userId", profile.userId)
-                                    putString("name", profile.name)
-                                    putString("field", profile.field)
-                                    putString("imageUrl", profile.profileImageUrl)
-                                }
-                            }
-                        } else {
-                            FriendProfileFollowFragment().apply {
-                                arguments = Bundle().apply {
-                                    putInt("userId", profile.userId)
-                                    putString("name", profile.name)
-                                    putString("field", profile.field)
-                                    putString("imageUrl", profile.profileImageUrl)
-                                }
-                            }
-                        }
+                    // 프레그먼트가 유효한 상태인지 확인
+                    if (!isAdded || view == null) {
+                        navigating = false
+                        return@getFriendProfile
+                    }
 
+                val args = Bundle().apply {
+                    putInt("userId", profile.userId)
+                    putString("name", profile.name)
+                    putString("field", profile.field)
+                    putString("imageUrl", profile.profileImageUrl)
+                }
+                val fragment: Fragment = if (profile.following) {
+                    FriendProfileFollowingFragment().apply { arguments = args }
+                } else {
+                    FriendProfileFollowFragment().apply { arguments = args }
+                }
                     parentFragmentManager.beginTransaction()
                         .hide(this@AlarmFragment)
                         .add(R.id.main_frm, fragment)
                         .addToBackStack(ALARM_FLOW)
                         .commit()
-
                 }
-
                 return@AlarmRVAdapter
             }
 
@@ -106,8 +99,9 @@ class AlarmFragment : Fragment() {
             }
 
             val tx = parentFragmentManager.beginTransaction()
-                .replace(R.id.main_frm, fragment)
-                .addToBackStack(ALARM_FLOW) // 뒤로가기 시 알림 화면으로 돌아오도록 유지
+                .hide(this@AlarmFragment)
+                .add(R.id.main_frm, fragment) // 뒤로가기 시 알림 화면으로 돌아오도록 유지
+                .addToBackStack(ALARM_FLOW)
 
             tx.commit()
         }
@@ -182,7 +176,12 @@ class AlarmFragment : Fragment() {
         super.onHiddenChanged(hidden)
         if (!hidden) {
             navigating = false
+            hideBottomNav()
         }
+    }
+
+    private fun hideBottomNav() {
+        activity?.findViewById<BottomNavigationView>(R.id.main_bnv)?.visibility = View.GONE
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #452 

## ✨ 작업 내용
상대방을 팔로우했는지 아닌지의 여부에 따라, 팔로우 알림 클릭 시 팔로우 또는 팔로잉 화면으로 이동.
userId 넘기고 있으나 name과 field, imageUrl까지 전달

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 팔로우/팔로잉 분기 처리

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 팔로우 알림을 탭하면 대상 사용자의 프로필로 직접 이동하는 전용 팔로우 흐름이 추가되어, 상대의 팔로우 상태에 맞는 화면이 표시됩니다.

* **개선 사항**
  * 탭 내비게이션 동작이 조정되어 팔로우 알림은 탭 전환 대상에서 제외되었습니다.
  * 하단 내비게이션 표시 제어와 프래그먼트 가시성 처리 로직이 개선되어 화면 전환과 알림 상태 관리가 더욱 안정적입니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->