### PR TITLE
[FEAT/#461] 알림 설정 조회

### DIFF
--- a/app/src/main/java/com/umc/teumteum/data/remote/mypage/model/AlarmSettingResponse.kt
+++ b/app/src/main/java/com/umc/teumteum/data/remote/mypage/model/AlarmSettingResponse.kt
@@ -1,0 +1,10 @@
+package com.umc.teumteum.data.remote.mypage.model
+
+import com.google.gson.annotations.SerializedName
+
+data class AlarmSettingResponse(
+    @SerializedName("todayTodo") val todayTodo: Boolean,
+    @SerializedName("remindAlarm") val remindAlarm: Boolean,
+    @SerializedName("follow") val follow: Boolean,
+    @SerializedName("teum") val teum: Boolean,
+)

--- a/app/src/main/java/com/umc/teumteum/data/remote/mypage/repository/SettingRepository.kt
+++ b/app/src/main/java/com/umc/teumteum/data/remote/mypage/repository/SettingRepository.kt
@@ -1,6 +1,7 @@
 package com.umc.teumteum.data.remote.mypage.repository
 
 import android.util.Log
+import com.umc.teumteum.data.remote.mypage.model.AlarmSettingResponse
 import com.umc.teumteum.data.remote.mypage.model.PushAlarmRequest
 import com.umc.teumteum.data.remote.mypage.model.RemindAlarmRequest
 import com.umc.teumteum.data.remote.mypage.model.RemindAlarmResponse
@@ -48,5 +49,12 @@ class SettingRepository @Inject constructor(
         val response = settingService.deleteSleepPattern()
         Log.d("Setting", "response = ${response.body()}")
         handleApiResponseUnit(response)
+    }
+
+    //알림 설정 조회
+    suspend fun getAlarmSettings(): Result<AlarmSettingResponse> = runCatching {
+        val response = settingService.getAlarmSettings()
+        Log.d("Setting", "response = ${response.body()}")
+        handleApiResponse(response)
     }
 }

--- a/app/src/main/java/com/umc/teumteum/data/remote/mypage/service/SettingService.kt
+++ b/app/src/main/java/com/umc/teumteum/data/remote/mypage/service/SettingService.kt
@@ -1,5 +1,6 @@
 package com.umc.teumteum.data.remote.mypage.service
 
+import com.umc.teumteum.data.remote.mypage.model.AlarmSettingResponse
 import com.umc.teumteum.data.remote.mypage.model.PushAlarmRequest
 import com.umc.teumteum.data.remote.mypage.model.RemindAlarmRequest
 import com.umc.teumteum.data.remote.mypage.model.RemindAlarmResponse
@@ -26,4 +27,8 @@ interface SettingService {
 
     @DELETE("/api/users/mypage/sleep-pattern")
     suspend fun deleteSleepPattern(): Response<ApiResponse<Unit>>
+
+    @GET("/api/users/mypage/alarm")
+    suspend fun getAlarmSettings(): Response<ApiResponse<AlarmSettingResponse>>
+
 }

--- a/app/src/main/java/com/umc/teumteum/ui/myhome/MyAlarmSettingFragment.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/myhome/MyAlarmSettingFragment.kt
@@ -35,6 +35,9 @@ class MyAlarmSettingFragment : Fragment() {
         (activity as? MainActivity)?.hideBottomBar()
 
         setupSwitchListeners()
+        observeViewModel()
+
+        viewModel.getAlarmSettings()
 
         binding.backArrowIv.setOnClickListener {
             parentFragmentManager.popBackStack()
@@ -56,11 +59,9 @@ class MyAlarmSettingFragment : Fragment() {
         val normalListener = CompoundButton.OnCheckedChangeListener { _, _ ->
             if (internalUpdate) return@OnCheckedChangeListener
 
-            if (binding.pushAlarmPauseSwitch.isChecked) {
-                internalUpdate = true
-                setAllDetailSwitches(false)
-                internalUpdate = false
-            }
+            internalUpdate = true
+            syncPauseSwitchFromDetails()
+            internalUpdate = false
 
             sendCurrentSetting()
         }
@@ -89,6 +90,35 @@ class MyAlarmSettingFragment : Fragment() {
         )
 
         viewModel.updatePushAlarmSetting(request)
+    }
+
+    private fun observeViewModel() {
+        viewModel.alarmSetting.observe(viewLifecycleOwner) { setting ->
+            internalUpdate = true
+
+            binding.todayTodoSwitch.isChecked = setting.todayTodo
+            binding.remindSettingSwitch.isChecked = setting.remindAlarm
+            binding.newFollowerSwitch.isChecked = setting.follow
+            binding.teumRequestSwitch.isChecked = setting.teum
+
+            syncPauseSwitchFromDetails()
+
+            internalUpdate = false
+        }
+
+        viewModel.error.observe(viewLifecycleOwner) { msg ->
+            if (msg.isNullOrBlank()) return@observe
+        }
+    }
+
+    private fun syncPauseSwitchFromDetails() {
+        val allOff =
+            !binding.todayTodoSwitch.isChecked &&
+                    !binding.remindSettingSwitch.isChecked &&
+                    !binding.newFollowerSwitch.isChecked &&
+                    !binding.teumRequestSwitch.isChecked
+
+        binding.pushAlarmPauseSwitch.isChecked = allOff
     }
 
 }

--- a/app/src/main/java/com/umc/teumteum/ui/myhome/viewModel/SettingViewModel.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/myhome/viewModel/SettingViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.umc.teumteum.data.remote.mypage.model.AlarmSettingResponse
 import com.umc.teumteum.data.remote.mypage.model.PushAlarmRequest
 import com.umc.teumteum.data.remote.mypage.model.RemindAlarmRequest
 import com.umc.teumteum.data.remote.mypage.repository.SettingRepository
@@ -27,6 +28,9 @@ class SettingViewModel @Inject constructor(
     private val _saving = MutableLiveData(false)
     val saving: LiveData<Boolean> = _saving
 
+    private val _alarmSetting = MutableLiveData<AlarmSettingResponse>()
+    val alarmSetting: LiveData<AlarmSettingResponse> = _alarmSetting
+
     fun getRemindAlarms() {
         viewModelScope.launch {
             repository.getRemindAlarms()
@@ -39,6 +43,20 @@ class SettingViewModel @Inject constructor(
                 }
         }
     }
+
+    fun getAlarmSettings() {
+        viewModelScope.launch {
+            repository.getAlarmSettings()
+                .onSuccess { result ->
+                    _alarmSetting.value = result
+                }
+                .onFailure {
+                    _error.value = "알림 설정 조회 실패: ${it.message}"
+                    Log.d("Setting", _error.value.toString())
+                }
+        }
+    }
+
 
     fun updateRemindAlarms(minutes: List<Int>) {
         viewModelScope.launch {


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #461

## ✨ 작업 내용
> 알림 설정 조회

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] 알림 설정이 제대로 조회되는지

## 📸 스크린샷 (선택)
> 기존 알림 설정 상태
<img width="345" height="734" alt="image" src="https://github.com/user-attachments/assets/ad27ff89-31b8-41f8-a1fa-89d21a046568" />

> 알림 설정 변경
<img width="338" height="734" alt="image" src="https://github.com/user-attachments/assets/c831f3ac-5a2e-4036-a0c4-ca4fee6cc592" />

> 다른 화면 이동 후 다시 알림 설정 페이지 이동 시 제대로 조회되는 지 확인
<img width="351" height="738" alt="image" src="https://github.com/user-attachments/assets/300aaa20-df72-4e9d-ba35-f68b3bae0e01" />



## 💬 기타 참고 사항
> 초기부터 사용하던 테스트 계정에서 알림 정보가 DB에 없는지 조회 실패가 뜨는데 다른 계정으로 테스트 시 정상적으로 작동합니다.
> API 실패: code=USER4041, message=사용자의 알림 설정 정보를 찾을 수 없습니다. 이 로그가 출력되면 다른 계정으로 테스트 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 알람 설정 조회 기능이 추가되어 사용자가 현재 알람 설정 상태를 확인할 수 있습니다.

## 개선 사항
* 알람 설정 화면의 UI 동기화 로직이 개선되어 설정이 더욱 안정적으로 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->