### PR TITLE
[BUG/#478] 이전 알림 사라짐 이슈

### DIFF
--- a/app/src/main/java/com/umc/teumteum/ui/alarm/AlarmFragment.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/alarm/AlarmFragment.kt
@@ -168,6 +168,7 @@ class AlarmFragment : Fragment() {
     override fun onResume() {
         super.onResume()
         navigating = false
+        viewModel.refresh()
     }
 
     private companion object {

--- a/app/src/main/java/com/umc/teumteum/ui/alarm/AlarmFragment.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/alarm/AlarmFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -26,7 +27,7 @@ class AlarmFragment : Fragment() {
     private var _binding: FragmentHomeAlarmBinding? = null
     private val binding get() = _binding!!
 
-    private val viewModel: NotificationViewModel by viewModels()
+    private val viewModel: NotificationViewModel by activityViewModels()
     private val friendViewModel: FriendViewModel by viewModels()
 
     private lateinit var adapter: AlarmRVAdapter
@@ -127,8 +128,9 @@ class AlarmFragment : Fragment() {
 
         observeViewModel()
 
-        // 최초 로드
-        viewModel.loadFirst()
+        if (viewModel.items.value.isNullOrEmpty()) {
+            viewModel.loadFirst()
+        }
     }
 
     private fun observeViewModel() {

--- a/app/src/main/java/com/umc/teumteum/ui/alarm/viewModel/NotificationViewModel.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/alarm/viewModel/NotificationViewModel.kt
@@ -41,6 +41,13 @@ class NotificationViewModel @Inject constructor(
         fetch(page + 1)
     }
 
+    fun refresh() {
+        if (isLoading) return
+        page = 1
+        hasNext = true
+        fetch(page)
+    }
+
     private fun fetch(targetPage: Int) {
         isLoading = true
         runningJob?.cancel()

--- a/app/src/main/java/com/umc/teumteum/ui/alarm/viewModel/NotificationViewModel.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/alarm/viewModel/NotificationViewModel.kt
@@ -30,10 +30,9 @@ class NotificationViewModel @Inject constructor(
     private var runningJob: Job? = null
 
     fun loadFirst() {
-        if (isLoading) return
+        if (isLoading || !_items.value.isNullOrEmpty()) return
         page = 1
         hasNext = true
-        _items.value = emptyList()
         fetch(page)
     }
 
@@ -51,12 +50,12 @@ class NotificationViewModel @Inject constructor(
                     hasNext = pageData.hasNext
                     page = pageData.currentPage
 
-                    val merged = if (targetPage == 1) {
-                        pageData.content
-                    } else {
-                        val old = _items.value.orEmpty()
-                        old + pageData.content
-                    }
+                    val old = _items.value.orEmpty()
+
+                    val merged = (pageData.content + old)
+                        .distinctBy { it.id }
+                        .sortedByDescending { it.createdAt }
+
                     _items.value = merged
                 }
                 .onFailure { e ->


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #478 

## ✨ 작업 내용
기존에는 Fragment Scope의 viewModel을 사용하여, 화면 이동 시 viewModel이 새로 생성되는 문제가 있었습니다. 이로 인해 알림 리스트가 초기화되거나 최신 일부 알림만 다시 조회되는 현상이 발생하였습니다.
따라서 Activity Scope로 변경하여 viewModel을 공유 + 화면 이동 시에도 기존 알림 데이터가 유지되도록 수정하였습니다.
추가로 초기 데이터 로드를 위해 loadFirst()는 데이터가 없는 경우에만 호출하도록 방어 로직을 적용하였습니다.

B 계정 -> A 계정으로 틈 요청, 틈 거절 알림을 보냈을 때 A 계정 알림 목록 조회 시 정상적으로 알림 데이터가 쌓이는 것을 확인하였으나 추후에 앱 테스트를 진행하면서 이전 알림이 사라지는 문제가 개선되었는지 확인할 필요가 있을 것 같습니다.

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 이전 알림 데이터가 삭제되지 않고 그대로 유지되는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 불필요한 알림 데이터 재로딩 방지
  * 중복된 알림 항목 제거 및 최신순 정렬 보장

* **개선**
  * 알림 화면 복귀 시 최신 상태로 자동 갱신
  * 알림 데이터가 화면 간에 일관되게 공유되어 중복 요청과 불일치 감소
<!-- end of auto-generated comment: release notes by coderabbit.ai -->