### PR TITLE
[REFACTOR/#465] 설정 페이지 UI 수정

### DIFF
--- a/app/src/main/java/com/umc/teumteum/data/remote/mypage/repository/SettingRepository.kt
+++ b/app/src/main/java/com/umc/teumteum/data/remote/mypage/repository/SettingRepository.kt
@@ -40,7 +40,7 @@ class SettingRepository @Inject constructor(
     suspend fun updateSleepPattern(sleepPattern: SleepPatternRequest): Result<Unit> = runCatching {
         val response = settingService.updateSleepPattern(sleepPattern)
         Log.d("Setting", "response = ${response.body()}")
-        handleApiResponse(response)
+        handleApiResponseUnit(response)
     }
 
     //수면패턴 삭제

--- a/app/src/main/java/com/umc/teumteum/ui/myhome/MyRoutineModifyFragment.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/myhome/MyRoutineModifyFragment.kt
@@ -1,11 +1,17 @@
 package com.umc.teumteum.ui.myhome
 
+import android.graphics.Rect
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.TouchDelegate
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -69,6 +75,31 @@ class MyRoutineModifyFragment : Fragment() {
 
         observeViewModel()
 
+        val initialMarginBottom =
+            (binding.nextBtn.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.nextBtn) { v, insets ->
+            val bottomInset = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom
+
+            v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                bottomMargin = initialMarginBottom + bottomInset
+            }
+            insets
+        }
+
+        binding.nextBtn.setOnClickListener {
+            parentFragmentManager.popBackStack(
+                null,
+                androidx.fragment.app.FragmentManager.POP_BACK_STACK_INCLUSIVE
+            )
+
+
+            val bottomNav = requireActivity()
+                .findViewById<com.google.android.material.bottomnavigation.BottomNavigationView>(R.id.main_bnv)
+
+            bottomNav.selectedItemId = R.id.fragment_home
+        }
+
         binding.backButton.setOnClickListener {
             parentFragmentManager.popBackStack()
         }
@@ -77,6 +108,7 @@ class MyRoutineModifyFragment : Fragment() {
             binding.sunTv, binding.monTv, binding.tueTv,
             binding.wedTv, binding.thuTv, binding.friTv, binding.satTv
         )
+        expandTouchAreas(dayTextViews, extraDp = 18)
 
         binding.scheduleRv.apply {
             layoutManager = LinearLayoutManager(requireContext())
@@ -161,4 +193,38 @@ class MyRoutineModifyFragment : Fragment() {
             scheduleAdapter.submitList(list)
         }
     }
+
+    private class MultiTouchDelegate(parent: View) : TouchDelegate(Rect(), parent) {
+        private val delegates = mutableListOf<TouchDelegate>()
+
+        fun add(delegate: TouchDelegate) {
+            delegates.add(delegate)
+        }
+
+        override fun onTouchEvent(event: MotionEvent): Boolean {
+            return delegates.any { it.onTouchEvent(event) }
+        }
+    }
+
+    private fun expandTouchAreas(views: List<View>, extraDp: Int = 18) {
+        if (views.isEmpty()) return
+        val parent = views.first().parent as? View ?: return
+
+        parent.post {
+            val density = parent.resources.displayMetrics.density
+            val extraPx = (extraDp * density).toInt()
+
+            val multi = MultiTouchDelegate(parent)
+
+            views.forEach { v ->
+                val rect = Rect()
+                v.getHitRect(rect)
+                rect.inset(-extraPx, -extraPx)
+                multi.add(TouchDelegate(rect, v))
+            }
+
+            parent.touchDelegate = multi
+        }
+    }
+
 }

--- a/app/src/main/java/com/umc/teumteum/ui/myhome/MySleepPatternSettingFragment.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/myhome/MySleepPatternSettingFragment.kt
@@ -11,6 +11,9 @@ import android.widget.Button
 import android.widget.NumberPicker
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
@@ -23,6 +26,7 @@ import com.umc.teumteum.ui.main.viewModel.HomeViewModel
 import com.umc.teumteum.ui.myhome.viewModel.SettingViewModel
 import com.umc.teumteum.utils.enableTapToNext
 import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.umc.teumteum.ui.myhome.viewModel.UiState
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
@@ -49,7 +53,21 @@ class MySleepPatternSettingFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         (activity as? MainActivity)?.hideBottomBar()
 
+        val initialMarginBottom =
+            (binding.confirmBtn.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.confirmBtn) { v, insets ->
+            val bottomInset = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom
+
+            v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                bottomMargin = initialMarginBottom + bottomInset
+            }
+            insets
+        }
+
         initSleepPattern()
+        observeViewModel()
+
         binding.deleteTv.paintFlags = binding.deleteTv.paintFlags or Paint.UNDERLINE_TEXT_FLAG
 
         binding.backButton.setOnClickListener {
@@ -234,4 +252,35 @@ class MySleepPatternSettingFragment : Fragment() {
             }
         }
     }
+
+    private fun observeViewModel() {
+        viewModel.state.observe(viewLifecycleOwner) { state ->
+            when (state) {
+                is UiState.Loading -> binding.confirmBtn.isEnabled = false
+
+                is UiState.Success -> {
+                    binding.confirmBtn.isEnabled = true
+                    navigateToHome()
+                    viewModel.resetState()
+                }
+
+                is UiState.Error -> {
+                    binding.confirmBtn.isEnabled = true
+                }
+
+                else -> Unit
+            }
+        }
+    }
+
+    private fun navigateToHome() {
+        parentFragmentManager.popBackStack(
+            null,
+            androidx.fragment.app.FragmentManager.POP_BACK_STACK_INCLUSIVE
+        )
+
+        val bottomNav = requireActivity().findViewById<com.google.android.material.bottomnavigation.BottomNavigationView>(R.id.main_bnv)
+        bottomNav.selectedItemId = R.id.fragment_home
+    }
+
 }

--- a/app/src/main/java/com/umc/teumteum/ui/myhome/viewModel/SettingViewModel.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/myhome/viewModel/SettingViewModel.kt
@@ -13,10 +13,20 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+sealed class UiState {
+    data object Idle : UiState()
+    data object Loading : UiState()
+    data object Success : UiState()
+    data class Error(val message: String) : UiState()
+}
+
 @HiltViewModel
 class SettingViewModel @Inject constructor(
     private val repository: SettingRepository
 ) : ViewModel() {
+
+    private val _state = MutableLiveData<UiState>(UiState.Idle)
+    val state: LiveData<UiState> = _state
 
     private val _error = MutableLiveData<String?>()
     val error: LiveData<String?> = _error
@@ -26,6 +36,10 @@ class SettingViewModel @Inject constructor(
 
     private val _saving = MutableLiveData(false)
     val saving: LiveData<Boolean> = _saving
+
+    fun resetState() {
+        _state.value = UiState.Idle
+    }
 
     fun getRemindAlarms() {
         viewModelScope.launch {
@@ -70,20 +84,35 @@ class SettingViewModel @Inject constructor(
 
     fun updateSleepPattern(request: SleepPatternRequest) {
         viewModelScope.launch {
+            _saving.value = true
+            _state.value = UiState.Loading
+
             repository.updateSleepPattern(request)
-                .onFailure {
-                    _error.value = "수면패턴 설정 저장 실패: ${it.message}"
-                    Log.d("Setting", _error.value.toString())
+                .onSuccess {
+                    _state.value = UiState.Success
                 }
+                .onFailure {
+                    val msg = "수면패턴 설정 저장 실패: ${it.message}"
+                    _error.value = msg
+                    _state.value = UiState.Error(msg)
+                    Log.d("Setting", msg)
+                }
+
+            _saving.value = false
         }
     }
 
     fun deleteSleepPattern() {
         viewModelScope.launch {
             repository.deleteSleepPattern()
+                .onSuccess {
+                    _state.value = UiState.Success
+                }
                 .onFailure {
-                    _error.value = "수면패턴 설정 저장 실패: ${it.message}"
-                    Log.d("Setting", _error.value.toString())
+                    val msg = "수면패턴 설정 저장 실패: ${it.message}"
+                    _error.value = msg
+                    _state.value = UiState.Error(msg)
+                    Log.d("Setting", msg)
                 }
         }
     }


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #465

## ✨ 작업 내용
> 반복일정 요일 클릭 범위 넓힘
> 하단 버튼 가려지는 부분 수정
> 반복일정, 수면패턴 수정 완료 시 홈화면 이동

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] 반복일정 요일 클릭
- [ ] 하단 버튼 가려지지 않는지
- [ ] 반복일정, 수면패턴 수정 시 홈화면으로 이동되는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 요일 선택 버튼의 터치 영역이 확대되어 더 쉽게 선택 가능
  * 하단 버튼(확인/다음)이 노치 및 내비게이션 바에 맞춰 자동으로 위치 조정
  * 수면 패턴 저장/삭제 흐름에 상태 기반 처리(로딩/성공/오류) 추가로 UI 반응성 및 오류 표시 개선
  * 저장 완료 시 홈으로 자동 이동되도록 내비게이션 흐름 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->