### PR TITLE
[BUG/#482] 틈 요청 카드뷰 텍스트 색상 처리

### DIFF
--- a/app/src/main/res/layout/friend01_item_recommend_card_read.xml
+++ b/app/src/main/res/layout/friend01_item_recommend_card_read.xml
@@ -68,6 +68,7 @@
                 android:lineSpacingExtra="0dp"
                 tools:text="사용자가 작성한 제목"
                 android:textSize="12sp"
+                android:textColor="@color/text_primary"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/border" />


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #482 

## ✨ 작업 내용
> 친구 화면에서 틈 요청 카드뷰를 읽었을 때 내용 부분이 회색이 아닌 기존의 검은색으로 처리되도록 색상 속성 추가

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 내용 부분이 미읽음/읽음 시 검은색으로 처리되는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
  * 텍스트 색상의 시각적 일관성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->