### PR TITLE
[REFACTOR/#467] 위시리스트 편집 화면 바텀 버튼 높이 수정

### DIFF
--- a/app/src/main/res/layout/fragment_wishlist_edit.xml
+++ b/app/src/main/res/layout/fragment_wishlist_edit.xml
@@ -125,7 +125,8 @@
         android:layout_width="0dp"
         android:layout_height="94dp"
         android:orientation="horizontal"
-        android:padding="14dp"
+        android:layout_marginBottom="20dp"
+        android:paddingTop="10dp"
         android:weightSum="2"
         android:background="@color/white"
         app:layout_constraintStart_toStartOf="parent"
@@ -135,23 +136,31 @@
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_wish_cancel"
             android:layout_width="0dp"
-            android:layout_height="65dp"
+            android:layout_height="56dp"
             android:layout_weight="1"
+            android:layout_marginStart="19dp"
             android:layout_marginEnd="8dp"
+            android:padding="0dp"
             android:text="선택 취소"
             android:textColor="@color/text_primary"
             app:backgroundTint="@color/teumteum_bg"
+            android:fontFamily="@font/noto_sans_kr_medium"
+            android:textSize="16sp"
             app:cornerRadius="12dp"/>
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_wish_delete"
             android:layout_width="0dp"
-            android:layout_height="65dp"
+            android:layout_height="56dp"
             android:layout_weight="1"
             android:layout_marginStart="8dp"
+            android:layout_marginEnd="19dp"
+            android:padding="0dp"
             android:text="삭제"
             android:textColor="@color/white"
             app:backgroundTint="@color/text_primary"
+            android:fontFamily="@font/noto_sans_kr_medium"
+            android:textSize="16sp"
             app:cornerRadius="12dp"/>
     </LinearLayout>
 


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #467 

## ✨ 작업 내용
> 위시리스트 편집 화면 바텀 버튼 높이 수정

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 하단 버튼이 네비에 가려지지 않는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 위시리스트 편집 화면의 버튼 레이아웃을 개선했습니다.
  * 버튼 크기와 간격을 최적화하여 UI 일관성을 향상시켰습니다.
  * 버튼 텍스트 스타일(폰트, 크기)을 개선했습니다.
  * 전체 레이아웃의 패딩과 마진을 조정하여 더 나은 사용자 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->