### PR TITLE
[Feat/#486] 프로필 이미지 변경 및 삭제

### DIFF
--- a/app/src/main/java/com/umc/teumteum/data/remote/mypage/repository/MyPageRepository.kt
+++ b/app/src/main/java/com/umc/teumteum/data/remote/mypage/repository/MyPageRepository.kt
@@ -42,6 +42,12 @@ class MyPageRepository @Inject constructor(
         handleApiResponseUnit(response)
     }
 
+    suspend fun deleteProfileImage(): Result<Unit> = runCatching {
+        val response = myPageService.deleteProfileImage()
+        Log.d("ProfileImageDelete", "response = ${response.body()}")
+        handleApiResponseUnit(response)
+    }
+
     //프로필 수정
     suspend fun updateProfile(request: ProfileUpdateRequest): Result<Unit> = runCatching {
         val response = myPageService.updateProfile(request)

--- a/app/src/main/java/com/umc/teumteum/data/remote/mypage/service/MyPageService.kt
+++ b/app/src/main/java/com/umc/teumteum/data/remote/mypage/service/MyPageService.kt
@@ -61,4 +61,7 @@ interface MyPageService {
 
     @DELETE("/api/users/mypage")
     suspend fun deleteUser(): Response<ApiResponse<Unit>>
+
+    @DELETE("/api/users/mypage/profile-image")
+    suspend fun deleteProfileImage(): Response<ApiResponse<Unit>>
 }

--- a/app/src/main/java/com/umc/teumteum/ui/myhome/BottomSheetSelectPictureFragment.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/myhome/BottomSheetSelectPictureFragment.kt
@@ -1,0 +1,59 @@
+package com.umc.teumteum.ui.myhome
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.umc.teumteum.databinding.FragmentBottomSheetSelectPictureBinding
+
+class BottomSheetSelectPictureFragment : BottomSheetDialogFragment() {
+
+    private var _binding: FragmentBottomSheetSelectPictureBinding? = null
+    private val binding get() = _binding!!
+
+    private var onGalleryClick: (() -> Unit)? = null
+    private var onDefaultProfileClick: (() -> Unit)? = null
+
+    fun setOnGalleryClickListener(listener: () -> Unit) {
+        onGalleryClick = listener
+    }
+
+    fun setOnDefaultProfileClickListener(listener: () -> Unit) {
+        onDefaultProfileClick = listener
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentBottomSheetSelectPictureBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.galleryLl.setOnClickListener {
+            onGalleryClick?.invoke()
+            dismiss()
+        }
+
+        binding.defaultProfileLl.setOnClickListener {
+            onDefaultProfileClick?.invoke()
+            dismiss()
+        }
+
+        binding.btnCancel.setOnClickListener {
+            dismiss()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        onGalleryClick = null
+        onDefaultProfileClick = null
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/umc/teumteum/ui/myhome/MyProfileFragment.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/myhome/MyProfileFragment.kt
@@ -10,6 +10,7 @@ import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.umc.teumteum.R
 import com.umc.teumteum.data.remote.mypage.model.PublicTodoResponse
 import com.umc.teumteum.databinding.FragmentMyProfileBinding
@@ -22,20 +23,17 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class MyProfileFragment : Fragment() {
 
-    private lateinit var binding: FragmentMyProfileBinding
+    private var _binding: FragmentMyProfileBinding? = null
+    private val binding get() = _binding!!
 
     private val viewModel: MyHomeViewModel by activityViewModels()
     private val homeViewModel: HomeViewModel by activityViewModels()
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-    }
-
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        binding = FragmentMyProfileBinding.inflate(inflater,container,false)
+    ): View {
+        _binding = FragmentMyProfileBinding.inflate(inflater, container, false)
         return binding.root
     }
 
@@ -45,9 +43,24 @@ class MyProfileFragment : Fragment() {
 
         ViewCompat.setOnApplyWindowInsetsListener(binding.fragmentMyProfileContainer) { _, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-
             binding.fragmentMyProfileContainer.updatePadding(bottom = systemBars.bottom)
             insets
+        }
+
+        // 최초 1회 조회
+        if (!viewModel.isLoaded) {
+            viewModel.getMyInfo()
+        }
+
+        // 프로필 수정 후 돌아왔을 때만 재조회
+        parentFragmentManager.setFragmentResultListener(
+            "profile_modify_result",
+            viewLifecycleOwner
+        ) { _, bundle ->
+            val updated = bundle.getBoolean("profile_updated", false)
+            if (updated) {
+                viewModel.getMyInfo()
+            }
         }
 
         binding.backBtn.setOnClickListener {
@@ -89,15 +102,16 @@ class MyProfileFragment : Fragment() {
             if (!imageUrl.isNullOrBlank()) {
                 Glide.with(this)
                     .load(imageUrl)
-                    .placeholder(R.drawable.gray_teum) // 기본 이미지 리소스
-                    .error(R.drawable.gray_teum)       // 에러 시 이미지
+                    .placeholder(R.drawable.gray_teum)
+                    .error(R.drawable.gray_teum)
+                    .diskCacheStrategy(DiskCacheStrategy.NONE)
+                    .skipMemoryCache(true)
                     .into(binding.profileIv)
             } else {
                 binding.profileIv.setImageResource(R.drawable.gray_teum)
             }
         }
 
-        //  최근 투두 관찰
         viewModel.recentTodos.observe(viewLifecycleOwner) { list ->
             bindTodos(list)
         }
@@ -110,30 +124,32 @@ class MyProfileFragment : Fragment() {
         binding.profileTimerTv.text = "${days}일 ${hours}시간 ${minutes}분"
     }
 
-    // 화면 내에 추가
     private fun bindTodos(list: List<PublicTodoResponse>) {
         val l = list.take(2)
 
-        // 컨테이너 보이기/숨기기
-        binding.scheduleCardContainer.visibility = if (l.isNotEmpty()) View.VISIBLE else View.GONE
+        binding.scheduleCardContainer.visibility =
+            if (l.isNotEmpty()) View.VISIBLE else View.GONE
 
         if (l.isEmpty()) return
 
-        // 첫 번째 카드
         val first = l[0]
         binding.schedule1TimeStartTv.text = first.startTime
-        binding.schedule1TimeEndTv.text   = first.endTime
-        binding.schedule1TitleTv.text     = first.title
+        binding.schedule1TimeEndTv.text = first.endTime
+        binding.schedule1TitleTv.text = first.title
 
-        // 두 번째 카드
         if (l.size >= 2) {
             val second = l[1]
             binding.schedule2Cl.visibility = View.VISIBLE
             binding.schedule2TimeStartTv.text = second.startTime
-            binding.schedule2TimeEndTv.text   = second.endTime
-            binding.schedule2TitleTv.text     = second.title
+            binding.schedule2TimeEndTv.text = second.endTime
+            binding.schedule2TitleTv.text = second.title
         } else {
             binding.schedule2Cl.visibility = View.GONE
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/com/umc/teumteum/ui/myhome/MyProfileModifyFragment.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/myhome/MyProfileModifyFragment.kt
@@ -7,12 +7,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.os.bundleOf
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.umc.teumteum.R
 import com.umc.teumteum.databinding.FragmentMyProfileModifyBinding
 import com.umc.teumteum.ui.main.MainActivity
@@ -25,18 +27,16 @@ import kotlin.math.max
 @AndroidEntryPoint
 class MyProfileModifyFragment : Fragment() {
 
-    private lateinit var binding: FragmentMyProfileModifyBinding
+    private var _binding: FragmentMyProfileModifyBinding? = null
+    private val binding get() = _binding!!
 
     private val viewModel: MyHomeViewModel by activityViewModels()
     private val homeViewModel: HomeViewModel by activityViewModels()
-
-    // 수정 전용 ViewModel
     private val modifyViewModel: ProfileModifyViewModel by activityViewModels()
 
     private var nicknameInitialized = false
     private var fieldInitialized = false
 
-    // 갤러리에서 이미지 선택
     private val galleryLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) { result ->
@@ -48,10 +48,11 @@ class MyProfileModifyFragment : Fragment() {
     }
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = FragmentMyProfileModifyBinding.inflate(inflater, container, false)
+        _binding = FragmentMyProfileModifyBinding.inflate(inflater, container, false)
         return binding.root
     }
 
@@ -63,7 +64,6 @@ class MyProfileModifyFragment : Fragment() {
             val imeBottom = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
             val sysBottom = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom
             val bottomPadding = if (imeBottom > 0) max(imeBottom, sysBottom) else 0
-
             v.updatePadding(bottom = bottomPadding)
             insets
         }
@@ -102,43 +102,44 @@ class MyProfileModifyFragment : Fragment() {
             }
         }
 
-        // 타이머
         homeViewModel.teumTimeDays.observe(viewLifecycleOwner) { updateTeumTime() }
         homeViewModel.teumTimeHours.observe(viewLifecycleOwner) { updateTeumTime() }
         homeViewModel.teumTimeMinutes.observe(viewLifecycleOwner) { updateTeumTime() }
 
-        modifyViewModel.tempImageUri.observe(viewLifecycleOwner) { uri ->
-            if (uri != null) {
-                binding.profileIv.setImageURI(uri)
-            }
+        modifyViewModel.imageEditState.observe(viewLifecycleOwner) {
+            renderEditProfileImagePreview()
         }
 
-        viewModel.profileImageUrl.observe(viewLifecycleOwner) { imageUrl ->
-            if (modifyViewModel.tempImageUri.value != null) return@observe
-
-            if (!imageUrl.isNullOrBlank()) {
-                Glide.with(this)
-                    .load(imageUrl)
-                    .placeholder(R.drawable.gray_teum)
-                    .error(R.drawable.gray_teum)
-                    .into(binding.profileIv)
-            } else {
-                binding.profileIv.setImageResource(R.drawable.gray_teum)
-            }
+        viewModel.profileImageUrl.observe(viewLifecycleOwner) {
+            renderEditProfileImagePreview()
         }
 
-        val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
         binding.profileIv.setOnClickListener {
-            galleryLauncher.launch(pickImageIntent)
+            val bottomSheet = BottomSheetSelectPictureFragment().apply {
+                setOnGalleryClickListener {
+                    val pickImageIntent = Intent(Intent.ACTION_PICK).apply {
+                        type = "image/*"
+                    }
+                    galleryLauncher.launch(pickImageIntent)
+                }
+
+                setOnDefaultProfileClickListener {
+                    modifyViewModel.setDefaultProfileImage()
+                }
+            }
+            bottomSheet.show(parentFragmentManager, "BottomSheetSelectPictureFragment")
         }
 
         modifyViewModel.saveSuccess.observe(viewLifecycleOwner) { ok ->
             if (ok == true) {
-                // 성공 후 내 프로필 재조회
-                viewModel.getMyInfo()
+                modifyViewModel.consumeSaveSuccess()
+
+                parentFragmentManager.setFragmentResult(
+                    "profile_modify_result",
+                    bundleOf("profile_updated" to true)
+                )
 
                 parentFragmentManager.popBackStack()
-                modifyViewModel.consumeSaveSuccess()
             }
         }
 
@@ -162,21 +163,37 @@ class MyProfileModifyFragment : Fragment() {
             val next = !(modifyViewModel.timePublic.value ?: true)
             modifyViewModel.setTimePublic(next)
         }
+
         binding.timerLockIv.setOnClickListener {
             val next = !(modifyViewModel.timePublic.value ?: true)
             modifyViewModel.setTimePublic(next)
         }
+    }
 
-        modifyViewModel.saveSuccess.observe(viewLifecycleOwner) { ok ->
-            if (ok == true) {
-                // 재조회
-                viewModel.getMyInfo()
+    private fun renderProfileImage(imageUrl: String?) {
+        if (!imageUrl.isNullOrBlank()) {
+            Glide.with(this)
+                .load(imageUrl)
+                .placeholder(R.drawable.gray_teum)
+                .error(R.drawable.gray_teum)
+                .diskCacheStrategy(DiskCacheStrategy.NONE)
+                .skipMemoryCache(true)
+                .into(binding.profileIv)
+        } else {
+            binding.profileIv.setImageResource(R.drawable.gray_teum)
+        }
+    }
 
-                viewModel.profileImageUrl.observe(viewLifecycleOwner) {
-                    parentFragmentManager.popBackStack()
-                }
-
-                modifyViewModel.consumeSaveSuccess()
+    private fun renderEditProfileImagePreview() {
+        when (val state = modifyViewModel.imageEditState.value) {
+            is ProfileModifyViewModel.ImageEditState.New -> {
+                binding.profileIv.setImageURI(state.uri)
+            }
+            is ProfileModifyViewModel.ImageEditState.Default -> {
+                binding.profileIv.setImageResource(R.drawable.gray_teum)
+            }
+            is ProfileModifyViewModel.ImageEditState.Keep, null -> {
+                renderProfileImage(viewModel.profileImageUrl.value)
             }
         }
     }
@@ -186,5 +203,10 @@ class MyProfileModifyFragment : Fragment() {
         val hours = homeViewModel.teumTimeHours.value ?: 0
         val minutes = homeViewModel.teumTimeMinutes.value ?: 0
         binding.profileTimerTv.text = "${days}일 ${hours}시간 ${minutes}분"
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/com/umc/teumteum/ui/myhome/MyProfileModifyFragment.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/myhome/MyProfileModifyFragment.kt
@@ -37,6 +37,10 @@ class MyProfileModifyFragment : Fragment() {
     private var nicknameInitialized = false
     private var fieldInitialized = false
 
+    companion object {
+        private const val SELECT_PICTURE_BOTTOM_SHEET_TAG = "BottomSheetSelectPictureFragment"
+    }
+
     private val galleryLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) { result ->
@@ -115,6 +119,10 @@ class MyProfileModifyFragment : Fragment() {
         }
 
         binding.profileIv.setOnClickListener {
+            if(parentFragmentManager.findFragmentByTag(SELECT_PICTURE_BOTTOM_SHEET_TAG) != null) {
+                return@setOnClickListener
+            }
+
             val bottomSheet = BottomSheetSelectPictureFragment().apply {
                 setOnGalleryClickListener {
                     val pickImageIntent = Intent(Intent.ACTION_PICK).apply {
@@ -127,7 +135,8 @@ class MyProfileModifyFragment : Fragment() {
                     modifyViewModel.setDefaultProfileImage()
                 }
             }
-            bottomSheet.show(parentFragmentManager, "BottomSheetSelectPictureFragment")
+//            bottomSheet.show(parentFragmentManager, "BottomSheetSelectPictureFragment")
+            bottomSheet.show(parentFragmentManager, SELECT_PICTURE_BOTTOM_SHEET_TAG)
         }
 
         modifyViewModel.saveSuccess.observe(viewLifecycleOwner) { ok ->
@@ -180,6 +189,7 @@ class MyProfileModifyFragment : Fragment() {
                 .skipMemoryCache(true)
                 .into(binding.profileIv)
         } else {
+            Glide.with(binding.profileIv).clear(binding.profileIv)
             binding.profileIv.setImageResource(R.drawable.gray_teum)
         }
     }
@@ -187,9 +197,11 @@ class MyProfileModifyFragment : Fragment() {
     private fun renderEditProfileImagePreview() {
         when (val state = modifyViewModel.imageEditState.value) {
             is ProfileModifyViewModel.ImageEditState.New -> {
+                Glide.with(binding.profileIv).clear(binding.profileIv)
                 binding.profileIv.setImageURI(state.uri)
             }
             is ProfileModifyViewModel.ImageEditState.Default -> {
+                Glide.with(binding.profileIv).clear(binding.profileIv)
                 binding.profileIv.setImageResource(R.drawable.gray_teum)
             }
             is ProfileModifyViewModel.ImageEditState.Keep, null -> {

--- a/app/src/main/java/com/umc/teumteum/ui/myhome/viewModel/ProfileModifyViewModel.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/myhome/viewModel/ProfileModifyViewModel.kt
@@ -11,7 +11,11 @@ import com.umc.teumteum.data.remote.mypage.repository.MyPageRepository
 import com.umc.teumteum.data.remote.onboarding.model.PresignedRequest
 import com.umc.teumteum.data.remote.onboarding.model.ProfileImageRequest
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
@@ -19,11 +23,19 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.IOException
 import javax.inject.Inject
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 @HiltViewModel
 class ProfileModifyViewModel @Inject constructor(
     private val repository: MyPageRepository
 ) : ViewModel() {
+
+    sealed class ImageEditState {
+        data object Keep : ImageEditState()
+        data object Default : ImageEditState()
+        data class New(val uri: Uri) : ImageEditState()
+    }
 
     private val okHttpClient = OkHttpClient()
 
@@ -37,22 +49,21 @@ class ProfileModifyViewModel @Inject constructor(
     private val _tempField = MutableLiveData<String?>(null)
     val tempField: LiveData<String?> = _tempField
 
-    private val _tempImageUri = MutableLiveData<Uri?>(null)
-    val tempImageUri: LiveData<Uri?> = _tempImageUri
+    private val _imageEditState = MutableLiveData<ImageEditState>(ImageEditState.Keep)
+    val imageEditState: LiveData<ImageEditState> = _imageEditState
 
     private val _timePublic = MutableLiveData(true)
     val timePublic: LiveData<Boolean> = _timePublic
 
-    fun setTimePublic(value: Boolean) {
-        _timePublic.value = value
-    }
-
-    // 저장 결과
     private val _saveSuccess = MutableLiveData(false)
     val saveSuccess: LiveData<Boolean> = _saveSuccess
 
     private val _saveError = MutableLiveData<String?>(null)
     val saveError: LiveData<String?> = _saveError
+
+    fun setTimePublic(value: Boolean) {
+        _timePublic.value = value
+    }
 
     fun startEdit(nickname: String?, field: String?, profileUrl: String?) {
         if (originNickname != null || originField != null || originProfileUrl != null) return
@@ -63,37 +74,43 @@ class ProfileModifyViewModel @Inject constructor(
 
         _tempNickname.value = nickname
         _tempField.value = field
-        _tempImageUri.value = null
+        _imageEditState.value = ImageEditState.Keep
     }
 
-    fun setTempNickname(v: String?) { _tempNickname.value = v }
-    fun setTempField(v: String?) { _tempField.value = v }
+    fun setTempNickname(v: String?) {
+        _tempNickname.value = v
+    }
+
+    fun setTempField(v: String?) {
+        _tempField.value = v
+    }
 
     fun setTempImage(uri: Uri) {
-        _tempImageUri.value = uri
+        _imageEditState.value = ImageEditState.New(uri)
+    }
+
+    fun setDefaultProfileImage() {
+        _imageEditState.value = ImageEditState.Default
+    }
+
+    fun keepCurrentProfileImage() {
+        _imageEditState.value = ImageEditState.Keep
     }
 
     fun cancelEdit() {
         _tempNickname.value = originNickname
         _tempField.value = originField
-        _tempImageUri.value = null
+        _imageEditState.value = ImageEditState.Keep
         clearSession()
     }
 
-    // 사용자 프로필 수정 반영
     fun commit(context: Context) {
         viewModelScope.launch {
             try {
-                //이미지 업로드
-                val uri = _tempImageUri.value
-                if (uri != null) {
-                    uploadProfileImageToS3AndRegister(context, uri)
-                }
-
-                //사용자 정보 수정
                 val nickname = _tempNickname.value?.trim().orEmpty()
                 val jobField = _tempField.value?.trim().orEmpty()
                 val timePublic = _timePublic.value ?: true
+                val imageState = _imageEditState.value ?: ImageEditState.Keep
 
                 repository.updateProfile(
                     ProfileUpdateRequest(
@@ -103,6 +120,18 @@ class ProfileModifyViewModel @Inject constructor(
                     )
                 ).getOrThrow()
 
+                when (imageState) {
+                    is ImageEditState.Keep -> Unit
+
+                    is ImageEditState.Default -> {
+                        repository.deleteProfileImage().getOrThrow()
+                    }
+
+                    is ImageEditState.New -> {
+                        uploadProfileImageToS3AndRegister(context, imageState.uri)
+                    }
+                }
+
                 _saveSuccess.value = true
                 clearSession()
             } catch (e: Exception) {
@@ -111,66 +140,80 @@ class ProfileModifyViewModel @Inject constructor(
         }
     }
 
-    private fun uploadProfileImageToS3AndRegister(context: Context, uri: Uri) {
+    private suspend fun uploadProfileImageToS3AndRegister(context: Context, uri: Uri) {
         val contentType = context.contentResolver.getType(uri) ?: "image/jpeg"
 
-        viewModelScope.launch {
-            repository.requestPresignedUrl(PresignedRequest(contentType))
-                .onSuccess { presignedResponse ->
-                    val fileName = presignedResponse.fileName
-                    val presignedUrl = presignedResponse.presignedUrl
+        val presignedResponse = repository
+            .requestPresignedUrl(PresignedRequest(contentType))
+            .getOrThrow()
 
-                    val inputStream = context.contentResolver.openInputStream(uri)
-                    val bytes = inputStream?.readBytes() ?: run {
-                        _saveError.postValue("이미지를 불러올 수 없습니다.")
-                        return@onSuccess
+        val inputStream = context.contentResolver.openInputStream(uri)
+            ?: throw IllegalStateException("이미지를 불러올 수 없습니다.")
+
+        val bytes = withContext(Dispatchers.IO) {
+            inputStream.use { it.readBytes() }
+        }
+
+        uploadToS3(
+            presignedUrl = presignedResponse.presignedUrl,
+            bytes = bytes,
+            contentType = contentType
+        )
+
+        repository.postProfileImage(
+            ProfileImageRequest(presignedResponse.fileName)
+        ).getOrThrow()
+    }
+
+    private suspend fun uploadToS3(
+        presignedUrl: String,
+        bytes: ByteArray,
+        contentType: String
+    ) = suspendCancellableCoroutine<Unit> { cont ->
+        val requestBody = bytes.toRequestBody(contentType.toMediaTypeOrNull())
+        val request = Request.Builder()
+            .url(presignedUrl)
+            .put(requestBody)
+            .build()
+
+        val call = okHttpClient.newCall(request)
+
+        cont.invokeOnCancellation {
+            call.cancel()
+        }
+
+        call.enqueue(object : Callback {
+            override fun onFailure(call: Call, e: IOException) {
+                if (cont.isActive) cont.resumeWithException(e)
+            }
+
+            override fun onResponse(call: Call, response: okhttp3.Response) {
+                response.use {
+                    if (!cont.isActive) return
+                    if (response.isSuccessful) {
+                        cont.resume(Unit)
+                    } else {
+                        cont.resumeWithException(
+                            IOException("이미지 업로드 실패 (code: ${response.code})")
+                        )
                     }
-
-                    val requestBody = bytes.toRequestBody(contentType.toMediaTypeOrNull())
-                    val request = Request.Builder()
-                        .url(presignedUrl)
-                        .put(requestBody)
-                        .build()
-
-                    okHttpClient.newCall(request).enqueue(object : Callback {
-                        override fun onFailure(call: okhttp3.Call, e: IOException) {
-                            _saveError.postValue("이미지 업로드 실패: ${e.message}")
-                        }
-
-                        override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
-                            if (response.isSuccessful) {
-                                postProfileImage(ProfileImageRequest(fileName))
-                            } else {
-                                _saveError.postValue("이미지 업로드 실패 (code: ${response.code})")
-                            }
-                        }
-                    })
                 }
-                .onFailure { e ->
-                    _saveError.postValue(e.message ?: "프리사인드 URL 발급 실패")
-                }
-        }
+            }
+        })
     }
 
-    private fun postProfileImage(request: ProfileImageRequest) {
-        viewModelScope.launch {
-            repository.postProfileImage(request)
-                .onSuccess {
-                    _saveSuccess.postValue(true)
-                    clearSession()
-                }
-                .onFailure { e ->
-                    _saveError.postValue(e.message ?: "프로필 이미지 등록 실패")
-                }
-        }
+    fun consumeSaveSuccess() {
+        _saveSuccess.value = false
     }
 
-    fun consumeSaveSuccess() { _saveSuccess.value = false }
-    fun clearError() { _saveError.value = null }
+    fun clearError() {
+        _saveError.value = null
+    }
 
     private fun clearSession() {
         originNickname = null
         originField = null
         originProfileUrl = null
+        _imageEditState.postValue(ImageEditState.Keep)
     }
 }

--- a/app/src/main/java/com/umc/teumteum/ui/onboarding/OnBoardingProfileFragment.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/onboarding/OnBoardingProfileFragment.kt
@@ -29,6 +29,10 @@ class OnBoardingProfileFragment : Fragment() {
 
     private val viewModel: OnBoardingViewModel by activityViewModels()
 
+    companion object {
+        private const val SELECT_PICTURE_BOTTOM_SHEET_TAG = "BottomSheetSelectPictureFragment"
+    }
+
     private val galleryLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) { result ->
@@ -85,6 +89,9 @@ class OnBoardingProfileFragment : Fragment() {
     }
 
     private fun showSelectPictureBottomSheet() {
+        if (parentFragmentManager.findFragmentByTag(SELECT_PICTURE_BOTTOM_SHEET_TAG) != null) {
+            return
+        }
         val bottomSheet = BottomSheetSelectPictureFragment().apply {
             setOnGalleryClickListener {
                 val pickImageIntent = Intent(Intent.ACTION_PICK).apply {
@@ -99,7 +106,8 @@ class OnBoardingProfileFragment : Fragment() {
             }
         }
 
-        bottomSheet.show(parentFragmentManager, "BottomSheetSelectPictureFragment")
+//        bottomSheet.show(parentFragmentManager, "BottomSheetSelectPictureFragment")
+        bottomSheet.show(parentFragmentManager, SELECT_PICTURE_BOTTOM_SHEET_TAG)
     }
 
     private fun observeViewModel() {

--- a/app/src/main/java/com/umc/teumteum/ui/onboarding/OnBoardingProfileFragment.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/onboarding/OnBoardingProfileFragment.kt
@@ -13,8 +13,10 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import com.umc.teumteum.R
 import com.umc.teumteum.databinding.FragmentOnBoardingProfileBinding
 import com.umc.teumteum.ui.auth.SignUpActivity
+import com.umc.teumteum.ui.myhome.BottomSheetSelectPictureFragment
 import com.umc.teumteum.ui.onboarding.viewModel.OnBoardingUiState
 import com.umc.teumteum.ui.onboarding.viewModel.OnBoardingViewModel
 import dagger.hilt.android.AndroidEntryPoint
@@ -22,20 +24,18 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class OnBoardingProfileFragment : Fragment() {
 
-    private lateinit var binding: FragmentOnBoardingProfileBinding
-    private val viewModel: OnBoardingViewModel by activityViewModels()
+    private var _binding: FragmentOnBoardingProfileBinding? = null
+    private val binding get() = _binding!!
 
-    private var lastSelectedImageUri: Uri? = null
+    private val viewModel: OnBoardingViewModel by activityViewModels()
 
     private val galleryLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) { result ->
         if (result.resultCode == Activity.RESULT_OK) {
             result.data?.data?.let { uri ->
-                lastSelectedImageUri = uri
-                binding.profileIv.setImageURI(uri)
-                binding.cameraBtn.visibility = View.GONE
                 viewModel.setProfileImage(uri)
+                renderProfileImage(uri)
             }
         }
     }
@@ -44,7 +44,7 @@ class OnBoardingProfileFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = FragmentOnBoardingProfileBinding.inflate(inflater, container, false)
+        _binding = FragmentOnBoardingProfileBinding.inflate(inflater, container, false)
         return binding.root
     }
 
@@ -54,10 +54,8 @@ class OnBoardingProfileFragment : Fragment() {
         val nickname = viewModel.nickname.value
         binding.titleTv.text = "$nickname 님"
         binding.nicknameTv.text = nickname
-        binding.profileIv.setImageURI(viewModel.profileImageUri.value)
-        if(viewModel.profileImageUri.value != null){
-            binding.cameraBtn.visibility = View.GONE
-        }
+
+        renderProfileImage(viewModel.profileImageUri.value)
 
         val initialMarginBottom =
             (binding.nextBtn.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin
@@ -73,13 +71,35 @@ class OnBoardingProfileFragment : Fragment() {
 
         observeViewModel()
 
-        val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
-        binding.galleryFl.setOnClickListener { galleryLauncher.launch(pickImageIntent) }
-        binding.cameraBtn.setOnClickListener { galleryLauncher.launch(pickImageIntent) }
+        binding.galleryFl.setOnClickListener {
+            showSelectPictureBottomSheet()
+        }
+
+//        binding.cameraBtn.setOnClickListener {
+//            showSelectPictureBottomSheet()
+//        }
 
         binding.nextBtn.setOnClickListener {
             viewModel.uploadProfileImage(requireContext())
         }
+    }
+
+    private fun showSelectPictureBottomSheet() {
+        val bottomSheet = BottomSheetSelectPictureFragment().apply {
+            setOnGalleryClickListener {
+                val pickImageIntent = Intent(Intent.ACTION_PICK).apply {
+                    type = "image/*"
+                }
+                galleryLauncher.launch(pickImageIntent)
+            }
+
+            setOnDefaultProfileClickListener {
+                viewModel.clearProfileImage()
+                renderProfileImage(null)
+            }
+        }
+
+        bottomSheet.show(parentFragmentManager, "BottomSheetSelectPictureFragment")
     }
 
     private fun observeViewModel() {
@@ -101,10 +121,29 @@ class OnBoardingProfileFragment : Fragment() {
                 else -> Unit
             }
         }
+
+        viewModel.profileImageUri.observe(viewLifecycleOwner) { uri ->
+            renderProfileImage(uri)
+        }
+    }
+
+    private fun renderProfileImage(uri: Uri?) {
+        if (uri != null) {
+            binding.profileIv.setImageURI(uri)
+//            binding.cameraBtn.visibility = View.GONE
+        } else {
+            binding.profileIv.setImageResource(R.drawable.gray_teum)
+//            binding.cameraBtn.visibility = View.VISIBLE
+        }
     }
 
     private fun navigateToNext() {
         (activity as? SignUpActivity)?.proceedToNextOnboardingStep(this)
         viewModel.resetState()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/com/umc/teumteum/ui/onboarding/viewModel/OnBoardingViewModel.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/onboarding/viewModel/OnBoardingViewModel.kt
@@ -139,7 +139,6 @@ class OnBoardingViewModel @Inject constructor(
                         override fun onResponse(call: Call, response: Response) {
                             response.use {
                                 if (response.isSuccessful) {
-                                    // ✅ 이미지 있을 때만 API 호출
                                     postProfileImage(
                                         ProfileImageRequest(
                                             _profileImageFileName.value!!

--- a/app/src/main/java/com/umc/teumteum/ui/onboarding/viewModel/OnBoardingViewModel.kt
+++ b/app/src/main/java/com/umc/teumteum/ui/onboarding/viewModel/OnBoardingViewModel.kt
@@ -18,11 +18,13 @@ import com.umc.teumteum.ui.onboarding.data.Schedule
 import com.umc.teumteum.utils.ApiException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
 import java.io.IOException
 import java.time.LocalTime
 import javax.inject.Inject
@@ -63,19 +65,17 @@ class OnBoardingViewModel @Inject constructor(
     private val _remindList = MutableLiveData<List<Int>>(emptyList())
     val remindList: LiveData<List<Int>> get() = _remindList
 
-    // 약관 동의
+    //약관동의
     fun postAgreements(request: AgreementRequest) {
         _state.value = OnBoardingUiState.Loading
         viewModelScope.launch {
             repository.postAgreements(request)
-                .onSuccess {
-                    _state.value = OnBoardingUiState.Success
-                }
+                .onSuccess { _state.value = OnBoardingUiState.Success }
                 .onFailure { handleError(it) }
         }
     }
 
-    // 닉네임/직종 등록
+    //닉네임, 직종
     fun postNicknameAndJob() {
         val nickname = _nickname.value.orEmpty()
         val jobField = _field.value.orEmpty()
@@ -83,16 +83,18 @@ class OnBoardingViewModel @Inject constructor(
         _state.value = OnBoardingUiState.Loading
         viewModelScope.launch {
             repository.postNicknameAndJobField(NicknameJobRequest(nickname, jobField))
-                .onSuccess {
-                    _state.value = OnBoardingUiState.Success
-                }
+                .onSuccess { _state.value = OnBoardingUiState.Success }
                 .onFailure { handleError(it) }
         }
     }
 
-    // 프리사인드 url 요청 후 실제 S3에 프로필 이미지 등록
+    //프로필 이미지
     fun uploadProfileImage(context: Context) {
-        val uri = _profileImageUri.value ?: run {
+
+        val uri = _profileImageUri.value
+
+        //기본 이미지 선택
+        if (uri == null) {
             _state.value = OnBoardingUiState.Success
             return
         }
@@ -103,19 +105,29 @@ class OnBoardingViewModel @Inject constructor(
         viewModelScope.launch {
             repository.requestPresignedUrl(PresignedRequest(contentType))
                 .onSuccess { response ->
+
                     _profileImageFileName.value = response.fileName
 
                     val inputStream = context.contentResolver.openInputStream(uri)
                     val bytes = inputStream?.readBytes() ?: run {
-                        _state.value = OnBoardingUiState.Error("UPLOAD_FAIL", "이미지를 불러올 수 없습니다.")
+                        _state.value = OnBoardingUiState.Error(
+                            "UPLOAD_FAIL",
+                            "이미지를 불러올 수 없습니다."
+                        )
                         return@onSuccess
                     }
 
-                    val requestBody = bytes.toRequestBody(contentType.toMediaTypeOrNull())
-                    val request = Request.Builder().url(response.presignedUrl).put(requestBody).build()
+                    val requestBody =
+                        bytes.toRequestBody(contentType.toMediaTypeOrNull())
+
+                    val request = Request.Builder()
+                        .url(response.presignedUrl)
+                        .put(requestBody)
+                        .build()
 
                     OkHttpClient().newCall(request).enqueue(object : Callback {
-                        override fun onFailure(call: okhttp3.Call, e: IOException) {
+
+                        override fun onFailure(call: Call, e: IOException) {
                             _state.postValue(
                                 OnBoardingUiState.Error(
                                     "UPLOAD_FAIL",
@@ -124,27 +136,28 @@ class OnBoardingViewModel @Inject constructor(
                             )
                         }
 
-                        override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
-                            if (response.isSuccessful) {
-                                postProfileImage(
-                                    ProfileImageRequest(
-                                        _profileImageFileName.value!!
+                        override fun onResponse(call: Call, response: Response) {
+                            response.use {
+                                if (response.isSuccessful) {
+                                    // ✅ 이미지 있을 때만 API 호출
+                                    postProfileImage(
+                                        ProfileImageRequest(
+                                            _profileImageFileName.value!!
+                                        )
                                     )
-                                )
-                            } else {
-                                _state.postValue(
-                                    OnBoardingUiState.Error(
-                                        "UPLOAD_FAIL",
-                                        "이미지 업로드 실패 (code: ${response.code})"
+                                } else {
+                                    _state.postValue(
+                                        OnBoardingUiState.Error(
+                                            "UPLOAD_FAIL",
+                                            "이미지 업로드 실패 (code: ${response.code})"
+                                        )
                                     )
-                                )
+                                }
                             }
                         }
                     })
                 }
-                .onFailure {
-                    handleError(it)
-                }
+                .onFailure { handleError(it) }
         }
     }
 
@@ -159,31 +172,26 @@ class OnBoardingViewModel @Inject constructor(
         }
     }
 
-    // 수면 패턴 등록
+    //수면 패턴
     fun postSleepPattern(request: SleepPatternRequest) {
         _state.value = OnBoardingUiState.Loading
         viewModelScope.launch {
             repository.postSleepPattern(request)
-                .onSuccess {
-                    _state.value = OnBoardingUiState.Success
-                }
+                .onSuccess { _state.value = OnBoardingUiState.Success }
                 .onFailure { handleError(it) }
         }
     }
 
-    // 반복 일정 등록
+    //반복일정
     fun postSchedule(request: ScheduleRequest) {
         _state.value = OnBoardingUiState.Loading
         viewModelScope.launch {
             repository.postSchedules(request)
-                .onSuccess {
-                    _state.value = OnBoardingUiState.Success
-                }
+                .onSuccess { _state.value = OnBoardingUiState.Success }
                 .onFailure { handleError(it) }
         }
     }
 
-    // 반복 일정 추가
     fun addSchedule(dayIndex: Int, schedule: Schedule) {
         val list = scheduleMap.getOrPut(dayIndex) { mutableListOf() }
         list.add(schedule)
@@ -200,14 +208,12 @@ class OnBoardingViewModel @Inject constructor(
         return current.size != target.size || current != target
     }
 
-    // 리마인드 알림 등록
+    //리마인드
     fun postRemind(request: RemindRequest) {
         _state.value = OnBoardingUiState.Loading
         viewModelScope.launch {
             repository.postRemind(request)
-                .onSuccess {
-                    _state.value = OnBoardingUiState.Success
-                }
+                .onSuccess { _state.value = OnBoardingUiState.Success }
                 .onFailure { handleError(it) }
         }
     }
@@ -216,22 +222,18 @@ class OnBoardingViewModel @Inject constructor(
         _state.value = OnBoardingUiState.Idle
     }
 
-    // 공통 에러 처리
     private fun handleError(e: Throwable) {
         if (e is ApiException) {
-            _state.value = OnBoardingUiState.Error(
-                code = e.code,
-                message = e.message
-            )
+            _state.value = OnBoardingUiState.Error(e.code, e.message)
         } else {
             _state.value = OnBoardingUiState.Error(
-                code = "NETWORK_ERROR",
-                message = "네트워크 오류가 발생했습니다."
+                "NETWORK_ERROR",
+                "네트워크 오류가 발생했습니다."
             )
         }
     }
 
-    // 수면 시간 설정
+    //setter
     fun setSleepStartTime(start: LocalTime) {
         _sleepStartTime.value = start
     }
@@ -248,8 +250,12 @@ class OnBoardingViewModel @Inject constructor(
         _field.value = value
     }
 
-    fun setProfileImage(uri: Uri) {
+    fun setProfileImage(uri: Uri?) {
         _profileImageUri.value = uri
+    }
+
+    fun clearProfileImage() {
+        _profileImageUri.value = null
     }
 
     fun updateCurrentDaySchedule(dayIndex: Int) {
@@ -273,7 +279,6 @@ class OnBoardingViewModel @Inject constructor(
         if (idx == -1) return
 
         list[idx] = new.copy(id = scheduleId)
-
         _currentDayScheduleList.value = list.toList()
     }
 
@@ -285,4 +290,3 @@ class OnBoardingViewModel @Inject constructor(
         _currentDayScheduleList.value = list.toList()
     }
 }
-

--- a/app/src/main/res/layout/fragment_bottom_sheet_select_picture.xml
+++ b/app/src/main/res/layout/fragment_bottom_sheet_select_picture.xml
@@ -42,7 +42,7 @@
         <TextView
             android:id="@+id/gallery_tv"
             android:fontFamily="@font/pretendard_medium"
-            android:textSize="20dp"
+            android:textSize="20sp"
             android:text="갤러리에서 이미지 선택"
             android:includeFontPadding="false"
             android:layout_width="wrap_content"
@@ -86,7 +86,7 @@
         <TextView
             android:id="@+id/basic_profile_tv"
             android:fontFamily="@font/pretendard_medium"
-            android:textSize="20dp"
+            android:textSize="20sp"
             android:text="기본 프로필로 변경"
             android:includeFontPadding="false"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_bottom_sheet_select_picture.xml
+++ b/app/src/main/res/layout/fragment_bottom_sheet_select_picture.xml
@@ -1,0 +1,123 @@
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/calendar_background">
+
+    <LinearLayout
+        android:id="@+id/header_container"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@drawable/calendar_background"
+        android:orientation="vertical"
+        android:layout_marginTop="12dp"
+        android:layout_marginBottom="12dp"
+        android:paddingBottom="12dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <View
+            android:layout_width="54dp"
+            android:layout_height="4dp"
+            android:layout_gravity="center_horizontal"
+            android:background="@drawable/bg_bottom_sheet_handle" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/gallery_ll"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:background="@color/white"
+        android:paddingTop="28dp"
+        android:paddingBottom="28dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/header_container">
+
+        <TextView
+            android:id="@+id/gallery_tv"
+            android:fontFamily="@font/pretendard_medium"
+            android:textSize="20dp"
+            android:text="갤러리에서 이미지 선택"
+            android:includeFontPadding="false"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/middle_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/white"
+        android:orientation="vertical"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/gallery_ll">
+
+        <View
+            android:layout_width="350dp"
+            android:layout_height="1dp"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginHorizontal="20dp"
+            android:background="@drawable/bg_bottom_sheet_handle" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/default_profile_ll"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:background="@color/white"
+        android:paddingVertical="28dp"
+
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/middle_bar">
+
+        <TextView
+            android:id="@+id/basic_profile_tv"
+            android:fontFamily="@font/pretendard_medium"
+            android:textSize="20dp"
+            android:text="기본 프로필로 변경"
+            android:includeFontPadding="false"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/cancel_ll"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/white"
+        android:orientation="horizontal"
+        android:layout_marginTop="5dp"
+        android:layout_marginBottom="19dp"
+        android:layout_marginHorizontal="19dp"
+        app:layout_constraintTop_toBottomOf="@+id/default_profile_ll"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_cancel"
+            android:layout_width="match_parent"
+            android:layout_height="65dp"
+            android:text="취소"
+            android:textColor="@color/text_primary"
+            app:backgroundTint="@color/teumteum_bg"
+            app:cornerRadius="12dp" />
+
+    </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_on_boarding_profile.xml
+++ b/app/src/main/res/layout/fragment_on_boarding_profile.xml
@@ -73,15 +73,15 @@
             android:scaleType="centerCrop"
             app:shapeAppearanceOverlay="@style/CircleImage" />
 
-        <ImageButton
-            android:id="@+id/camera_btn"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:background="@color/transparent"
-            android:src="@drawable/camera_btn"
-            android:scaleType="centerInside"
-            android:layout_gravity="center"
-            android:contentDescription="카메라 버튼" />
+<!--        <ImageButton-->
+<!--            android:id="@+id/camera_btn"-->
+<!--            android:layout_width="32dp"-->
+<!--            android:layout_height="32dp"-->
+<!--            android:background="@color/transparent"-->
+<!--            android:src="@drawable/camera_btn"-->
+<!--            android:scaleType="centerInside"-->
+<!--            android:layout_gravity="center"-->
+<!--            android:contentDescription="카메라 버튼" />-->
     </FrameLayout>
 
     <TextView


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #486

## ✨ 작업 내용
> 온보딩, 프로필 수정 화면에서 프로필 사진 변경 시 바텀 시트 -> 갤러리 이미지 선택 or 기본 이미지 변경
> 온보딩 화면: 갤러리 이미지 선택 시에만 API 호출
> 프로필 수정 화면: 기본 이미지 선택 시 프로필 이미지 삭제 API 호출

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [x] 온보딩 화면에서 프로필 사진 변경 or 기본 이미지 선택이 반영되는지
- [x] 프로필 수정 화면에서 프로필 사진 변경 or 기본 이미지 선택이 반영되는지

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 프로필 이미지 삭제 기능 추가
  * 이미지 선택용 하단 시트 UI 추가(갤러리 선택 / 기본 프로필)

* **Bug Fixes**
  * 프로필 이미지 캐시 문제 해결(디스크·메모리 캐시 비활성화)

* **Refactor**
  * 뷰 바인딩 생명주기 관리 개선(메모리 누수 방지)
  * 프로필 이미지 편집 상태 관리 로직 개선(기본/유지/새 이미지 처리)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->